### PR TITLE
Add /issue-triage skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,8 +10,8 @@
     {
       "name": "han",
       "source": "./plugin",
-      "description": "Evidence-based planning, investigation, and documentation skills for software projects. Includes deep-dive investigations with root cause analysis, iterative plan refinement, architectural decision records (ADRs), project and feature documentation, coding standards, code reviews, test planning, PR descriptions, PR code reviews, and adversarial security vulnerability analysis.",
-      "version": "2.2.0"
+      "description": "Evidence-based planning, investigation, and documentation skills for software projects. Includes issue triage, deep-dive investigations with root cause analysis, iterative plan refinement, architectural decision records (ADRs), project and feature documentation, coding standards, code reviews, test planning, PR descriptions, PR code reviews, and adversarial security vulnerability analysis.",
+      "version": "2.3.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Read [Concepts](./docs/concepts.md) for the skill-and-agent model that runs thro
 
 ## Skills
 
-Fifteen skills, grouped by the moment you reach for them. Each category links to the full long-form docs through the [Skills Index](./docs/skills/README.md).
+Sixteen skills, grouped by the moment you reach for them. Each category links to the full long-form docs through the [Skills Index](./docs/skills/README.md).
 
 ### Planning
 
@@ -38,6 +38,7 @@ Spec what to build, plan how to build it, sequence it into phases, and stress-te
 
 Find out *why* something is broken, with evidence to back it.
 
+- **[`/issue-triage`](docs/skills/issue-triage.md).** Classify a vague issue or bug report, identify missing information, assess severity and reproducibility, and recommend the right next skill.
 - **[`/investigate`](./docs/skills/investigate.md).** Evidence-based investigation of bugs, failures, and unexpected behavior, with adversarial validation of the proposed fix.
 
 ### Review & analysis
@@ -85,7 +86,7 @@ Add the Test Double skills marketplace to Claude Code, then install the plugin:
 
 - [Concepts](./docs/concepts.md). Skill vs. agent, and how they compose. Read once before using the plugin.
 - [Quickstart](./docs/quickstart.md). Four paths for four common situations. Each path is a short sequence of skills.
-- [Skills Index](./docs/skills/README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./docs/skills/README.md). All 16 skills, grouped by purpose.
 - [Agents Index](./docs/agents/README.md). All 21 agents, grouped by role.
 - [Sizing](./docs/sizing.md). The small / medium / large model that decides how many agents the swarming skills dispatch.
 - [YAGNI](./docs/yagni.md). The evidence-based "You Aren't Gonna Need It" rule every planning, review, and architecture skill applies.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read [Concepts](./docs/concepts.md) for the skill-and-agent model that runs thro
 ## Which path are you on?
 
 - **New to han?** → Start with [Concepts](./docs/concepts.md), then the [Quickstart](./docs/quickstart.md).
-- **Looking for a specific skill?** → [Skills Index](./docs/skills/README.md). 15 skills grouped by purpose.
+- **Looking for a specific skill?** → [Skills Index](./docs/skills/README.md). 16 skills grouped by purpose.
 - **Looking for a specific agent?** → [Agents Index](./docs/agents/README.md). 21 agents grouped by role.
 - **Wondering how the agent swarms scale?** → [Sizing](./docs/sizing.md). The small / medium / large dispatch model used by `/code-review`, `/gap-analysis`, `/iterative-plan-review`, `/plan-a-feature`, and `/plan-implementation`.
 - **Wondering why a skill said "YAGNI"?** → [YAGNI](./docs/yagni.md). The evidence-based rule every planning, review, and architecture skill applies before committing items to an artifact.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,8 +32,9 @@ You have a feature idea and want a specification grounded in evidence, then a pl
 
 Something is broken. You want a root cause, not a guess.
 
-1. **[`/investigate`](./skills/investigate.md).** Evidence-based investigation: file paths, line numbers, git history, test coverage. Produces an investigation report with the root cause and a proposed fix that an `adversarial-validator` has already tried to falsify.
-2. **[`/iterative-plan-review`](./skills/iterative-plan-review.md)** *(optional).* If the investigation produced a fix plan you do not trust, iterate on it before writing code.
+1. **[`/issue-triage`](./skills/issue-triage.md)** *(as needed).* If the report is vague or incomplete, classify the issue, identify missing information, and capture the next step before you investigate.
+2. **[`/investigate`](./skills/investigate.md).** Evidence-based investigation: file paths, line numbers, git history, test coverage. Produces an investigation report with the root cause and a proposed fix that an `adversarial-validator` has already tried to falsify.
+3. **[`/iterative-plan-review`](./skills/iterative-plan-review.md)** *(optional).* If the investigation produced a fix plan you do not trust, iterate on it before writing code.
 
 **You are done when:** you have a report that names the root cause with file-level evidence, and a fix plan that has survived adversarial review.
 

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -21,6 +21,7 @@ Skills for specifying *what* a feature does, planning *how* to build it, and str
 
 Skills for finding out *why* something is broken, with evidence to back it.
 
+- **[`/issue-triage`](./issue-triage.md).** Classify a vague issue or bug report, identify missing information, assess severity and reproducibility, and recommend the right next skill to run.
 - **[`/investigate`](./investigate.md).** Evidence-based investigation of bugs, failures, and unexpected behavior, with adversarial validation of the proposed fix.
 
 ## Review & analysis
@@ -76,6 +77,7 @@ Most han skills dispatch agents to do their judgment-heavy work. The [Concepts](
 
 A few common compositions:
 
+- **Triage → investigate.** `/issue-triage` → `/investigate`.
 - **Plan → implement → iterate.** `/plan-a-feature` → `/plan-implementation` → `/iterative-plan-review`.
 - **Discover → document → standardize.** `/project-discovery` → `/project-documentation` → `/coding-standard`.
 - **Review locally → post to PR.** `/code-review` → `/gh-pr-review`.

--- a/docs/skills/architectural-analysis.md
+++ b/docs/skills/architectural-analysis.md
@@ -130,7 +130,7 @@ URL: https://www.domainlanguage.com/ddd/
 ## Related documentation
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [`structural-analyst`](../agents/structural-analyst.md), [`behavioral-analyst`](../agents/behavioral-analyst.md), [`concurrency-analyst`](../agents/concurrency-analyst.md). The three parallel analysts.
 - [`risk-analyst`](../agents/risk-analyst.md). The agent that scores the analysts' findings by likelihood, severity, blast radius, and reversibility.
 - [`software-architect`](../agents/software-architect.md). The adversarial synthesis agent that produces intra-codebase recommendations and pseudocode sketches (dispatched by this skill).

--- a/docs/skills/architectural-decision-record.md
+++ b/docs/skills/architectural-decision-record.md
@@ -120,7 +120,7 @@ URL: https://www.thoughtworks.com/radar/techniques/lightweight-architecture-deci
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
 - [YAGNI](../yagni.md). The evidence-based "You Aren't Gonna Need It" rule this skill applies before committing items. The two gates, the acceptable-evidence list, the named anti-patterns, and the deferral format.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [`/coding-standard`](./coding-standard.md). For rules that come out of a decision. Link the standard to the ADR.
 - [`/architectural-analysis`](./architectural-analysis.md). Often produces decisions worth recording as ADRs.
 - [`/project-documentation`](./project-documentation.md). For feature docs that reference the ADR.

--- a/docs/skills/code-review.md
+++ b/docs/skills/code-review.md
@@ -171,7 +171,7 @@ URL: https://itrevolution.com/product/accelerate/
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
 - [YAGNI](../yagni.md). The evidence-based "You Aren't Gonna Need It" rule this skill applies before committing items. The two gates, the acceptable-evidence list, the named anti-patterns, and the deferral format.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [`/gh-pr-review`](./gh-pr-review.md). Wraps this skill and posts the review to a GitHub PR.
 - [`/investigate`](./investigate.md). Next step when a CRIT finding hides a bug whose root cause needs deeper analysis.
 - [`/architectural-analysis`](./architectural-analysis.md). Run alongside when the change touches module boundaries.

--- a/docs/skills/coding-standard.md
+++ b/docs/skills/coding-standard.md
@@ -118,7 +118,7 @@ URL: https://sre.google/sre-book/
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
 - [YAGNI](../yagni.md). The evidence-based "You Aren't Gonna Need It" rule this skill applies before committing items. The two gates, the acceptable-evidence list, the named anti-patterns, and the deferral format.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [`/architectural-decision-record`](./architectural-decision-record.md). For decisions rather than rules. Link the standard to the ADR when the rule embeds a choice.
 - [`/project-documentation`](./project-documentation.md). For system and feature documentation that is not a rule.
 - [`/code-review`](./code-review.md). Reads standards during every review. Violations become findings.

--- a/docs/skills/gap-analysis.md
+++ b/docs/skills/gap-analysis.md
@@ -200,7 +200,7 @@ URLs: https://hbr.org/2007/09/performing-a-project-premortem and https://en.wiki
 ## Related documentation
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [Sizing](../sizing.md). The cross-skill sizing model. Explains the small / medium / large bands, the default-to-small rule, and the `$size` override.
 - [`gap-analyzer`](../agents/gap-analyzer.md). The agent that performs the underlying gap analysis. The skill always dispatches it once and reads its full output.
 - [`adversarial-validator`](../agents/adversarial-validator.md). Required swarm role at every size. Attacks each gap with counter-evidence to produce per-gap `confirmed` / `contradicted` / `inconclusive` verdicts.

--- a/docs/skills/gh-pr-review.md
+++ b/docs/skills/gh-pr-review.md
@@ -98,7 +98,7 @@ URL: https://google.github.io/eng-practices/review/reviewer/
 ## Related documentation
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [`/code-review`](./code-review.md). The skill this one wraps. Use directly for local review without GitHub posting.
 - [`/update-pr-description`](./update-pr-description.md). For writing the PR description.
 - [`/investigate`](./investigate.md). Next step when a Critical finding hides a bug.

--- a/docs/skills/investigate.md
+++ b/docs/skills/investigate.md
@@ -121,7 +121,8 @@ URL: https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary
 ## Related documentation
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
+- [`/issue-triage`](https://github.com/testdouble/han/blob/main/docs/skills/issue-triage.md). Run before investigation when the incoming report is too vague to trace; triage produces the sharp problem statement investigation needs.
 - [`evidence-based-investigator`](../agents/evidence-based-investigator.md). The agent the skill dispatches in parallel for multi-angle evidence gathering.
 - [`adversarial-validator`](../agents/adversarial-validator.md). The agent that challenges evidence and fix after the plan is drafted.
 - [`concurrency-analyst`](../agents/concurrency-analyst.md), [`behavioral-analyst`](../agents/behavioral-analyst.md), [`data-engineer`](../agents/data-engineer.md). Specialist analysts dispatched alongside the investigators when the symptom classification calls for them.

--- a/docs/skills/issue-triage.md
+++ b/docs/skills/issue-triage.md
@@ -31,9 +31,9 @@ Operator documentation for the `/issue-triage` skill in the han plugin. This doc
 
 **Do not invoke for:**
 
-- **Root cause analysis.** Use [`/investigate`](https://github.com/testdouble/han/blob/main/docs/skills/investigate.md) to trace symptoms to code-level evidence.
-- **Feature planning.** Use [`/plan-a-feature`](https://github.com/testdouble/han/blob/main/docs/skills/plan-a-feature.md) when the problem is well-defined and you are ready to spec the solution.
-- **Implementation planning.** Use [`/plan-implementation`](https://github.com/testdouble/han/blob/main/docs/skills/plan-implementation.md) when you have a feature spec and are ready to plan the build.
+- **Root cause analysis.** Use [`/investigate`](./investigate.md) to trace symptoms to code-level evidence.
+- **Feature planning.** Use [`/plan-a-feature`](./plan-a-feature.md) when the problem is well-defined and you are ready to spec the solution.
+- **Implementation planning.** Use [`/plan-implementation`](./plan-implementation.md) when you have a feature spec and are ready to plan the build.
 
 
 ## How to invoke it
@@ -61,7 +61,7 @@ A triage report file with these sections:
 - **Issue Type.** One of: Bug, Feature Request, Performance, Security, Regression, Question, Other.
 - **Reported Behavior.** What the reporter said happened, in their words or close paraphrase.
 - **Expected Behavior.** What the reporter said should happen, or Unknown if not stated.
-- **Missing Information.** A list of what is absent from the report but needed to proceed. States "None. Report has enough to proceed." when nothing is missing.
+- **Missing Information.** A list of what is absent from the report but needed to proceed. States "None - report has enough to proceed." when nothing is missing.
 - **Suspected Areas.** Code or system areas the issue plausibly touches, based on the report and project context. Omitted when nothing is inferable.
 - **Severity.** An estimate: Critical, High, Medium, Low, or Unknown.
 - **Reproducibility.** An estimate: Always, Intermittent, Rare, or Unknown.
@@ -90,7 +90,7 @@ This is the exact output contract the skill follows. It is intentionally strict 
 
 # Missing Information
 
-{bulleted list, or "None. Report has enough to proceed."}
+{bulleted list, or "None - report has enough to proceed."}
 
 # Suspected Areas
 

--- a/docs/skills/issue-triage.md
+++ b/docs/skills/issue-triage.md
@@ -67,6 +67,48 @@ A triage report file with these sections:
 - **Reproducibility.** An estimate: Always, Intermittent, Rare, or Unknown.
 - **Recommended Next Step.** The single most appropriate han skill to run next, or "Clarify with reporter before proceeding" when critical reproduction or scope details are missing.
 
+## Output contract
+
+This is the exact output contract the skill follows. It is intentionally strict to prevent inference from vague reports.
+
+```md
+# Summary
+
+{one sentence}
+
+# Issue Type
+
+{Bug | Feature Request | Performance | Security | Regression | Question | Other}
+
+# Reported Behavior
+
+{what the reporter said happened}
+
+# Expected Behavior
+
+{what the reporter said should happen, or Unknown}
+
+# Missing Information
+
+{bulleted list, or "None. Report has enough to proceed."}
+
+# Suspected Areas
+
+{bulleted list. Omit if nothing is explicitly mentioned}
+
+# Severity
+
+{Critical | High | Medium | Low | Unknown}
+
+# Reproducibility
+
+{Always | Intermittent | Rare | Unknown}
+
+# Recommended Next Step
+
+{"Clarify with reporter before proceeding" or one of: /investigate, /plan-a-feature, /plan-implementation}
+```
+
 
 ## How to get the most out of it
 
@@ -74,6 +116,52 @@ A triage report file with these sections:
 - **Use the output as a handoff document.** The triage report is the input for the next skill. Pass it to `/investigate` or `/plan-a-feature` rather than re-summarizing the issue from scratch.
 - **Run it before `/investigate` on ambiguous issues.** Investigation works best with a sharp problem statement. Triage produces one. A few seconds of triage avoids a wasted investigation run on a problem that was not yet well-defined.
 - **Follow the Recommended Next Step.** When the report still has critical gaps, the recommendation will say so explicitly. That is the signal to go back to the reporter before running the next skill.
+
+## Minimal example
+
+Input:
+
+```
+"Uploads fail sometimes. Not sure why."
+```
+
+Output:
+
+```md
+# Summary
+
+Uploads fail intermittently.
+
+# Issue Type
+
+Bug
+
+# Reported Behavior
+
+Uploads fail sometimes.
+
+# Expected Behavior
+
+Unknown
+
+# Missing Information
+
+- Reproduction steps
+- Environment details (OS, browser, version)
+- User-impact scope
+
+# Severity
+
+Unknown
+
+# Reproducibility
+
+Intermittent
+
+# Recommended Next Step
+
+"Clarify with reporter before proceeding"
+```
 
 
 ## Cost and latency

--- a/docs/skills/issue-triage.md
+++ b/docs/skills/issue-triage.md
@@ -1,0 +1,91 @@
+# /issue-triage
+
+Operator documentation for the `/issue-triage` skill in the han plugin. This document helps you decide *when* and *how* to use the skill. For what the skill does internally, read the skill definition at [`plugin/skills/issue-triage/SKILL.md`](https://github.com/testdouble/han/blob/main/plugin/skills/issue-triage/SKILL.md).
+
+> See also: [Plugin landing page](https://github.com/testdouble/han/blob/main/README.md) · [All skills](https://github.com/testdouble/han/blob/main/docs/skills/README.md) · [All agents](https://github.com/testdouble/han/blob/main/docs/agents/README.md) · [YAGNI](https://github.com/testdouble/han/blob/main/docs/yagni.md)
+
+## TL;DR
+
+- **What it does.** Converts a raw, vague issue or bug report into a structured triage document: issue type, known behavior, missing information, severity, reproducibility, and a recommended next skill.
+- **When to use it.** You have an incoming issue that is too vague or incomplete to hand directly to `/investigate` or `/plan-a-feature`.
+- **What you get back.** A triage report file with a structured breakdown of the issue and a single recommended next han skill.
+
+
+## Key concepts
+
+- **Issue type drives the gap list.** Different issue types have different missing-information profiles. A bug needs reproduction steps and environment details. A feature request needs use case and success criteria. The skill classifies first, then determines what is absent for that type.
+- **Severity is an estimate.** The skill cannot assess severity with certainty from a vague report. It makes the best judgment from what is in the report and marks severity Unknown when impact is not inferable.
+- **Triage stops before investigation.** The skill does not read the codebase for root cause. It reads the report and project context only enough to suggest suspected areas. Investigation starts after triage completes.
+- **The recommended next step is a single skill.** The report ends with one recommendation: the skill most appropriate to run next, given what is now known about the issue.
+
+
+## When to use it
+
+**Invoke when:**
+
+- An incoming issue, bug report, or problem description is too vague to hand directly to `/investigate` or `/plan-a-feature`.
+- A report is missing information you would need to reproduce or plan against.
+- You want to classify an issue and document gaps before investigation or planning starts.
+- You received a terse ticket, a one-line Slack message, or a forwarded user complaint and need a structured handoff document.
+
+
+**Do not invoke for:**
+
+- **Root cause analysis.** Use [`/investigate`](https://github.com/testdouble/han/blob/main/docs/skills/investigate.md) to trace symptoms to code-level evidence.
+- **Feature planning.** Use [`/plan-a-feature`](https://github.com/testdouble/han/blob/main/docs/skills/plan-a-feature.md) when the problem is well-defined and you are ready to spec the solution.
+- **Implementation planning.** Use [`/plan-implementation`](https://github.com/testdouble/han/blob/main/docs/skills/plan-implementation.md) when you have a feature spec and are ready to plan the build.
+
+
+## How to invoke it
+
+Run `/issue-triage` in Claude Code with the raw issue text.
+
+Give it:
+
+1. **The raw issue or report.** Paste the text directly: a Slack message, a GitHub issue body, a user complaint, a support ticket. The skill works from what the reporter wrote. Do not clean the text up before handing it over.
+2. **An output path, optional.** Defaults to `~/.claude/triages/{kebab-case-summary}.md` if no path is given.
+
+
+Example prompts:
+
+- `/issue-triage`. *"Uploading large PDFs freezes the app sometimes. Happened to two people already."*
+- `/issue-triage`. *"Users are complaining the dashboard is slow. Here's what one of them wrote: [paste]"*
+- `/issue-triage docs/triages/pdf-freeze.md`. Triage the issue and write the report to a specific path.
+
+
+## What you get back
+
+A triage report file with these sections:
+
+- **Summary.** One sentence naming the problem in plain terms.
+- **Issue Type.** One of: Bug, Feature Request, Performance, Security, Regression, Question, Other.
+- **Reported Behavior.** What the reporter said happened, in their words or close paraphrase.
+- **Expected Behavior.** What should have happened, or Unknown if not inferable.
+- **Missing Information.** A list of what is absent from the report but needed to proceed. States "None — report has enough to proceed" when nothing is missing.
+- **Suspected Areas.** Code or system areas the issue plausibly touches, based on the report and project context. Omitted when nothing is inferable.
+- **Severity.** An estimate: Critical, High, Medium, Low, or Unknown.
+- **Reproducibility.** An estimate: Always, Intermittent, Rare, or Unknown.
+- **Recommended Next Step.** The single most appropriate han skill to run next, or "Clarify with reporter before proceeding" when the report is too thin to route confidently.
+
+
+## How to get the most out of it
+
+- **Paste the raw text.** The skill is designed to work on incomplete, messy input. Editing the report before passing it in changes what counts as missing information.
+- **Use the output as a handoff document.** The triage report is the input for the next skill. Pass it to `/investigate` or `/plan-a-feature` rather than re-summarizing the issue from scratch.
+- **Run it before `/investigate` on ambiguous issues.** Investigation works best with a sharp problem statement. Triage produces one. A few seconds of triage avoids a wasted investigation run on a problem that was not yet well-defined.
+- **Follow the Recommended Next Step.** When the report still has critical gaps, the recommendation will say so explicitly. That is the signal to go back to the reporter before running the next skill.
+
+
+## Cost and latency
+
+The skill dispatches no sub-agents. It reads the report and the project context (CLAUDE.md if present), then produces the triage document in a single pass. Expect fast turnaround relative to investigation or planning skills. Use it freely at the start of any incoming issue before deciding which deeper skill to run.
+
+
+## Related documentation
+
+- [Plugin landing page](https://github.com/testdouble/han/blob/main/README.md). The front door. Start here if you arrived from outside the docs tree.
+- [Skills Index](https://github.com/testdouble/han/blob/main/docs/skills/README.md). All 16 skills, grouped by purpose.
+- [`/investigate`](https://github.com/testdouble/han/blob/main/docs/skills/investigate.md). The natural next skill when the issue is a bug or failure with enough context to trace.
+- [`/plan-a-feature`](https://github.com/testdouble/han/blob/main/docs/skills/plan-a-feature.md). The natural next skill when the issue is a feature request with enough context to spec.
+- [`/plan-implementation`](https://github.com/testdouble/han/blob/main/docs/skills/plan-implementation.md). The next skill when triage confirms a well-defined problem and a spec already exists.
+- [`SKILL.md` for /issue-triage](https://github.com/testdouble/han/blob/main/plugin/skills/issue-triage/SKILL.md). The internal process definition.

--- a/docs/skills/issue-triage.md
+++ b/docs/skills/issue-triage.md
@@ -1,8 +1,8 @@
 # /issue-triage
 
-Operator documentation for the `/issue-triage` skill in the han plugin. This document helps you decide *when* and *how* to use the skill. For what the skill does internally, read the skill definition at [`plugin/skills/issue-triage/SKILL.md`](https://github.com/testdouble/han/blob/main/plugin/skills/issue-triage/SKILL.md).
+Operator documentation for the `/issue-triage` skill in the han plugin. This document helps you decide *when* and *how* to use the skill. For what the skill does internally, read the skill definition at [`plugin/skills/issue-triage/SKILL.md`](../../plugin/skills/issue-triage/SKILL.md).
 
-> See also: [Plugin landing page](https://github.com/testdouble/han/blob/main/README.md) · [All skills](https://github.com/testdouble/han/blob/main/docs/skills/README.md) · [All agents](https://github.com/testdouble/han/blob/main/docs/agents/README.md) · [YAGNI](https://github.com/testdouble/han/blob/main/docs/yagni.md)
+> See also: [Plugin landing page](../../README.md) · [All skills](./README.md) · [All agents](../agents/README.md) · [YAGNI](../yagni.md)
 
 ## TL;DR
 
@@ -60,12 +60,12 @@ A triage report file with these sections:
 - **Summary.** One sentence naming the problem in plain terms.
 - **Issue Type.** One of: Bug, Feature Request, Performance, Security, Regression, Question, Other.
 - **Reported Behavior.** What the reporter said happened, in their words or close paraphrase.
-- **Expected Behavior.** What should have happened, or Unknown if not inferable.
-- **Missing Information.** A list of what is absent from the report but needed to proceed. States "None — report has enough to proceed" when nothing is missing.
+- **Expected Behavior.** What the reporter said should happen, or Unknown if not stated.
+- **Missing Information.** A list of what is absent from the report but needed to proceed. States "None. Report has enough to proceed." when nothing is missing.
 - **Suspected Areas.** Code or system areas the issue plausibly touches, based on the report and project context. Omitted when nothing is inferable.
 - **Severity.** An estimate: Critical, High, Medium, Low, or Unknown.
 - **Reproducibility.** An estimate: Always, Intermittent, Rare, or Unknown.
-- **Recommended Next Step.** The single most appropriate han skill to run next, or "Clarify with reporter before proceeding" when the report is too thin to route confidently.
+- **Recommended Next Step.** The single most appropriate han skill to run next, or "Clarify with reporter before proceeding" when critical reproduction or scope details are missing.
 
 
 ## How to get the most out of it
@@ -78,14 +78,14 @@ A triage report file with these sections:
 
 ## Cost and latency
 
-The skill dispatches no sub-agents. It reads the report and the project context (CLAUDE.md if present), then produces the triage document in a single pass. Expect fast turnaround relative to investigation or planning skills. Use it freely at the start of any incoming issue before deciding which deeper skill to run.
+The skill dispatches no sub-agents. It reads the report and the project context (CLAUDE.md if present), then produces the triage document in a single pass. Expect fast turnaround relative to investigation or planning skills. Use it at the start of any incoming issue before deciding which deeper skill to run.
 
 
 ## Related documentation
 
-- [Plugin landing page](https://github.com/testdouble/han/blob/main/README.md). The front door. Start here if you arrived from outside the docs tree.
-- [Skills Index](https://github.com/testdouble/han/blob/main/docs/skills/README.md). All 16 skills, grouped by purpose.
-- [`/investigate`](https://github.com/testdouble/han/blob/main/docs/skills/investigate.md). The natural next skill when the issue is a bug or failure with enough context to trace.
-- [`/plan-a-feature`](https://github.com/testdouble/han/blob/main/docs/skills/plan-a-feature.md). The natural next skill when the issue is a feature request with enough context to spec.
-- [`/plan-implementation`](https://github.com/testdouble/han/blob/main/docs/skills/plan-implementation.md). The next skill when triage confirms a well-defined problem and a spec already exists.
-- [`SKILL.md` for /issue-triage](https://github.com/testdouble/han/blob/main/plugin/skills/issue-triage/SKILL.md). The internal process definition.
+- [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
+- [`/investigate`](./investigate.md). The natural next skill when the issue is a bug or failure with enough context to trace.
+- [`/plan-a-feature`](./plan-a-feature.md). The natural next skill when the issue is a feature request with enough context to spec.
+- [`/plan-implementation`](./plan-implementation.md). The next skill when triage confirms a well-defined problem and a spec already exists.
+- [`SKILL.md` for /issue-triage](../../plugin/skills/issue-triage/SKILL.md). The internal process definition.

--- a/docs/skills/iterative-plan-review.md
+++ b/docs/skills/iterative-plan-review.md
@@ -191,7 +191,7 @@ URLs: https://asana.com/resources/raid-log and https://projectmanagementcompass.
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
 - [YAGNI](../yagni.md). The evidence-based "You Aren't Gonna Need It" rule this skill applies before committing items. The two gates, the acceptable-evidence list, the named anti-patterns, and the deferral format.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [Sizing](../sizing.md). The cross-skill sizing model. Explains the small / medium / large bands, the default-to-small rule, and the `$size` override.
 - [`/plan-a-feature`](./plan-a-feature.md). The upstream skill for producing a feature specification from scratch. This skill can iterate on that spec, but the typical handoff is spec → `/plan-implementation` → this skill.
 - [`/plan-implementation`](./plan-implementation.md). The upstream skill for producing a committable implementation plan. This skill is the natural next step when the team wants the implementation plan stress-tested across multiple review passes.

--- a/docs/skills/plan-a-feature.md
+++ b/docs/skills/plan-a-feature.md
@@ -183,7 +183,7 @@ URLs: https://asana.com/resources/raid-log and https://projectmanagementcompass.
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
 - [YAGNI](../yagni.md). The evidence-based "You Aren't Gonna Need It" rule this skill applies before committing items. The two gates, the acceptable-evidence list, the named anti-patterns, and the deferral format.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [Sizing](../sizing.md). The cross-skill sizing model. Explains the small / medium / large bands, the default-to-small rule, and the `$size` override.
 - [`/plan-implementation`](./plan-implementation.md). The next step after this skill. Takes the `feature-specification.md` produced here and turns it into a feature-implementation-plan through an iterative, project-manager-led team conversation.
 - [`/iterative-plan-review`](./iterative-plan-review.md). The complement for plans that already exist. Use this when an implementation plan or spec has been drafted and needs multiple review passes to challenge assumptions and refine.

--- a/docs/skills/plan-a-phased-build.md
+++ b/docs/skills/plan-a-phased-build.md
@@ -195,7 +195,7 @@ URL: see [`information-architect` agent definition](../../plugin/agents/informat
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
 - [YAGNI](../yagni.md). The evidence-based "You Aren't Gonna Need It" rule this skill applies before committing items. The two gates, the acceptable-evidence list, the named anti-patterns, and the deferral format.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [`information-architect`](../agents/information-architect.md). The agent the skill dispatches at runtime to review the rendered outline. Also the agent that reviewed the output template before the skill shipped.
 - [`/gap-analysis`](./gap-analysis.md). Pair upstream when the source artifact is a comparison between current and desired state. Run `/gap-analysis` first to produce the gap report, then point this skill at the report. `G-NNN` gap IDs become source citations on the phase entries that close them.
 - [`/plan-a-feature`](./plan-a-feature.md). Pair upstream when the source artifact is a single feature that needs a phased rollout. Run `/plan-a-feature` first to produce the spec, then point this skill at the spec when the feature is large enough to ship in slices rather than all at once.

--- a/docs/skills/plan-implementation.md
+++ b/docs/skills/plan-implementation.md
@@ -200,7 +200,7 @@ URL: https://ieeexplore.ieee.org/document/1204375
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
 - [YAGNI](../yagni.md). The evidence-based "You Aren't Gonna Need It" rule this skill applies before committing items. The two gates, the acceptable-evidence list, the named anti-patterns, and the deferral format.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [Sizing](../sizing.md). The cross-skill sizing model. Explains the small / medium / large bands, the default-to-small rule, and the `$size` override.
 - [`/plan-a-feature`](./plan-a-feature.md). The prior step. Produces the `feature-specification.md` this skill consumes. Running the two in sequence is the intended flow: *what* first, *how* second.
 - [`/iterative-plan-review`](./iterative-plan-review.md). The complement for stress-testing the plan after it lands. This skill produces the committable plan. `/iterative-plan-review` iterates on it.

--- a/docs/skills/project-discovery.md
+++ b/docs/skills/project-discovery.md
@@ -98,7 +98,7 @@ URL: https://research.google/pubs/why-google-stores-billions-of-lines-of-code-in
 ## Related documentation
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [`/project-documentation`](./project-documentation.md). For feature and system docs. Reads the discovery reference to find the right directory and language.
 - [`/coding-standard`](./coding-standard.md). For coding rules. Reads the discovery reference to find the standards directory.
 - [`/architectural-decision-record`](./architectural-decision-record.md). For architectural decisions. Reads the discovery reference to find the ADR directory.

--- a/docs/skills/project-documentation.md
+++ b/docs/skills/project-documentation.md
@@ -115,7 +115,7 @@ URL: https://en.wikipedia.org/wiki/Darwin_Information_Typing_Architecture
 ## Related documentation
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [`/project-discovery`](./project-discovery.md). Run first. The documentation skill reads the discovery reference to find the docs directory and stack language.
 - [`/architectural-decision-record`](./architectural-decision-record.md). Use for decisions rather than system documentation.
 - [`/coding-standard`](./coding-standard.md). Use for rules rather than descriptions.

--- a/docs/skills/test-planning.md
+++ b/docs/skills/test-planning.md
@@ -115,7 +115,7 @@ URL: https://www.wiley.com/en-us/Testing+Computer+Software%2C+2nd+Edition-p-9780
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
 - [YAGNI](../yagni.md). The evidence-based "You Aren't Gonna Need It" rule this skill applies before committing items. The two gates, the acceptable-evidence list, the named anti-patterns, and the deferral format.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [`/code-review`](./code-review.md). Dispatches the same agents plus `adversarial-security-analyst`. Use when you want correctness findings too.
 - [`/architectural-analysis`](./architectural-analysis.md). For structural testability concerns.
 - [`/iterative-plan-review`](./iterative-plan-review.md). Use to stress-test an already-written test plan.

--- a/docs/skills/update-pr-description.md
+++ b/docs/skills/update-pr-description.md
@@ -99,7 +99,7 @@ URL: https://martinfowler.com/articles/feature-toggles.html
 ## Related documentation
 
 - [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
-- [Skills Index](./README.md). All 15 skills, grouped by purpose.
+- [Skills Index](./README.md). All 16 skills, grouped by purpose.
 - [`/gh-pr-review`](./gh-pr-review.md). Post a code review to the same PR.
 - [`/code-review`](./code-review.md). Local code review without touching GitHub.
 - [`junior-developer`](../agents/junior-developer.md). Runs the reviewer context check against the drafted description.

--- a/plugin/skills/issue-triage/SKILL.md
+++ b/plugin/skills/issue-triage/SKILL.md
@@ -53,7 +53,7 @@ List what a developer would need to reproduce or investigate this issue that is 
 
 List only what is genuinely absent. Do not list information already present in the report.
 
-If nothing is missing, write: `None — report has enough to proceed.`
+If nothing is missing, write: `None - report has enough to proceed.`
 
 ## Step 5: Assess Severity and Reproducibility
 
@@ -101,7 +101,7 @@ Use this structure:
 
 # Missing Information
 
-{bulleted list, or "None — report has enough to proceed."}
+{bulleted list, or "None - report has enough to proceed."}
 
 # Suspected Areas
 

--- a/plugin/skills/issue-triage/SKILL.md
+++ b/plugin/skills/issue-triage/SKILL.md
@@ -1,0 +1,122 @@
+| name | issue-triage |
+| --- | --- |
+| description | Triage a raw, vague issue or bug report into a structured document that names what is known, what is missing, and what to do next. Use when an incoming issue, bug report, or problem description is too vague or incomplete for investigation or planning: classify the issue type, identify missing information, assess severity and reproducibility, and recommend the right next han skill. Does not investigate root causes or trace code paths; use investigate for debugging, diagnosis, and root cause analysis. Does not plan features or build solutions; use plan-a-feature or plan-implementation for that. |
+| allowed-tools | Read, Glob, Write |
+
+## Project Context
+
+- CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
+
+## Triage Approach
+
+- Work only from what the reporter wrote. Do not infer facts that are not stated.
+- Classify the issue type before doing anything else. The type drives what counts as missing information.
+- Severity is an estimate based on what is known. Mark it Unknown when impact is not inferable from the report.
+- The recommended next step is the single most appropriate han skill to run after triage completes.
+- Read CLAUDE.md only to inform Suspected Areas. Do not use it to fill gaps the reporter did not provide.
+
+# Issue Triage
+
+## Step 1: Read Project Context
+
+Read CLAUDE.md if present. Use it to identify relevant system areas when populating Suspected Areas. Do not use it to supply information the reporter omitted.
+
+## Step 2: Classify the Issue
+
+Determine the issue type from the report text:
+
+- **Bug** — something is broken or behaving unexpectedly
+- **Feature Request** — something new is being asked for
+- **Performance** — the system is too slow, uses too much memory, or degrades under load
+- **Security** — a vulnerability, exposure, or access control concern
+- **Regression** — something that used to work has stopped working
+- **Question** — the reporter is asking how something works, not reporting a problem
+- **Other** — none of the above apply
+
+## Step 3: Extract What Is Known
+
+From the report, identify:
+
+- **Summary** — one sentence describing the problem in plain terms
+- **Reported Behavior** — what the reporter said happened, in their words or close paraphrase
+- **Expected Behavior** — what should have happened (infer if obvious; mark Unknown if not)
+
+## Step 4: Identify Missing Information
+
+List what a developer would need to reproduce or investigate this issue that is absent from the report. Common gaps by issue type:
+
+- **Bug / Regression** — reproduction steps, environment (OS, browser, version), error messages or stack traces, affected data or user accounts, frequency of occurrence
+- **Performance** — scale or load at which the problem occurs, baseline measurements, environment
+- **Security** — affected endpoints or data, attack surface description, access level required to trigger
+- **Feature Request** — use case or job to be done, success criteria, constraints
+
+List only what is genuinely absent. Do not list information already present in the report.
+
+If nothing is missing, write: `None — report has enough to proceed.`
+
+## Step 5: Assess Severity and Reproducibility
+
+**Severity** (estimate from what is known):
+
+- **Critical** — data loss, system down, security breach, or blocks all users
+- **High** — major feature broken, significant user impact, no workaround known
+- **Medium** — feature degraded, workaround exists, or affects a subset of users
+- **Low** — cosmetic, edge case, or minor inconvenience
+- **Unknown** — not enough information to assess
+
+**Reproducibility** (estimate from what is known):
+
+- **Always** — happens consistently under described conditions
+- **Intermittent** — happens sometimes; conditions unclear
+- **Rare** — reported once or infrequently; hard to reproduce
+- **Unknown** — not stated in the report
+
+## Step 6: Identify Suspected Areas
+
+If the report or project context points to specific system areas, list them. Examples: upload pipeline, authentication middleware, database migrations, frontend state management. If nothing in the report or CLAUDE.md points to a specific area, omit this section.
+
+## Step 7: Write the Triage Report
+
+Write the report to `~/.claude/triages/{kebab-case-summary}.md` unless the user specified a path.
+
+Use this structure:
+
+```md
+# Summary
+
+{one sentence}
+
+# Issue Type
+
+{type}
+
+# Reported Behavior
+
+{what the reporter said happened}
+
+# Expected Behavior
+
+{what should happen, or Unknown}
+
+# Missing Information
+
+{bulleted list, or "None — report has enough to proceed."}
+
+# Suspected Areas
+
+{bulleted list — omit section if nothing is inferable}
+
+# Severity
+
+{Critical | High | Medium | Low | Unknown}
+
+# Reproducibility
+
+{Always | Intermittent | Rare | Unknown}
+
+# Recommended Next Step
+
+{/investigate | /plan-a-feature | /plan-implementation | "Clarify with reporter before proceeding"}
+```
+
+Present the triage report to the user.

--- a/plugin/skills/issue-triage/SKILL.md
+++ b/plugin/skills/issue-triage/SKILL.md
@@ -10,6 +10,7 @@
 ## Triage Approach
 
 - Work only from what the reporter wrote. Do not infer facts that are not stated.
+- For Expected Behavior and Suspected Areas, do not fill gaps with assumed intent or codebase guesses.
 - Classify the issue type before doing anything else. The type drives what counts as missing information.
 - Severity is an estimate based on what is known. Mark it Unknown when impact is not inferable from the report.
 - The recommended next step is the single most appropriate han skill to run after triage completes.
@@ -29,7 +30,7 @@ Determine the issue type from the report text:
 - **Feature Request** — something new is being asked for
 - **Performance** — the system is too slow, uses too much memory, or degrades under load
 - **Security** — a vulnerability, exposure, or access control concern
-- **Regression** — the reporter explicitly says it used to work and no longer does
+- **Regression** — the reporter explicitly says it used to work and no longer does; quote or paraphrase that statement
 - **Question** — the reporter is asking how something works, not reporting a problem
 - **Other** — none of the above apply
 
@@ -73,7 +74,7 @@ If nothing is missing, write: `None — report has enough to proceed.`
 
 ## Step 6: Identify Suspected Areas
 
-If the report or project context points to specific system areas, list them. Examples: upload pipeline, authentication middleware, database migrations, frontend state management. If nothing in the report or CLAUDE.md points to a specific area, omit this section.
+If the report or project context points to specific system areas, list them. Examples: upload pipeline, authentication middleware, database migrations, frontend state management. Do not infer areas that are not mentioned. If nothing in the report or CLAUDE.md points to a specific area, omit this section.
 
 ## Step 7: Write the Triage Report
 
@@ -116,7 +117,7 @@ Use this structure:
 
 # Recommended Next Step
 
-{If any critical reproduction or scope details are missing, write "Clarify with reporter before proceeding". Otherwise choose the single most appropriate skill: /investigate, /plan-a-feature, or /plan-implementation.}
+{If any of these are missing, write "Clarify with reporter before proceeding": reproduction steps, environment details (OS, browser, version), or the user-impact scope. Otherwise choose the single most appropriate skill: /investigate, /plan-a-feature, or /plan-implementation.}
 ```
 
 Present the triage report to the user.

--- a/plugin/skills/issue-triage/SKILL.md
+++ b/plugin/skills/issue-triage/SKILL.md
@@ -1,7 +1,7 @@
 | name | issue-triage |
 | --- | --- |
 | description | Triage a raw, vague issue or bug report into a structured document that names what is known, what is missing, and what to do next. Use when an incoming issue, bug report, or problem description is too vague or incomplete for investigation or planning: classify the issue type, identify missing information, assess severity and reproducibility, and recommend the right next han skill. Does not investigate root causes or trace code paths; use investigate for debugging, diagnosis, and root cause analysis. Does not plan features or build solutions; use plan-a-feature or plan-implementation for that. |
-| allowed-tools | Read, Glob, Write |
+| allowed-tools | Read, Write |
 
 ## Project Context
 
@@ -29,7 +29,7 @@ Determine the issue type from the report text:
 - **Feature Request** — something new is being asked for
 - **Performance** — the system is too slow, uses too much memory, or degrades under load
 - **Security** — a vulnerability, exposure, or access control concern
-- **Regression** — something that used to work has stopped working
+- **Regression** — the reporter explicitly says it used to work and no longer does
 - **Question** — the reporter is asking how something works, not reporting a problem
 - **Other** — none of the above apply
 
@@ -39,7 +39,7 @@ From the report, identify:
 
 - **Summary** — one sentence describing the problem in plain terms
 - **Reported Behavior** — what the reporter said happened, in their words or close paraphrase
-- **Expected Behavior** — what should have happened (infer if obvious; mark Unknown if not)
+- **Expected Behavior** — what the reporter said should happen; if not stated, mark Unknown
 
 ## Step 4: Identify Missing Information
 
@@ -116,7 +116,7 @@ Use this structure:
 
 # Recommended Next Step
 
-{/investigate | /plan-a-feature | /plan-implementation | "Clarify with reporter before proceeding"}
+{If any critical reproduction or scope details are missing, write "Clarify with reporter before proceeding". Otherwise choose the single most appropriate skill: /investigate, /plan-a-feature, or /plan-implementation.}
 ```
 
 Present the triage report to the user.


### PR DESCRIPTION
closes #4 

# PR Summary

- Add the new /issue-triage skill definition and operator documentation.
- Update quickstart, skills index, and related docs to include the new skill and adjust the skill count to 16.
- Bump marketplace description and version to 2.3.0 to reflect the new capability.