### PR TITLE
Coding standards skill update: symlink as rules

### DIFF
--- a/.claude/rules/agents/agent-domain-focus.md
+++ b/.claude/rules/agents/agent-domain-focus.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/agent-building-guidelines/agent-domain-focus.md

--- a/.claude/rules/agents/agent-external-files.md
+++ b/.claude/rules/agents/agent-external-files.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/agent-building-guidelines/agent-external-files.md

--- a/.claude/rules/agents/agent-model-selection.md
+++ b/.claude/rules/agents/agent-model-selection.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/agent-building-guidelines/agent-model-selection.md

--- a/.claude/rules/agents/graceful-degradation.md
+++ b/.claude/rules/agents/graceful-degradation.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/agent-building-guidelines/graceful-degradation.md

--- a/.claude/rules/agents/multi-agent-economics.md
+++ b/.claude/rules/agents/multi-agent-economics.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/agent-building-guidelines/multi-agent-economics.md

--- a/.claude/rules/plugin-entity-taxonomy.md
+++ b/.claude/rules/plugin-entity-taxonomy.md
@@ -1,0 +1,1 @@
+../../docs/guidance/plugin-entity-taxonomy.md

--- a/.claude/rules/skills/allowed-tools-AskUserQuestion.md
+++ b/.claude/rules/skills/allowed-tools-AskUserQuestion.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/allowed-tools-AskUserQuestion.md

--- a/.claude/rules/skills/allowed-tools-bash-permissions.md
+++ b/.claude/rules/skills/allowed-tools-bash-permissions.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/allowed-tools-bash-permissions.md

--- a/.claude/rules/skills/context-hygiene.md
+++ b/.claude/rules/skills/context-hygiene.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/context-hygiene.md

--- a/.claude/rules/skills/context-injection-commands.md
+++ b/.claude/rules/skills/context-injection-commands.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/context-injection-commands.md

--- a/.claude/rules/skills/cowork-specific-skill-instructions.md
+++ b/.claude/rules/skills/cowork-specific-skill-instructions.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/cowork-specific-skill-instructions.md

--- a/.claude/rules/skills/documentation-maintenance.md
+++ b/.claude/rules/skills/documentation-maintenance.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/documentation-maintenance.md

--- a/.claude/rules/skills/dynamic-project-discovery.md
+++ b/.claude/rules/skills/dynamic-project-discovery.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/dynamic-project-discovery.md

--- a/.claude/rules/skills/graceful-degradation.md
+++ b/.claude/rules/skills/graceful-degradation.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/graceful-degradation.md

--- a/.claude/rules/skills/hardening-fuzzy-vs-deterministic.md
+++ b/.claude/rules/skills/hardening-fuzzy-vs-deterministic.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/hardening-fuzzy-vs-deterministic.md

--- a/.claude/rules/skills/naming-conventions.md
+++ b/.claude/rules/skills/naming-conventions.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/naming-conventions.md

--- a/.claude/rules/skills/optional-git-repositories.md
+++ b/.claude/rules/skills/optional-git-repositories.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/optional-git-repositories.md

--- a/.claude/rules/skills/progressive-disclosure.md
+++ b/.claude/rules/skills/progressive-disclosure.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/progressive-disclosure.md

--- a/.claude/rules/skills/script-execution-instructions.md
+++ b/.claude/rules/skills/script-execution-instructions.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/script-execution-instructions.md

--- a/.claude/rules/skills/security-restrictions.md
+++ b/.claude/rules/skills/security-restrictions.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/security-restrictions.md

--- a/.claude/rules/skills/skill-composition.md
+++ b/.claude/rules/skills/skill-composition.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/skill-composition.md

--- a/.claude/rules/skills/skill-decomposition.md
+++ b/.claude/rules/skills/skill-decomposition.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/skill-decomposition.md

--- a/.claude/rules/skills/skill-description-frontmatter.md
+++ b/.claude/rules/skills/skill-description-frontmatter.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/skill-description-frontmatter.md

--- a/.claude/rules/skills/skill-reference-files.md
+++ b/.claude/rules/skills/skill-reference-files.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/skill-reference-files.md

--- a/.claude/rules/skills/success-criteria-and-testing.md
+++ b/.claude/rules/skills/success-criteria-and-testing.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/success-criteria-and-testing.md

--- a/.claude/rules/skills/troubleshooting.md
+++ b/.claude/rules/skills/troubleshooting.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/troubleshooting.md

--- a/.claude/rules/skills/use-case-planning.md
+++ b/.claude/rules/skills/use-case-planning.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/use-case-planning.md

--- a/.claude/rules/skills/workflow-patterns.md
+++ b/.claude/rules/skills/workflow-patterns.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/workflow-patterns.md

--- a/.claude/rules/skills/writing-effective-instructions.md
+++ b/.claude/rules/skills/writing-effective-instructions.md
@@ -1,0 +1,1 @@
+../../../docs/guidance/skill-building-guidance/writing-effective-instructions.md

--- a/docs/guidance/agent-building-guidelines/agent-domain-focus.md
+++ b/docs/guidance/agent-building-guidelines/agent-domain-focus.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/agents/**/*.md"
+---
+
 # Domain Focus in Agent Definitions
 
 Agents perform better when they target a narrow domain with precise vocabulary. A focused agent activates deep expertise in the model. A broad generalist activates shallow, averaged knowledge across competing domains.

--- a/docs/guidance/agent-building-guidelines/agent-external-files.md
+++ b/docs/guidance/agent-building-guidelines/agent-external-files.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/agents/**/*.md"
+---
+
 # External File References in Agent Definitions
 
 Agent definitions are self-contained markdown files. Unlike skills, agents do not support external file references. No `references/` folders, no `scripts/` folders, and no context injection commands. All content must be inlined directly in the agent `.md` file.

--- a/docs/guidance/agent-building-guidelines/agent-model-selection.md
+++ b/docs/guidance/agent-building-guidelines/agent-model-selection.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/agents/**/*.md"
+---
+
 # Choosing the Right Model for Agent Definitions
 
 Agents support a `model` frontmatter field that skills do not. Choosing the right model is about matching capability and speed to the task the agent performs. **Cost is not a factor in model selection for our agents.** Choose based on what the task demands, not price.

--- a/docs/guidance/agent-building-guidelines/graceful-degradation.md
+++ b/docs/guidance/agent-building-guidelines/graceful-degradation.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/agents/**/*.md"
+---
+
 # Graceful Degradation
 
 Agent definitions are self-contained and dispatched by skills. When a skill operates in degraded mode (for example, no git), the agents it dispatches may include steps that depend on git history, branch context, or other tools that may be absent. Without this guidance, agents that fail or produce errors when a tool is missing force the orchestrating skill to add defensive guards around every agent dispatch. An agent that checks tool availability inline and skips gracefully self-adapts to degraded environments.

--- a/docs/guidance/agent-building-guidelines/multi-agent-economics.md
+++ b/docs/guidance/agent-building-guidelines/multi-agent-economics.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/agents/**/*.md"
+---
+
 # Multi-Agent Economics
 
 When a skill dispatches agents via the `Agent` tool, each agent adds latency and token cost. This doc provides the decision framework for when adding agents is justified and when it's wasteful.

--- a/docs/guidance/skill-building-guidance/allowed-tools-AskUserQuestion.md
+++ b/docs/guidance/skill-building-guidance/allowed-tools-AskUserQuestion.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # `AskUserQuestion` in Skill `allowed-tools`
 
 The `allowed-tools` frontmatter in a SKILL.md file defines which tools are auto-approved without user permission prompts when the skill is active. Due to a bug in Claude Code's permission evaluator, `AskUserQuestion` must not be listed in `allowed-tools` — doing so silently breaks the tool's interactive prompt.

--- a/docs/guidance/skill-building-guidance/allowed-tools-bash-permissions.md
+++ b/docs/guidance/skill-building-guidance/allowed-tools-bash-permissions.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Bash Permission Patterns in `allowed-tools`
 
 The `allowed-tools` frontmatter in a SKILL.md file declares which Bash commands are auto-approved without user permission prompts. Bash permissions use a glob pattern syntax: `Bash(command prefix *)`. Getting the syntax or granularity wrong causes skills to either stall on permission prompts or silently auto-approve unintended commands.

--- a/docs/guidance/skill-building-guidance/context-hygiene.md
+++ b/docs/guidance/skill-building-guidance/context-hygiene.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Context Hygiene
 
 Context hygiene is the discipline of keeping a skill's context footprint minimal, well-positioned, and free of stale or irrelevant tokens. Several other guidance docs contain rules that serve this goal — progressive disclosure, frontmatter conciseness, extracting to references/, position-aware ordering, stale-doc audits. This doc explains the mechanisms behind those rules: why they work and what happens when they're violated. It is based on the [Context Hygiene principle](https://jdforsythe.github.io/10-principles/principles/context-hygiene/), adapted for skill-building concerns.

--- a/docs/guidance/skill-building-guidance/context-injection-commands.md
+++ b/docs/guidance/skill-building-guidance/context-injection-commands.md
@@ -217,9 +217,10 @@ Real examples organized by purpose, with source file references:
 
 **File/directory discovery:**
 - `` !`find . -maxdepth 1 -name "CLAUDE.md" -type f` `` — check for file (`code-review`, `coding-standard`, `architectural-decision-record`, `investigate`, `iterative-plan-review`, `project-discovery`, `project-documentation`, `test-planning`)
-- `` !`find . -maxdepth 1 -name "AGENTS.md" -type f` `` — check for file (`project-discovery`)
+- `` !`find . -maxdepth 1 -name "AGENTS.md" -type f` `` — check for file (`coding-standard`, `project-discovery`)
 - `` !`find . -maxdepth 1 -name "README*" -type f` `` — check for file (`project-discovery`)
 - `` !`find . -maxdepth 3 -name "project-discovery.md" -type f` `` — find discovery output (`code-review`, `coding-standard`, `architectural-decision-record`, `investigate`, `iterative-plan-review`, `project-documentation`, `test-planning`)
+- `` !`find . -maxdepth 4 -type d -path "*/.claude/rules/coding-standards"` `` — check for path-scoped rules directory (`coding-standard`)
 
 **Tool availability:**
 - `` !`which gh` `` — check for gh CLI (`update-pr-description`, `gh-pr-review`)

--- a/docs/guidance/skill-building-guidance/context-injection-commands.md
+++ b/docs/guidance/skill-building-guidance/context-injection-commands.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Context Injection Commands in Skill Files
 
 Context injection commands use the `` !`command` `` syntax to execute a shell command at skill load time and inject its stdout into the skill as runtime context. The command runs **once when the skill loads**, not during each step. This gives skill steps access to dynamic information about the current environment without hardcoding values.

--- a/docs/guidance/skill-building-guidance/cowork-specific-skill-instructions.md
+++ b/docs/guidance/skill-building-guidance/cowork-specific-skill-instructions.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Claude Cowork — Complete Reference
 
 ## What is Cowork?

--- a/docs/guidance/skill-building-guidance/documentation-maintenance.md
+++ b/docs/guidance/skill-building-guidance/documentation-maintenance.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Documentation Maintenance
 
 A skill that worked last month can silently degrade if its SKILL.md or references describe things that have changed. The model follows stale instructions faithfully — stale documentation is active poison, not passive neglect.

--- a/docs/guidance/skill-building-guidance/dynamic-project-discovery.md
+++ b/docs/guidance/skill-building-guidance/dynamic-project-discovery.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Dynamic Project Discovery
 
 Skills run in whatever repository the user invokes them from. They must discover the project's structure, branch names, and tool availability dynamically rather than hardcoding assumptions.

--- a/docs/guidance/skill-building-guidance/graceful-degradation.md
+++ b/docs/guidance/skill-building-guidance/graceful-degradation.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+  - "plugin/skills/**/scripts/**"
+---
+
 # Graceful Degradation
 
 **Differentiation from `dynamic-project-discovery.md`:** That doc covers hard prerequisites — tools or capabilities the skill cannot function without at all; when they're missing, the skill stops with a message to the user. This doc covers *partial context* — situations where the environment is usable but some data (a git history, project config, docs directory) is absent. Graceful degradation means detecting what is available, selecting a named execution mode, and continuing to produce useful output.

--- a/docs/guidance/skill-building-guidance/hardening-fuzzy-vs-deterministic.md
+++ b/docs/guidance/skill-building-guidance/hardening-fuzzy-vs-deterministic.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Hardening: Fuzzy vs. Deterministic Steps
 
 Other guidance docs tell you to extract deterministic operations to scripts ([Progressive Disclosure](./progressive-disclosure.md), [Writing Effective Instructions](./writing-effective-instructions.md)). This doc provides the decision framework for recognizing which steps are candidates and classifying them correctly.

--- a/docs/guidance/skill-building-guidance/naming-conventions.md
+++ b/docs/guidance/skill-building-guidance/naming-conventions.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Naming Conventions
 
 Consistent naming across plugins, skills, and directories helps users discover and understand what a skill does from its name alone.

--- a/docs/guidance/skill-building-guidance/optional-git-repositories.md
+++ b/docs/guidance/skill-building-guidance/optional-git-repositories.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Optional Git Repositories
 
 Skills that analyze code should treat git as optional. Hard-requiring git breaks skills in common, legitimate scenarios — and the moments when git is *not* fully set up are often the most valuable times to run an analysis skill.

--- a/docs/guidance/skill-building-guidance/progressive-disclosure.md
+++ b/docs/guidance/skill-building-guidance/progressive-disclosure.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Progressive Disclosure
 
 Skills use a three-level information architecture that balances context availability with token efficiency. Each level loads only when needed, keeping Claude's context window focused on what matters for the current task.

--- a/docs/guidance/skill-building-guidance/script-execution-instructions.md
+++ b/docs/guidance/skill-building-guidance/script-execution-instructions.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+  - "plugin/skills/**/scripts/**"
+---
+
 # Script Execution Instructions in SKILL.md
 
 When a skill needs to run shell scripts during its steps, the SKILL.md body must describe the invocation as numbered prose instructions — not fenced code blocks.

--- a/docs/guidance/skill-building-guidance/security-restrictions.md
+++ b/docs/guidance/skill-building-guidance/security-restrictions.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Security Restrictions
 
 Skill frontmatter appears in Claude's system prompt. This privileged position means malicious or malformed frontmatter could inject instructions into the system prompt, bypass skill boundaries, or cause silent failures. These restrictions prevent those risks.

--- a/docs/guidance/skill-building-guidance/skill-composition.md
+++ b/docs/guidance/skill-building-guidance/skill-composition.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Skill Composition
 
 Skills should not call other skills via the Skill tool. Sub-skill calls have

--- a/docs/guidance/skill-building-guidance/skill-decomposition.md
+++ b/docs/guidance/skill-building-guidance/skill-decomposition.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Skill Decomposition
 
 A skill should do one thing well. When a skill handles too many responsibilities, it becomes fragile, hard to debug, and difficult for the LLM to follow consistently. Split monolithic skills into focused units and extract reusable agent definitions.

--- a/docs/guidance/skill-building-guidance/skill-description-frontmatter.md
+++ b/docs/guidance/skill-building-guidance/skill-description-frontmatter.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Skill Description Frontmatter
 
 The `description` field in SKILL.md frontmatter is the primary mechanism Claude uses to decide when to invoke a skill. Every installed skill's description is always loaded into Claude's context, where descriptions compete against each other for selection. A thin description means missed triggers — users ask for something the skill handles, but Claude doesn't recognize the match. An overbroad description means false triggers — Claude invokes the wrong skill because descriptions overlap without clear boundaries.

--- a/docs/guidance/skill-building-guidance/skill-reference-files.md
+++ b/docs/guidance/skill-building-guidance/skill-reference-files.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Skill Reference Files
 
 Skills can include reference documents — templates, checklists, examples, and other supporting content — in a `references/` subdirectory within the skill folder. These files are loaded into the skill's context on demand when a step explicitly references them.

--- a/docs/guidance/skill-building-guidance/success-criteria-and-testing.md
+++ b/docs/guidance/skill-building-guidance/success-criteria-and-testing.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Success Criteria and Testing
 
 How do you know a skill is working? Without defined success criteria, "it seems fine" becomes the bar — and that bar shifts with each conversation. This guide defines three test types that cover whether a skill triggers correctly, executes its workflow, and actually improves outcomes compared to working without it.

--- a/docs/guidance/skill-building-guidance/troubleshooting.md
+++ b/docs/guidance/skill-building-guidance/troubleshooting.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Troubleshooting
 
 This guide covers common problems encountered when building and using skills, organized by symptom. Each section describes the symptom, explains the likely cause, and provides a concrete fix.

--- a/docs/guidance/skill-building-guidance/use-case-planning.md
+++ b/docs/guidance/skill-building-guidance/use-case-planning.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Use Case Planning
 
 Before writing a SKILL.md, define 2-3 concrete use cases the skill should handle. Use cases ground the skill in real user workflows rather than abstract capabilities, and they become the test cases you run after building.

--- a/docs/guidance/skill-building-guidance/workflow-patterns.md
+++ b/docs/guidance/skill-building-guidance/workflow-patterns.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Workflow Patterns
 
 Skills encode workflows — multi-step processes that Claude executes in a specific order with specific tools. This guide documents four structural patterns that appear across well-built skills. Each pattern solves a different workflow shape, and most real skills combine two or more.

--- a/docs/guidance/skill-building-guidance/writing-effective-instructions.md
+++ b/docs/guidance/skill-building-guidance/writing-effective-instructions.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "plugin/skills/**/*.md"
+---
+
 # Writing Effective Instructions
 
 The SKILL.md body — everything below the YAML frontmatter — is where you tell Claude *how* to execute the skill. These instructions load when the skill triggers (Level 2 in the progressive disclosure model) and guide Claude through the workflow step by step.

--- a/docs/skills/coding-standard.md
+++ b/docs/skills/coding-standard.md
@@ -8,7 +8,7 @@ Operator documentation for the `/coding-standard` skill in the han plugin. This 
 
 - **What it does.** Creates and updates coding standards for the current project. From scratch, by converting an existing document, or by updating an existing standard.
 - **When to use it.** You want to formalize a convention the team already follows, or to research and establish a new one, with real code examples from the codebase.
-- **What you get back.** A hierarchically-named coding-standard document under `docs/coding-standards/` with metadata, Correct-usage examples, What-to-avoid examples, and a reference added to `CLAUDE.md`.
+- **What you get back.** A hierarchically-named coding-standard document under `docs/coding-standards/` with metadata, `paths:` YAML frontmatter, Correct-usage examples, What-to-avoid examples, and a symlink under `.claude/rules/coding-standards/` so Claude Code loads the standard as a path-scoped rule on demand.
 
 ## Key concepts
 
@@ -17,6 +17,7 @@ Operator documentation for the `/coding-standard` skill in the han plugin. This 
 - **Evidence from the codebase via parallel explorers.** Two `codebase-explorer` agents run in parallel. One finds implementation patterns (Correct-usage and What-to-avoid candidates with file:line references); the other finds existing standards and ADRs the new one should link or resolve. Correct-usage examples are drawn from real files. If the pattern is not yet implemented, examples are labeled "Proposed pattern."
 - **Adversarial review before verification.** A `junior-developer` agent stress-tests the draft for ambiguous rules, hidden assumptions, and conflicts with existing standards. An `information-architect` agent audits the draft for findability, scannability, and whether the Rationale is placed where the right reader will find it.
 - **Hierarchically-prefixed filenames.** `{top-level}[-{second-level}]-{hyphenated-name}.md`. A one- or two-level hierarchy prefix (for example, `svelte-stores-state-shape.md`) discovered at runtime from existing standards and project context, so related standards sort together in a directory listing.
+- **Path-scoped rules via symlink.** Each new standard carries `paths:` YAML frontmatter declaring the file globs it governs, and is symlinked from `.claude/rules/coding-standards/{filename}` into the canonical doc. Claude Code loads the standard into context only when it reads a file matching one of the globs (`load_reason: path_glob_match`), so the rule does not bloat session startup. Standards do not appear in the available-skills picker — the rules surface is separate.
 - **`/code-review` reads these automatically.** Once landed, the standards are consulted during every `/code-review`. Violations surface as findings.
 
 ## When to use it
@@ -56,8 +57,8 @@ Example prompts:
 
 A coding-standard document in the project's coding-standards directory, plus integration:
 
-- **`docs/coding-standards/{top-level}[-{second-level}]-{name}.md`.** The standard itself, following the template at [`references/template.md`](../../plugin/skills/coding-standard/references/template.md). The hierarchy prefix is discovered from existing standards and the project's languages, frameworks, and subsystems so related standards sort together. Includes metadata (Status, Authors, Applies To, Date Created, Last Updated, Reviewers), an Introduction, the Standard (rules in testable form), Correct-usage examples from real code, What-to-avoid examples, Rationale, and Additional Resources.
-- **A reference added to `CLAUDE.md`** under the coding-standards section, following the project's existing pattern so every downstream skill finds it.
+- **`docs/coding-standards/{top-level}[-{second-level}]-{name}.md`.** The standard itself, following the template at [`references/template.md`](../../plugin/skills/coding-standard/references/template.md). The hierarchy prefix is discovered from existing standards and the project's languages, frameworks, and subsystems so related standards sort together. The file opens with a YAML frontmatter block carrying the approved `paths:` globs, followed by metadata (Status, Authors, Applies To, Date Created, Last Updated, Reviewers), an Introduction, the Standard (rules in testable form), Correct-usage examples from real code, What-to-avoid examples, Rationale, and Additional Resources.
+- **A symlink under `.claude/rules/coding-standards/{filename}`** with a relative target pointing back to the canonical doc. Claude Code resolves it as a path-scoped rule and loads the standard into context only when a file matching one of the `paths:` globs is read. The skill never adds the standard as an enumerated entry in `CLAUDE.md` (or `AGENTS.md`); it adds a one-time pointer paragraph to the memory file only if the file does not already reference `.claude/rules/coding-standards/`.
 - **Cross-references.** Links to related standards, ADRs, and feature docs, added bidirectionally.
 - **Source-document handling** (conversion mode). If the source is fully subsumed, it is deleted and references updated. If it retains useful content, a link to the new standard is added.
 
@@ -79,13 +80,13 @@ The skill walks a nine-step process:
 
 1. **Determine mode.** Creating new / Converting existing / Updating existing.
 2. **Evaluate appropriateness.** Should this be tooling instead? If yes, warn and ask.
-3. **Discover project structure.** Find the coding-standards directory (or create one), enumerate existing standards, check format compatibility, resolve author info, and discover the filename hierarchy taxonomy from existing standards' filenames plus the project's languages, frameworks, and subsystems.
+3. **Discover project structure.** Find the coding-standards directory (or create one), enumerate existing standards, check format compatibility, resolve author info, discover the filename hierarchy taxonomy from existing standards' filenames plus the project's languages, frameworks, and subsystems, and capture the project's primary file-type globs for the `paths:` proposal in Step 6.
 4. **Gather context.** Topic, scope, motivation. Dispatch two `codebase-explorer` agents in parallel for implementation patterns and existing standards/ADRs.
 5. **Convert source document** (conversion mode only). Map sections using the ADR-conversion-mapping reference; handle the source file (delete if fully subsumed, link if partial).
-6. **Write the coding standard.** Hierarchically-prefixed filename (top-level subsystem/framework, optional second level), fill the template with real code examples and actual project language identifiers.
-7. **Integration.** Add `CLAUDE.md` reference; add cross-references in both directions.
+6. **Write the coding standard.** Hierarchically-prefixed filename (top-level subsystem/framework, optional second level), fill the template with real code examples and actual project language identifiers. Propose a `paths:` glob list scoped to what the standard governs, get user approval, and write it as YAML frontmatter at the top of the file.
+7. **Integration.** Create the symlink at `.claude/rules/coding-standards/{filename}` pointing back to the canonical doc with a relative target; ensure the memory file's pointer paragraph exists (added once if missing, never enumerating individual standards); add cross-references in both directions.
 8. **Adversarial review.** Dispatch `junior-developer` for ambiguity and assumption checks and `information-architect` for findability and structure. Apply actionable edits.
-9. **Verification.** Re-read the file, confirm metadata, template structure, real file paths, distinct Correct-vs-Avoid examples, and that Step 8 edits were applied.
+9. **Verification.** Re-read the file, confirm metadata, template structure, `paths:` frontmatter, working symlink, real file paths, distinct Correct-vs-Avoid examples, and that Step 8 edits were applied.
 
 ## YAGNI
 
@@ -114,6 +115,12 @@ URL: https://www.aboutamazon.com/news/workplace/what-is-a-six-page-narrative
 The SRE Book's treatment of postmortem and incident-review conventions (named, discoverable, reviewable documents) shaped the skill's bias toward hierarchically-named filenames that group related standards together and a reviewable metadata block.
 
 URL: https://sre.google/sre-book/
+
+### Claude Code Memory: Path-Scoped Rules
+
+Anthropic's Claude Code memory documentation defines the `.claude/rules/` surface, the `paths:` YAML frontmatter that scopes a rule to file globs (`load_reason: path_glob_match`), and the symlink support that lets the canonical doc live in the project's human-readable docs folder while Claude finds it through the rules surface. The skill's integration step is a direct application of this model: rules out of the memory file, into a path-scoped rules folder, loaded on demand.
+
+URL: https://code.claude.com/docs/en/memory
 
 ## Related documentation
 

--- a/docs/skills/coding-standard.md
+++ b/docs/skills/coding-standard.md
@@ -62,6 +62,20 @@ A coding-standard document in the project's coding-standards directory, plus int
 - **Cross-references.** Links to related standards, ADRs, and feature docs, added bidirectionally.
 - **Source-document handling** (conversion mode). If the source is fully subsumed, it is deleted and references updated. If it retains useful content, a link to the new standard is added.
 
+## Why the canonical doc lives in `docs/` and a symlink lives in `.claude/rules/`
+
+Plain-language version of the design choice, for anyone who reads a new standard and wonders why the file is in two places.
+
+**One file. Two ways to find it.** The actual standard is a single readable document under your project's coding-standards directory (usually `docs/coding-standards/`). That is the only copy. The file under `.claude/rules/coding-standards/` is a symlink — a pointer back to that one canonical file, not a second copy. Edit either path; you are editing the same file.
+
+**Why not just store the standards inside `.claude/rules/`?** Because `.claude/` is a directory most teams treat as tool configuration, not human-readable documentation. Standards are documents people open in pull request reviews, link from onboarding pages, and read on GitHub. They belong in `docs/`. The symlink lets Claude Code find them through its rules surface without dragging the source-of-truth out of the docs tree.
+
+**Why not duplicate the file into both places?** Because two copies drift. The first time someone fixes a typo in one but not the other, the standard quietly forks. A symlink makes drift impossible: there is one file, and both access paths resolve to it.
+
+**Why a symlink instead of an enumerated link in `CLAUDE.md`?** Claude Code's path-scoped rules (see [Claude Code memory](https://code.claude.com/docs/en/memory)) load a rule only when a file matching its `paths:` glob is read. A standard about Go service code, scoped to `**/*.go`, will not load when you are editing a TypeScript file — so it does not bloat session startup. An enumerated link in `CLAUDE.md` loads on every session whether the standard is relevant or not. The symlink + `paths:` model keeps context small and load-on-demand.
+
+**What the skill does and does not touch in `CLAUDE.md`/`AGENTS.md`.** It will add a short pointer paragraph once, only if the memory file does not already mention `.claude/rules/coding-standards/`. It never adds an enumerated link for the new standard. Pre-existing enumerated entries from earlier versions of this skill are left alone — migrating them out is a separate one-time operation, not the skill's job.
+
 ## How to get the most out of it
 
 - **Run `/project-discovery` first.** The skill reads CLAUDE.md's Project Discovery section to find the coding-standards directory, the language, and the documentation root. Without discovery, it falls back to Glob defaults.

--- a/docs/skills/coding-standard.md
+++ b/docs/skills/coding-standard.md
@@ -86,11 +86,11 @@ Plain-language version of the design choice, for anyone who reads a new standard
 
 ## Cost and latency
 
-The skill dispatches two `codebase-explorer` agents in parallel during Step 4 (evidence gathering) and two review agents in parallel during Step 8 (`junior-developer` + `information-architect`). All four run on their default models. Cost scales with codebase size and how many documents the explorers have to read. Typical runs are a few minutes.
+The skill dispatches two `codebase-explorer` agents in parallel during Step 4 (evidence gathering) and two review agents in parallel during Step 9 (`junior-developer` + `information-architect`). All four run on their default models. Cost scales with codebase size and how many documents the explorers have to read. Typical runs are a few minutes.
 
 ## In more detail
 
-The skill walks a nine-step process:
+The skill walks a ten-step process:
 
 1. **Determine mode.** Creating new / Converting existing / Updating existing.
 2. **Evaluate appropriateness.** Should this be tooling instead? If yes, warn and ask.
@@ -99,8 +99,9 @@ The skill walks a nine-step process:
 5. **Convert source document** (conversion mode only). Map sections using the ADR-conversion-mapping reference; handle the source file (delete if fully subsumed, link if partial).
 6. **Write the coding standard.** Hierarchically-prefixed filename (top-level subsystem/framework, optional second level), fill the template with real code examples and actual project language identifiers. Propose a `paths:` glob list scoped to what the standard governs, get user approval, and write it as YAML frontmatter at the top of the file.
 7. **Integration.** Create the symlink at `.claude/rules/coding-standards/{filename}` pointing back to the canonical doc with a relative target; ensure the memory file's pointer paragraph exists (added once if missing, never enumerating individual standards); add cross-references in both directions.
-8. **Adversarial review.** Dispatch `junior-developer` for ambiguity and assumption checks and `information-architect` for findability and structure. Apply actionable edits.
-9. **Verification.** Re-read the file, confirm metadata, template structure, `paths:` frontmatter, working symlink, real file paths, distinct Correct-vs-Avoid examples, and that Step 8 edits were applied.
+8. **Adoption-bias audit.** Six structural checks against over-application: primary-rationale visibility, a decision tree near the top, a substantive *When NOT to Apply* section, surfaced (not buried) exceptions, code-example comments that match the primary rationale, and a verification step for defensive adoptions.
+9. **Adversarial review.** Dispatch `junior-developer` for ambiguity and assumption checks and `information-architect` for findability and structure. Apply actionable edits.
+10. **Verification.** Re-read the file, confirm metadata, template structure, `paths:` frontmatter, a working symlink, real file paths, distinct Correct-vs-Avoid examples, that no enumerated entry was added to the memory file, and that Step 8 and Step 9 edits were applied.
 
 ## YAGNI
 

--- a/plugin/skills/coding-standard/SKILL.md
+++ b/plugin/skills/coding-standard/SKILL.md
@@ -11,7 +11,7 @@ description: >
   open-ended options or prior art that is not destined for a standard — use
   research.
 argument-hint: [standard-topic or document-path]
-allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(git config *), Bash(whoami), Bash(mkdir *), Bash(find *)
+allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(git config *), Bash(whoami), Bash(mkdir *), Bash(find *), Bash(ln *), Bash(test *), Bash(readlink *)
 ---
 
 ## Project Context
@@ -19,7 +19,9 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(git config *), Bash(wh
 - Git user: !`git config user.name` (!`git config user.email`)
 - OS username: !`whoami`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
+- AGENTS.md: !`find . -maxdepth 1 -name "AGENTS.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- Rules directory: !`find .claude/rules/coding-standards -maxdepth 1 -type d 2>/dev/null || echo "absent"`
 
 ## Step 1: Determine Mode
 
@@ -77,6 +79,12 @@ If no accepted evidence applies, recommend deferring the standard with the trigg
    - **From project context:** Read CLAUDE.md and project-discovery.md (paths from project context above) to identify the project's languages, frameworks, runtimes, and major subsystems. Each of these is a candidate top-level hierarchy (e.g., `svelte`, `rails`, `postgres`, `terraform`, `api`, `worker`).
    - **Carry forward to Step 6:** the discovered top-level prefixes (existing + candidate) and any second-level prefixes already in use under each.
 
+7. **Discover the project's primary file-type globs.** The `paths:` frontmatter in Step 6 needs file globs scoped to the languages and directories the new standard governs. Build the candidate glob set now so Step 6 has it on hand.
+   - **From CLAUDE.md and project-discovery.md:** extract every language, file extension, and major source directory the project actually uses (e.g., `**/*.go`, `**/*.ts`, `**/*.tsx`, `**/*.py`, `**/*.rb`, `app/**/*.rb`, `services/**/*.go`).
+   - **From existing standards' `paths:` frontmatter:** if any existing standard already carries `paths:`, collect its globs as candidate glob prefixes — they reflect the project's accepted scoping vocabulary.
+   - **Fallback:** if neither source yields globs, glob the project root for the dominant file extensions (`**/*.{ext}` for each extension seen in more than a handful of files) and surface what you found.
+   - **Carry forward to Step 6:** the resolved candidate glob set, grouped by language or subsystem.
+
 ## Step 4: Gather Context
 
 1. From the arguments and conversation, determine:
@@ -123,20 +131,51 @@ When converting an existing document into a coding standard:
    - **Applies To**: free-text matching the project's terminology
    - **Date Created / Last Updated**: current date and time
    - **Reviewers**: leave empty
-5. **Fill each template section** with real code examples from the codebase (found in Step 4)
-6. **Code fence language identifiers** must match the project's actual languages
-7. **For cross-cutting coding standards:** include examples from each system area, label by area not language, set Applies To to list all areas
-8. **If no real code examples exist yet** (coding standard for a pattern not yet implemented): label examples as "Proposed pattern" and note this in the Introduction
+5. **Propose the `paths:` glob list and get user approval.** The `paths:` field in the YAML frontmatter is what makes the standard load-on-demand under [Claude Code path-scoped rules](https://code.claude.com/docs/en/memory). Rules without `paths:` load at every session start and bloat startup context; rules with `paths:` load only when Claude reads a file whose path matches one of the globs (`load_reason: path_glob_match`).
+   - **Build the candidate list** from the Applies To text and Scope section of this standard, intersected with the project file-type globs discovered in Step 3.7. Scope a glob no broader than the standard actually governs — if the standard applies only to Svelte stores, prefer `src/**/stores/**/*.ts` over `**/*.ts`.
+   - **Surface the proposal to the user** with `AskUserQuestion` (or as a recommendation when running unattended). Quote the Applies To text or scope clause that justifies each glob; mark inferred globs as `(inferred)`. Do not write the file until the user confirms or proposes a substitute.
+   - **YAML rule:** each glob must be double-quoted (characters like `*`, `{`, `[` are YAML-significant and fail to parse unquoted). Globs follow Claude Code's standard glob syntax (`**`, `*`, `?`, `{a,b}`).
+6. **Write the YAML frontmatter at the top of the file.** Place a `---` block before the `# {Title}` heading containing at minimum the approved `paths:` list. Example:
+   ```
+   ---
+   paths:
+     - "**/*.go"
+     - "internal/services/**/*.go"
+   ---
+   ```
+   When updating an existing standard (Step 1 mode = "Updating existing"), preserve every existing frontmatter key — only ADD or REPLACE `paths:`. Never strip `name`, `description`, `type`, or any other key the file already carries.
+7. **Fill each template section** with real code examples from the codebase (found in Step 4)
+8. **Code fence language identifiers** must match the project's actual languages
+9. **For cross-cutting coding standards:** include examples from each system area, label by area not language, set Applies To to list all areas, and propose a `paths:` list that includes one glob per area (e.g., `"app/**/*.rb"` plus `"services/**/*.go"`)
+10. **If no real code examples exist yet** (coding standard for a pattern not yet implemented): label examples as "Proposed pattern" and note this in the Introduction
 
 ## Step 7: Integration
 
-1. Add a reference in `CLAUDE.md` (or equivalent) following the existing pattern for coding standard references. If no pattern exists, add under a "Coding Standards" section:
-   ```
-   - [Title](./docs/coding-standards/{filename}) — brief description
-   ```
-2. Search for related documentation (other coding standards, ADRs, feature docs)
-3. Add cross-references in the new coding standard's "Additional Resources" section
-4. Add back-references from related docs where they add value
+The standard is now consumed by Claude Code as a [path-scoped rule](https://code.claude.com/docs/en/memory) via a symlink under `.claude/rules/coding-standards/`. The canonical file remains in the project's coding-standards documentation directory; the symlink gives Claude a second access path without duplicating content. **Do not add the new standard as an enumerated link in `CLAUDE.md` (or `AGENTS.md`).** Rules are discovered through the `.claude/rules/` surface, not through the memory file, and enumerating them in the memory file is the failure mode this integration replaces.
+
+1. **Create the symlink.**
+   - Ensure `.claude/rules/coding-standards/` exists: `mkdir -p .claude/rules/coding-standards`
+   - Symlink the canonical standard into it with a **relative** target so the link survives moving the repo:
+     ```
+     ln -s ../../../{relative-path-to-canonical-file} .claude/rules/coding-standards/{filename}
+     ```
+     The target path must be relative to the symlink's directory (`.claude/rules/coding-standards/`). For a canonical file at `docs/coding-standards/{filename}.md`, the target is `../../../docs/coding-standards/{filename}.md`. Adjust the `../` depth when the docs directory is nested differently.
+   - If the symlink already exists (update mode), verify with `readlink` that it points to the canonical file. If not, remove it and recreate with the correct target.
+2. **Ensure the pointer paragraph exists in `CLAUDE.md` (or `AGENTS.md`).** The memory file should mention the rules surface exactly once; the skill never adds an enumerated entry for the new standard.
+   - Check whether the memory file already references `.claude/rules/coding-standards/`. If yes, leave it alone.
+   - If not, append a short pointer paragraph under a "Coding Standards" heading. Adapt the wording to the project's voice, but keep the four load-bearing facts:
+     ```
+     Coding standards live in `{docs-directory}` and are also exposed to Claude
+     Code as path-scoped rules via symlinks under `.claude/rules/coding-standards/`.
+     Each rule carries a `paths:` field in its YAML frontmatter, so Claude only
+     loads the standard into context when it reads a file matching the glob.
+     Standards do not appear in the available-skills picker. Humans continue to
+     browse `{docs-directory}` for the canonical readable form.
+     ```
+   - Do not touch any pre-existing enumerated coding-standard entries in the memory file. Migrating those out is a separate operation, not this skill's responsibility.
+3. Search for related documentation (other coding standards, ADRs, feature docs).
+4. Add cross-references in the new coding standard's "Additional Resources" section.
+5. Add back-references from related docs where they add value.
 
 ## Step 8: Adoption-Bias Audit
 
@@ -176,10 +215,13 @@ Read back the coding standard file and confirm:
 
 1. All metadata fields are filled in (no `{placeholder}` values remain)
 2. Template structure from [template.md](references/template.md) was followed
-3. Code examples reference real files that exist (verify with Glob) — cross-check against the Correct-usage candidates returned in Step 4
-4. "What to avoid" examples are distinct from "Correct usage" examples
-5. If converting (Step 5): confirm source document was handled (deleted or updated with link)
-6. Confirm agent configuration file references are correct
-7. Confirm each of the six Adoption-Bias Audit checks (Step 8) has a cited satisfying section in the final draft, or that the failing check produced an applied revision
-8. Confirm actionable edits from Step 9 were applied, or that any skipped edits were surfaced to the user
-9. If any issues are found, fix them
+3. YAML frontmatter is present at the top of the file with a `paths:` list, every glob is double-quoted, and the frontmatter closes with `---` before the `# {Title}` heading. When updating an existing standard, confirm no pre-existing frontmatter keys were stripped.
+4. The symlink at `.claude/rules/coding-standards/{filename}` exists and resolves to the canonical file. Verify with `readlink` and `test -e`.
+5. `CLAUDE.md` (or `AGENTS.md`) was **not** given a new enumerated entry for this standard. If a pointer paragraph was added because none existed, confirm it appears exactly once.
+6. Code examples reference real files that exist (verify with Glob) — cross-check against the Correct-usage candidates returned in Step 4
+7. "What to avoid" examples are distinct from "Correct usage" examples
+8. If converting (Step 5): confirm source document was handled (deleted or updated with link)
+9. Confirm agent configuration file references are correct
+10. Confirm each of the six Adoption-Bias Audit checks (Step 8) has a cited satisfying section in the final draft, or that the failing check produced an applied revision
+11. Confirm actionable edits from Step 9 were applied, or that any skipped edits were surfaced to the user
+12. If any issues are found, fix them

--- a/plugin/skills/coding-standard/SKILL.md
+++ b/plugin/skills/coding-standard/SKILL.md
@@ -21,7 +21,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(git config *), Bash(wh
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - AGENTS.md: !`find . -maxdepth 1 -name "AGENTS.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- Rules directory: !`find .claude/rules/coding-standards -maxdepth 1 -type d 2>/dev/null || echo "absent"`
+- Rules directory: !`find . -maxdepth 4 -type d -path "*/.claude/rules/coding-standards"`
 
 ## Step 1: Determine Mode
 

--- a/plugin/skills/coding-standard/references/template.md
+++ b/plugin/skills/coding-standard/references/template.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "{glob-1}"
+  - "{glob-2}"
+---
+
 # {Title}
 
 - **Status:** {proposed | accepted | deprecated}


### PR DESCRIPTION
## Summary

**This PR exposes the plugin's contributor guidance as path-scoped Claude Code rules, so that authoring rules load automatically into context only when an agent edits the plugin file they govern — instead of relying on humans to remember them.**

- 30 contributor guidance docs (24 skill-building, 5 agent-building, plus the entity taxonomy) each gained a `paths:` YAML frontmatter block and a matching symlink under `.claude/rules/`. Claude Code's path-scoped rules feature loads a rule into context only when a file matching one of its globs is read (`load_reason: path_glob_match`), so editing `plugin/skills/foo/SKILL.md` now auto-loads all skill-building guidance, and editing `plugin/agents/bar.md` auto-loads agent-building guidance. No change at session startup; nothing loads until a matching file is touched.
- The `/coding-standard` skill was rewritten so the standards it produces use the same mechanism: every new standard now carries `paths:` frontmatter and is symlinked into `.claude/rules/coding-standards/`, replacing the old approach of adding an enumerated link to `CLAUDE.md`. The skill grew from 9 to 10 steps and gained an Adoption-Bias Audit step.
- This is documentation and skill-definition only. No runtime/product code, no migrations. The behavioral surface that changes is *how Claude Code itself loads guidance and how the `/coding-standard` skill writes its output* — there is nothing for a human to invoke differently.
- Pay closest attention to the `paths:` glob scoping (broad `plugin/skills/**/*.md` vs. narrower second globs) and to the backward-compatibility promise that the rewritten skill leaves pre-existing enumerated `CLAUDE.md` entries untouched.

### Behavior changes

Two distinct behavioral changes, both about *loading and authoring guidance*, not product runtime:

| Surface | Before | After |
|---|---|---|
| Contributor guidance docs (the 30 files in `docs/guidance/`) | Plain markdown. Loaded into an agent's context only if a human pointed at them or the agent went looking. | Each carries a `paths:` glob and a symlink under `.claude/rules/`. Claude Code auto-loads the doc into context when any file matching the glob is read. Skill-building docs scope to `"plugin/skills/**/*.md"`; agent-building docs and the entity taxonomy scope to `"plugin/agents/**/*.md"`. Two skill docs (`graceful-degradation.md`, `script-execution-instructions.md`) add a second glob `"plugin/skills/**/scripts/**"` so they also load when scripts are touched. |
| `/coding-standard` skill output | Wrote the standard to `docs/coding-standards/`, then added an enumerated link to `CLAUDE.md`/`AGENTS.md`. That link loaded on every session whether relevant or not. | Writes `paths:` frontmatter into the standard, then creates a relative symlink at `.claude/rules/coding-standards/{filename}` pointing back to the canonical doc. Adds a one-time pointer paragraph to the memory file only if it does not already reference `.claude/rules/coding-standards/`. Never adds a new enumerated entry; pre-existing enumerated entries from earlier skill versions are deliberately left alone (migrating them out is explicitly out of scope). |

The canonical doc still lives in `docs/`; the `.claude/rules/` entry is a relative symlink to it, so there is one file with two access paths and no duplication/drift.

## What to look at first

- **Glob scoping breadth.** Skill-building docs all use the same broad `"plugin/skills/**/*.md"` glob, which means editing any single SKILL.md pulls all ~24 skill-building docs into context at once. Worth deciding whether that is the intended tradeoff (complete guidance vs. context size) or whether narrower scoping was considered and rejected.
- **The two docs with a second `scripts/**` glob.** `graceful-degradation.md` and `script-execution-instructions.md` add `"plugin/skills/**/scripts/**"`. Confirm that pairing is deliberate and that other script-relevant docs (e.g., `hardening-fuzzy-vs-deterministic.md`) were intentionally not given it.
- **Backward-compatibility promise in the rewritten skill.** Step 7 and Step 10 of `coding-standard/SKILL.md` claim the skill will not touch pre-existing enumerated `CLAUDE.md` entries and only adds a pointer paragraph if one is absent. This is the main behavioral risk surface — verify the conditional logic actually distinguishes "pointer paragraph exists" from "enumerated entry exists."
- **Symlink relative-path depth.** Targets use a fixed `../` depth (`../../../docs/...` for skills/agents, `../../docs/...` for the top-level taxonomy). The skill instructs adjusting depth when the docs directory is nested differently — check whether that instruction is clear enough to apply correctly in a project whose docs tree differs from this repo's.

## Files of interest

- `plugin/skills/coding-standard/SKILL.md` — the substantive rewrite: new `allowed-tools` (`ln`, `test`, `readlink`), glob discovery in Step 3, `paths:` frontmatter authoring in Step 6, symlink-based integration in Step 7, new Adoption-Bias Audit in Step 8.
- `docs/skills/coding-standard.md` — operator-facing explanation, including the new "Why the canonical doc lives in `docs/` and a symlink lives in `.claude/rules/`" section that justifies symlink-over-enumerated-link.
- `plugin/...coding-standard/references/template.md` — gained the `paths:` frontmatter block standards are now generated with.
- `docs/...building-guidance/graceful-degradation.md` — representative of the 30 frontmatter additions, and one of the two docs carrying the extra `scripts/**` glob.
- `.claude/rules/skills/context-hygiene.md` — representative symlink; confirms the relative-target convention back into `docs/guidance/`.
