### PR TITLE
Add /stakeholder-summary skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Han is a Claude Code plugin: a suite of skills and agents for solo (or small-tea
 │   ├── sizing.md
 │   ├── yagni.md
 │   ├── agents/         # Long-form docs for all 22 agents, plus README
-│   ├── skills/         # Long-form docs for all 19 skills, plus README
+│   ├── skills/         # Long-form docs for all 20 skills, plus README
 │   ├── guidance/       # Contributor-facing authoring guidance
 │   └── templates/      # Templates and coverage rule for long-form docs
 └── images/             # Banner and graphics for README
@@ -54,10 +54,11 @@ The plugin is shipped from `plugin/`; documentation lives in `docs/`. Long-form 
 
 ### Skill catalog (`docs/skills/`)
 
-- **[docs/skills/README.md](./docs/skills/README.md).** Index of all 19 skills grouped by purpose (planning, building, investigation and research, review, discovery, conventions, reporting). Start here when looking for the right slash command.
+- **[docs/skills/README.md](./docs/skills/README.md).** Index of all 20 skills grouped by purpose (planning, building, investigation and research, review, discovery, conventions, reporting). Start here when looking for the right slash command.
 - **[docs/skills/plan-a-feature.md](./docs/skills/plan-a-feature.md).** Spec a feature from scratch through an evidence-based interview that walks the design tree and dispatches specialist reviewers.
 - **[docs/skills/plan-implementation.md](./docs/skills/plan-implementation.md).** Turn a feature specification into an implementation plan through a project-manager-led team conversation.
 - **[docs/skills/plan-a-phased-build.md](./docs/skills/plan-a-phased-build.md).** Split a body of context (gap analysis, PRD, design doc) into a numbered sequence of vertical-slice phases, each independently demoable.
+- **[docs/skills/stakeholder-summary.md](./docs/skills/stakeholder-summary.md).** Turn a feature specification into a plain-language stakeholder summary with Mermaid diagrams, for non-technical feedback before implementation kicks off.
 - **[docs/skills/iterative-plan-review.md](./docs/skills/iterative-plan-review.md).** Stress-test an existing plan through multiple codebase-grounded review passes. Edits the plan in place and records every finding.
 - **[docs/skills/plan-work-items.md](./docs/skills/plan-work-items.md).** Break a trusted implementation plan into independently-grabbable, atomic work items in a single work-items file.
 - **[docs/skills/tdd.md](./docs/skills/tdd.md).** Drive a feature or behavior through a BDD-framed red-green-refactor loop with an enforced observed-failure gate. The plugin's only execution skill: it writes code, applying coding standards and ADRs in green and refactor.
@@ -125,4 +126,4 @@ Subdirectories:
 - **Every long-form doc links up.** The first bullet of the "Related Documentation" section always points back to the README at the repo root.
 - **Voice is uniform.** Every doc follows [docs/writing-voice.md](./docs/writing-voice.md). No em-dashes, direct second person, no flattery or hype.
 - **YAGNI applies to docs too.** Don't add speculative sections, for-future-flexibility warnings, or examples for behavior the skill doesn't have. The same evidence rule that gates plan steps gates docs.
-- **Counts to verify when editing indexes.** 22 agents in `plugin/agents/`; 19 skills in `plugin/skills/`; 22 long-form agent docs in `docs/agents/`; 19 long-form skill docs in `docs/skills/`.
+- **Counts to verify when editing indexes.** 22 agents in `plugin/agents/`; 20 skills in `plugin/skills/`; 22 long-form agent docs in `docs/agents/`; 19 long-form skill docs in `docs/skills/`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read [Concepts](./docs/concepts.md) for the skill-and-agent model that runs thro
 ## Which path are you on?
 
 - **New to han?** → Start with [Concepts](./docs/concepts.md), then the [Quickstart](./docs/quickstart.md).
-- **Looking for a specific skill?** → [Skills Index](./docs/skills/README.md). 19 skills grouped by purpose.
+- **Looking for a specific skill?** → [Skills Index](./docs/skills/README.md). 20 skills grouped by purpose.
 - **Looking for a specific agent?** → [Agents Index](./docs/agents/README.md). 22 agents grouped by role.
 - **Wondering how the agent swarms scale?** → [Sizing](./docs/sizing.md). The small / medium / large dispatch model used by `/architectural-analysis`, `/code-review`, `/gap-analysis`, `/iterative-plan-review`, `/plan-a-feature`, `/plan-implementation`, and `/research`.
 - **Wondering why a skill said "YAGNI"?** → [YAGNI](./docs/yagni.md). The evidence-based rule every planning, review, and architecture skill applies before committing items to an artifact.
@@ -34,7 +34,7 @@ Add the Test Double skills marketplace to Claude Code, then install the plugin:
 
 - [Concepts](./docs/concepts.md). Skill vs. agent, and how they compose. Read once before using the plugin.
 - [Quickstart](./docs/quickstart.md). Four paths for four common situations. Each path is a short sequence of skills.
-- [Skills Index](./docs/skills/README.md). All 19 skills, grouped by purpose.
+- [Skills Index](./docs/skills/README.md). All 20 skills, grouped by purpose.
 - [Agents Index](./docs/agents/README.md). All 22 agents, grouped by role.
 - [Sizing](./docs/sizing.md). The small / medium / large model that decides how many agents the swarming skills dispatch.
 - [YAGNI](./docs/yagni.md). The evidence-based "You Aren't Gonna Need It" rule every planning, review, and architecture skill applies.

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -17,6 +17,7 @@ Skills for specifying *what* a feature does, planning *how* to build it, and str
 - **[`/plan-a-phased-build`](./plan-a-phased-build.md).** Split a body of context (gap analysis, PRD, design doc, feature spec, requirements list) into a numbered sequence of vertical-slice build phases, each independently demoable to a real person and each building on the prior. Dispatches `information-architect` against the rendered outline to verify findability, EPPO standalone-ness of phase entries, and progressive comprehension.
 - **[`/iterative-plan-review`](./iterative-plan-review.md).** Stress-test an already-written plan through multiple codebase-grounded review passes.
 - **[`/plan-work-items`](./plan-work-items.md).** Divide a trusted implementation plan into independently-grabbable work items in a single work-items file.
+- **[`/stakeholder-summary`](./stakeholder-summary.md).** Turn a feature specification into a plain-language stakeholder summary with Mermaid diagrams for user experience and data flow — for getting non-technical feedback before implementation kicks off.
 
 
 ## Building

--- a/docs/skills/stakeholder-summary.md
+++ b/docs/skills/stakeholder-summary.md
@@ -1,0 +1,75 @@
+# /stakeholder-summary
+
+Operator documentation for the `/stakeholder-summary` skill in the han plugin. This document helps you decide *when* and *how* to use the skill. For what the skill does internally, read the skill definition at [`plugin/skills/stakeholder-summary/SKILL.md`](../../plugin/skills/stakeholder-summary/SKILL.md).
+
+> See also: [Plugin landing page](../../README.md) · [All skills](./README.md) · [All agents](../agents/README.md) · [YAGNI](../yagni.md)
+
+## TL;DR
+
+- **What it does.** Turns a feature specification into a plain-language stakeholder summary you can share before implementation kicks off.
+- **When to use it.** You have a feature spec written and want stakeholder feedback on shape, scope, and trade-offs before the team starts building.
+- **What you get back.** A `stakeholder-summary.md` file next to the source spec, with Mermaid diagrams for user experience and data flow.
+
+## Key concepts
+
+- **Stakeholder-shaped, not engineer-shaped.** The document is for non-technical readers. No file paths, no API shapes, no database tables — just the customer problem, the experience, the before-and-after, and the open questions.
+- **Diagrams replace prose.** A user-experience flowchart and before-and-after data-flow diagrams carry most of the weight. The text frames them, but the diagrams do the explaining.
+- **Feedback before kickoff.** The closing questions ask stakeholders to confirm framing and scope, not to make technical decisions.
+
+## When to use it
+
+**Invoke when:**
+
+- A feature specification exists and you want to share it with non-technical stakeholders for feedback.
+- Leadership, product, or customer-facing stakeholders need to greenlight a feature before implementation starts.
+- You want a one-page artifact that sits next to the full spec for stakeholder use.
+
+**Do not invoke for:**
+
+- **Writing the spec itself.** Use [`/plan-a-feature`](./plan-a-feature.md) instead.
+- **Sequencing the build.** Use [`/plan-a-phased-build`](./plan-a-phased-build.md) instead.
+- **Producing an implementation plan.** Use [`/plan-implementation`](./plan-implementation.md) instead.
+
+## How to invoke it
+
+Run `/stakeholder-summary` in Claude Code.
+
+Give it:
+
+1. **The source specification.** Usually `feature-specification.md`, but any feature spec, PRD, or design document works. The summary lands in the same directory.
+2. **Optional shaping context.** Audience ("this is going to leadership"), emphasis ("lean into the customer-trust angle"), or anything else that should shape tone.
+
+Example prompts:
+
+- `/stakeholder-summary docs/features/share/feature-specification.md`
+- `/stakeholder-summary docs/features/share/feature-specification.md — emphasize the customer-trust angle for leadership`
+
+## What you get back
+
+One file: `stakeholder-summary.md`, written in the same directory as the source spec. It has six sections in fixed order:
+
+1. **What problem are we solving?** — customer-voice framing plus the capabilities introduced.
+2. **What does this open up?** — outcomes the feature unblocks.
+3. **What will the user experience look like?** — paragraph plus a Mermaid `flowchart TD`.
+4. **How does the data flow today vs. after this change?** — Mermaid `flowchart LR` diagrams for today and each after-this-change path.
+5. **What is intentionally not in this slice?** — explicit deferrals from the source spec.
+6. **What we are asking stakeholders.** — open questions in stakeholder language.
+
+## How to get the most out of it
+
+- **Write the spec first.** The summary derives from the spec — the cleaner the spec, the better the summary. Pair with [`/plan-a-feature`](./plan-a-feature.md) before this.
+- **Name your audience.** Leadership, customers, and product reviewers read for different things. Tell the skill who will receive it.
+- **Confirm the "intentionally not in this slice" list.** That section is where stakeholder pushback usually happens — make sure it matches what the spec actually defers.
+- **Pair with `/plan-a-phased-build` next.** Once stakeholders greenlight the shape, sequence the build.
+- **Cross-repo planning folders are supported.** If the source spec lives outside the current working directory (for example, a planning folder for a different project), the skill reads that project's `CLAUDE.md` to pick up its vocabulary and naming conventions — not the cwd's.
+
+## Cost and latency
+
+Single-pass authoring with no sub-agent dispatch. Reads the source spec, drafts the summary, writes it once, and self-checks. Built for tight-loop iteration — re-run it after the spec changes.
+
+## Related documentation
+
+- [Plugin landing page](../../README.md). The front door. Start here if you arrived from outside the docs tree.
+- [`/plan-a-feature`](./plan-a-feature.md). Produces the feature specification this skill consumes.
+- [`/plan-a-phased-build`](./plan-a-phased-build.md). The natural next step once the summary lands stakeholder feedback.
+- [`/plan-implementation`](./plan-implementation.md). Turns the spec into an implementation plan after stakeholders sign off.

--- a/plugin/skills/stakeholder-summary/SKILL.md
+++ b/plugin/skills/stakeholder-summary/SKILL.md
@@ -81,14 +81,31 @@ Use the template at [`references/stakeholder-summary-template.md`](references/st
 
 ## Step 5: Self-Check Before Presenting
 
-Before reporting the summary as done, verify:
+Run two passes before reporting the summary as done. Each pass has a single focus, and **each pass begins with a fresh Read of the output file from disk** — do not check against working memory or the draft you held while writing. The Read tool call is required, not optional. Working memory drifts from what actually landed on disk; only the file contents matter.
 
-- No file paths, function names, class names, database tables, API endpoints, or library names appear in the document.
-- Every Mermaid diagram renders mentally — node labels are short, edges are labeled where the relationship is not obvious, and the diagram tells a story without needing the surrounding prose.
-- The "intentionally not in this slice" list matches what the source spec actually defers — nothing fabricated.
-- The closing questions are answerable by a stakeholder without engineering context.
+### Pass A: Plain-language audit
 
-If any check fails, fix it before presenting.
+**First, use the Read tool to load the output file from disk.** Then read the document as a non-technical stakeholder. For each sentence, ask: would a reader without engineering context understand this without translation? Fix anything that fails. Specifically verify:
+
+- **No engineering artifacts.** No file paths, function names, class names, database tables or columns, API endpoints, HTTP verbs, library or framework names, environment variables, queue or topic names, or language primitives.
+- **No engineering hedges.** No "eventually consistent", "idempotent", "race condition", "backfill", "migration", "schema", "payload", "request/response", "stateless", "async", "webhook", "polling vs. push", or similar. If a concept like this is load-bearing, restate it as a user-visible behavior or omit it.
+- **No leftover scaffolding.** Template placeholders, TODOs, "TBD", or example text from the template that was not replaced with real content.
+- **Closing questions are stakeholder-answerable.** A non-technical reader can give a real answer without asking an engineer what the question means.
+
+If Pass A required any edits, apply them with Edit, then **Read the file again from disk** before starting Pass B. The Pass B read-through must run against the post-fix contents, not your memory of what you intended to fix.
+
+### Pass B: Reading-order and progressive-disclosure check
+
+**First, use the Read tool to load the output file from disk again** — even if Pass A required no edits. This re-load is what makes Pass B an actual second pass rather than a continuation of Pass A's attention. Then read the document straight through, top to bottom, as someone arriving cold. Verify the document builds on itself rather than assuming context from a later section:
+
+- **The opening establishes the customer problem before naming any capability.** A reader should know *who is hurting and why* before they see *what we are building*.
+- **Each section uses only vocabulary the reader has already encountered.** A noun that appears in the data-flow diagram should have been introduced in the problem or capabilities sections — not first defined inside the diagram. Acronyms and product-internal names appear only if a stakeholder would already know them; otherwise generalize one level up ("the telematics provider", "the customer list").
+- **Diagrams are readable on their own.** Node labels and edge labels tell the story without requiring the surrounding prose. A reader who only skims the diagrams should still get the shape of the change.
+- **The "today vs. after this change" pairing is obvious.** The before-and-after diagrams sit close enough together that the contrast is visible without scrolling back and forth.
+- **The "intentionally not in this slice" list comes after the reader understands what *is* in the slice.** Out-of-scope only makes sense once in-scope is concrete.
+- **The closing questions follow from the body.** Each question should connect to a specific section above it — not introduce a new topic the document never mentioned.
+
+If any check in either pass fails, fix it with Edit and Read the file again before re-running the affected pass. Do not present a summary that fails Pass A — a stakeholder who has to ask "what does X mean?" has already lost trust in the document.
 
 ## Step 6: Present the Summary
 

--- a/plugin/skills/stakeholder-summary/SKILL.md
+++ b/plugin/skills/stakeholder-summary/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: "stakeholder-summary"
+description: >
+  Produces a plain-language stakeholder summary from an existing feature
+  specification, for sharing with non-technical stakeholders before
+  implementation kicks off. Use when the user wants to draft a stakeholder
+  summary, executive summary, or business summary of a feature spec or PRD.
+  Does not write the spec itself — use plan-a-feature. Does not sequence the
+  build into phases — use plan-a-phased-build. Does not produce an
+  implementation plan — use plan-implementation.
+argument-hint: "[path to feature-specification.md, optional: extra context for the summary]"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *)
+---
+
+## Project Context
+
+- CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
+- project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+
+## Operating Principles
+
+- **Plain language only.** The stakeholder summary never contains file paths, line numbers, function or class names, library mechanics, database tables, API shapes, or language primitives. Use product-level subsystem names ("the telematics provider", "the customer list"), user-facing UI vocabulary (badge, popup, list), and behavioral verbs (create, edit, update, claim, merge, sync). A non-technical stakeholder must be able to read the document end-to-end without translation.
+- **Center the customer, not the system.** Lead with the problem the customer experiences, then the capabilities introduced, then the experience, then the data flow, then what is out of scope, then the questions. The system is the means, not the subject.
+- **High level only.** A stakeholder summary is for getting feedback before kickoff. Skip anything that would only matter once implementation has started: schemas, sequencing, file boundaries, test plans, rollout strategy, telemetry. If a detail is only meaningful to engineers, it does not belong in this document.
+- **Diagrams carry weight.** Use Mermaid for both the user experience flow and the data flow before-and-after. Diagrams are not decoration — they replace paragraphs of prose, so they must be readable on their own.
+- **Open questions are stakeholder-shaped.** The closing questions are framed in customer or product language, not engineering language. They ask stakeholders to confirm framing, scope, and trade-offs — not to make technical decisions.
+
+# Stakeholder Summary
+
+## Step 1: Resolve the Source and Output Paths
+
+Read the user's argument and conversation context. Identify:
+
+1. **The source specification** — the file the summary will be derived from. Usually a `feature-specification.md`, but may be a PRD, design doc, or similar. If the user did not name a file, ask in one short message which file to summarize.
+2. **The output path** — `stakeholder-summary.md` in the **same directory** as the source file. Do not place it anywhere else unless the user explicitly says so.
+3. **Shaping context** — anything the user added about the audience, tone, or emphasis ("this is going to leadership", "lean into the customer-trust angle"). Capture it for use in Steps 3 and 4.
+
+If `stakeholder-summary.md` already exists in the target directory, ask the user whether to overwrite, append a timestamp suffix, or stop. Do not silently overwrite.
+
+## Step 2: Read the Source and Project Context
+
+Read the feature specification end-to-end. Then capture:
+
+- The customer problem the feature addresses, in the customer's own words where possible.
+- The capabilities the feature introduces, expressed as user-visible actions (not API endpoints, not database changes). This is true even if the outcome is an API and not user visible yet. We want to provide what the spec will do for our end users.
+- The user experience: what the customer sees, what choices they make, what happens after each choice.
+- The current data flow (what happens today) and the new data flow (what will happen after this ships), at the level of "system A sends X to system B".
+- What the spec explicitly says is out of scope, deferred, or handled elsewhere.
+- Any open questions the spec already names.
+
+Read the CLAUDE.md in the project named in the specification and `project-discovery.md` if present — they may surface vocabulary or naming conventions the stakeholder summary should follow.
+
+## Step 3: Translate Technical Content into Plain Language
+
+For every piece of content destined for the summary, apply a translation pass:
+
+- **System names generalize one level up.** "PostgreSQL" → "the database"; "the FleetCommand API" → "the telematics provider"; "the React component" → "the screen".
+- **API and data shapes become user-visible behaviors.** "POST /units/claim" → "Claim it"; "PATCH /customers/1/update endpoint with [field_name]" → "update the existing customer record".
+- **Engineering trade-offs become product trade-offs.** "Eventually consistent reads from the replica" → not mentioned; "we are not building bulk actions" → "Bulk actions. One record at a time for now."
+- **Acronyms and brand names** stay only if a stakeholder would already know them (e.g., the product's own brand, well-known integrations). Otherwise generalize.
+
+If a piece of content cannot be translated without losing meaning, leave it out. The summary is for feedback on shape and direction, not technical correctness.
+
+## Step 4: Draft the Stakeholder Summary
+
+Use the template at [`references/stakeholder-summary-template.md`](references/stakeholder-summary-template.md). Write the file at the resolved output path, filling in each section in order:
+
+1. **Title** — `# {{Feature Name}} — Stakeholder Summary`. Derive the feature name from the source spec's title or H1.
+2. **What problem are we solving?** One or two short paragraphs from the customer's point of view, followed by a short bulleted list of the capabilities the feature introduces (each as a bold name plus one sentence in the customer's voice).
+3. **What does this open up?** Four to six bullets naming the outcomes the feature enables — customer confidence, data trust, downstream features unblocked, etc. Each bullet leads with a bold phrase and adds one sentence of why it matters.
+4. **What will the user experience look like?** One short paragraph framing the experience, followed by a Mermaid `flowchart TD` showing the user-facing decision and its branches. Keep nodes short and customer-readable. It is acceptable to omit if the change truly has no user interface impact, but this will be rare.
+5. **How does the data flow today vs. after this change?** Mermaid `flowchart LR` diagrams:
+  - today (showing the pain point with `style` highlighting on the problem nodes)
+  - after-this-change for each meaningful path (highlighting the resulting good state in green).
+  - Match the diagram count to the actual number of paths in the spec — do not invent paths just to mirror the template.
+  - For all Mermaid charts, do not literally match the template unless the spec aligns. Use a chart that makes sense for the user experience and data flows being described by the feature specification itself. The template contains examples only.
+6. **What is intentionally not in this slice?** Bulleted list of items deliberately excluded. Each item leads with a bold phrase and a one-sentence reason or pointer to where it lives instead.
+7. **What we are asking stakeholders.** Three to five open questions, phrased so a non-technical reader can answer them. Frame them as framing/scope/trade-off questions, not technical decisions.
+
+**Write the file in one pass once the content is ready** — the document is short enough that incremental saves are unnecessary. After writing, read it back end-to-end and rewrite any sentence that still leaks implementation detail.
+
+## Step 5: Self-Check Before Presenting
+
+Before reporting the summary as done, verify:
+
+- No file paths, function names, class names, database tables, API endpoints, or library names appear in the document.
+- Every Mermaid diagram renders mentally — node labels are short, edges are labeled where the relationship is not obvious, and the diagram tells a story without needing the surrounding prose.
+- The "intentionally not in this slice" list matches what the source spec actually defers — nothing fabricated.
+- The closing questions are answerable by a stakeholder without engineering context.
+
+If any check fails, fix it before presenting.
+
+## Step 6: Present the Summary
+
+Summarize for the user in one short message:
+
+- The output file path.
+- The number of capabilities introduced, the number of "what this opens up" outcomes, and the number of open questions.
+- The next concrete action — typically "review the summary, especially the open questions section, and share it with stakeholders, or tell me what to tighten before you do".
+
+Ask whether the user wants to refine wording, add or remove a question, or consider the summary ready to share.

--- a/plugin/skills/stakeholder-summary/SKILL.md
+++ b/plugin/skills/stakeholder-summary/SKILL.md
@@ -69,21 +69,47 @@ Use the template at [`references/stakeholder-summary-template.md`](references/st
 2. **What problem are we solving?** One or two short paragraphs from the customer's point of view, followed by a short bulleted list of the capabilities the feature introduces (each as a bold name plus one sentence in the customer's voice).
 3. **What does this open up?** Four to six bullets naming the outcomes the feature enables — customer confidence, data trust, downstream features unblocked, etc. Each bullet leads with a bold phrase and adds one sentence of why it matters.
 4. **What will the user experience look like?** One short paragraph framing the experience, followed by a Mermaid `flowchart TD` showing the user-facing decision and its branches. Keep nodes short and customer-readable. It is acceptable to omit if the change truly has no user interface impact, but this will be rare.
-5. **How does the data flow today vs. after this change?** Mermaid `flowchart LR` diagrams:
-  - today (showing the pain point with `style` highlighting on the problem nodes)
-  - after-this-change for each meaningful path (highlighting the resulting good state in green).
-  - Match the diagram count to the actual number of paths in the spec — do not invent paths just to mirror the template.
+5. **How does the data flow today vs. after this change?** Mermaid `flowchart LR` diagrams. **The number of diagrams in each subsection — both "today" and "after this change" — matches the number of meaningfully distinct paths the spec actually describes. Never invent paths to hit a template count. Never collapse genuinely distinct paths into one diagram to fit a template count. One today diagram and three "after this change" diagrams is correct if that is what the spec needs; two today diagrams and one "after this change" diagram is also correct if that is what the spec needs.** Both subsections follow the same shape:
+
+  - **Today.** One diagram per meaningfully distinct *current* path, each showing the pain point with `style` highlighting on the problem nodes. If there is only one current path worth showing (the common case), produce a single "Today" diagram with a one-sentence lead-in above it and no prose block below — the lead-in is enough. If there are two or more current paths, each diagram gets a one-sentence lead-in *and* a 3 to 5 sentence prose block immediately below that walks the reader through the flow, names the pain point, and names what makes this current path distinct from the other current paths.
+  - **After this change.** One diagram per meaningfully distinct *new* path, highlighting the resulting good state in green. Every "after this change" diagram is followed by a 3 to 5 sentence prose description placed immediately below the diagram, walking the reader through the flow the diagram shows. When there are two or more "after this change" paths, each prose block must additionally name the trigger or condition that sends the customer down this path rather than the others, and the outcome that differs between paths — a stakeholder reading the prose blocks back-to-back should be able to articulate when each path applies. When there is only one "after this change" path, the prose still walks the flow but does not manufacture a contrast against paths that do not exist.
   - For all Mermaid charts, do not literally match the template unless the spec aligns. Use a chart that makes sense for the user experience and data flows being described by the feature specification itself. The template contains examples only.
-6. **What is intentionally not in this slice?** Bulleted list of items deliberately excluded. Each item leads with a bold phrase and a one-sentence reason or pointer to where it lives instead.
-7. **What we are asking stakeholders.** Three to five open questions, phrased so a non-technical reader can answer them. Frame them as framing/scope/trade-off questions, not technical decisions.
+6. **What is intentionally not in this slice?** Bulleted list of items deliberately excluded. Each item leads with a bold phrase and a one-sentence reason or pointer to where it lives instead. Close the section with a single one-line catch-all confirmation prompt directed at stakeholders — something like *"If any of these cuts would block your team, flag it before we kick off."* That one line replaces the per-item "is this OK?" question that would otherwise duplicate into the next section.
+7. **What we are asking stakeholders.** Three to five open questions that present a real trade-off, framing call, or sequencing choice the stakeholder must weigh in on. **A question only earns a spot here if it asks the stakeholder to choose between two or more substantive alternatives, or to confirm framing the document presents as genuinely open.** A bare "is it acceptable that X is deferred?" — where X is already listed in "What is intentionally not in this slice?" — is the duplication this rule exists to prevent. Push those back into the prior section's closing prompt. Questions in this section must either:
+  - present a trade-off with two or more named alternatives (for example, *"Remove the broken button vs. show a placeholder message — which fits the brand better?"*), or
+  - confirm framing or scope that is not already settled by the body of the document (for example, *"Are we right to treat this as a v1 for desktop users only, or should mobile parity be part of v1?"*), or
+  - surface an open question the source spec itself names as unresolved.
+  Frame every question so a non-technical reader can answer it, and connect each one to a section above it so the reader can see what it follows from.
 
 **Write the file in one pass once the content is ready** — the document is short enough that incremental saves are unnecessary. After writing, read it back end-to-end and rewrite any sentence that still leaks implementation detail.
 
 ## Step 5: Self-Check Before Presenting
 
-Run two passes before reporting the summary as done. Each pass has a single focus, and **each pass begins with a fresh Read of the output file from disk** — do not check against working memory or the draft you held while writing. The Read tool call is required, not optional. Working memory drifts from what actually landed on disk; only the file contents matter.
+Run three passes before reporting the summary as done. Each pass has a single focus, and **each pass begins with a fresh Read of the output file from disk** — do not check against working memory or the draft you held while writing. The Read tool call is required, not optional. Working memory drifts from what actually landed on disk; only the file contents matter.
 
-### Pass A: Plain-language audit
+### Pass A: Internal-consistency / contradiction check
+
+**First, use the Read tool to load the output file from disk.** Then list every load-bearing claim the document makes — capability included, capability deferred, behavior described in a diagram, prose narrative below a diagram, item under "What is intentionally not in this slice", trade-off or framing call in "What we are asking stakeholders". For every pair of claims, ask: does claim X assert something that claim Y denies or implies the opposite of? Pay special attention to:
+
+- **Diagram vs. exclusion.** A capability shown in any data-flow diagram (or its prose block below) that "What is intentionally not in this slice" says is deferred, and vice versa. This is the most common form of contradiction: a diagram walks the customer through a step that uses a capability the exclusion section says is not in the slice. The fix is almost always to disambiguate the wording on one side — clarifying that the diagram is showing a narrower capability than the exclusion appears to forbid, or vice versa.
+- **UX vs. data flow.** A behavior in the user-experience flowchart that contradicts a behavior in any data-flow diagram, or vice versa.
+- **Outcomes vs. exclusion.** A capability named in "What does this open up?" that "What is intentionally not in this slice" says is deferred.
+- **Diagram vs. diagram.** An assumption in the prose under one diagram that conflicts with an assumption in the prose under another diagram.
+- **Vocabulary collisions.** The same term used to mean two different things in different sections (for example, "share" used both for *sending a URL another user can open* and for *publishing a view to your whole organization*), or different terms used for the same thing in different sections.
+
+For every contradiction found, take an evidence-based approach to resolving it:
+
+1. **Re-read the source specification** identified in Step 1. The spec is the authoritative source for what the feature does and does not do. Most contradictions in the summary are translation errors — the spec is internally consistent and the summary mistranslated one side.
+2. **If the spec resolves the contradiction:** edit the summary so both sides match the spec. If the apparent contradiction is actually a terminology collision (the same word covering two distinct concepts), disambiguate the wording — typically by renaming one usage to a more specific term that the source spec, its CLAUDE.md, or its project-discovery vocabulary already supports. Record in working memory which contradiction was resolved and how, so the same disambiguation can be applied uniformly across every section.
+3. **If the spec does not resolve the contradiction** — because the spec is silent on the point, the spec itself is internally inconsistent, or the resolution depends on a judgment call only the user can make — **stop and ask the user.** Do not guess. Use `AskUserQuestion` to surface a structured ask containing:
+  - **A plain-language description of the contradiction**, naming both sides explicitly ("Section X says A; Section Y says B; these conflict because…"). Quote the actual phrasing from each section.
+  - **Two to four resolution options.** Typical patterns: keep A and rewrite B; keep B and rewrite A; reconcile by disambiguating terminology and using the disambiguated terms in both sections; move the contradicting capability into "What is intentionally not in this slice" and remove it from elsewhere.
+  - **Your recommended option, marked clearly,** with a one-sentence reason grounded in the source spec, the project's conventions, or the stakeholder framing the user provided in Step 1. The recommendation must be a concrete option from the list above, not a fresh suggestion.
+  - **A direct request that the user pick which resolution to apply.**
+
+After applying any contradiction-driven edits, Read the file from disk again before continuing. Pass B and Pass C must run against the post-fix contents.
+
+### Pass B: Plain-language audit
 
 **First, use the Read tool to load the output file from disk.** Then read the document as a non-technical stakeholder. For each sentence, ask: would a reader without engineering context understand this without translation? Fix anything that fails. Specifically verify:
 
@@ -92,20 +118,24 @@ Run two passes before reporting the summary as done. Each pass has a single focu
 - **No leftover scaffolding.** Template placeholders, TODOs, "TBD", or example text from the template that was not replaced with real content.
 - **Closing questions are stakeholder-answerable.** A non-technical reader can give a real answer without asking an engineer what the question means.
 
-If Pass A required any edits, apply them with Edit, then **Read the file again from disk** before starting Pass B. The Pass B read-through must run against the post-fix contents, not your memory of what you intended to fix.
+If Pass B required any edits, apply them with Edit, then **Read the file again from disk** before starting Pass C. The Pass C read-through must run against the post-fix contents, not your memory of what you intended to fix.
 
-### Pass B: Reading-order and progressive-disclosure check
+### Pass C: Reading-order and progressive-disclosure check
 
-**First, use the Read tool to load the output file from disk again** — even if Pass A required no edits. This re-load is what makes Pass B an actual second pass rather than a continuation of Pass A's attention. Then read the document straight through, top to bottom, as someone arriving cold. Verify the document builds on itself rather than assuming context from a later section:
+**First, use the Read tool to load the output file from disk again** — even if Pass B required no edits. This re-load is what makes Pass C an actual third pass rather than a continuation of Pass B's attention. Then read the document straight through, top to bottom, as someone arriving cold. Verify the document builds on itself rather than assuming context from a later section:
 
 - **The opening establishes the customer problem before naming any capability.** A reader should know *who is hurting and why* before they see *what we are building*.
 - **Each section uses only vocabulary the reader has already encountered.** A noun that appears in the data-flow diagram should have been introduced in the problem or capabilities sections — not first defined inside the diagram. Acronyms and product-internal names appear only if a stakeholder would already know them; otherwise generalize one level up ("the telematics provider", "the customer list").
 - **Diagrams are readable on their own.** Node labels and edge labels tell the story without requiring the surrounding prose. A reader who only skims the diagrams should still get the shape of the change.
+- **Diagram counts match the spec, not the template.** Both "today" and "after this change" subsections have one diagram per meaningfully distinct path in the spec — no padding to two, no collapsing distinct paths into one. A spec with one current path and three new paths should produce 1 today diagram + 3 after-this-change diagrams. A spec with two current paths and one new path should produce 2 today diagrams + 1 after-this-change diagram.
+- **Every "after this change" diagram has a 3-5 sentence prose block immediately below it.** The block walks through the flow. When two or more "after this change" paths exist, each block also names what triggers this path and what outcome differs from the others, so a stakeholder reading the blocks back-to-back can articulate when each path applies. When only one "after this change" path exists, the block walks the flow without manufacturing a contrast against absent siblings.
+- **The "Today" subsection scales the same way.** A single today diagram needs only its one-sentence lead-in — no prose block below. Two or more today diagrams each get a 3-5 sentence prose block below that walks the flow, names the pain point, and names what makes this current path distinct from the other current paths.
 - **The "today vs. after this change" pairing is obvious.** The before-and-after diagrams sit close enough together that the contrast is visible without scrolling back and forth.
 - **The "intentionally not in this slice" list comes after the reader understands what *is* in the slice.** Out-of-scope only makes sense once in-scope is concrete.
 - **The closing questions follow from the body.** Each question should connect to a specific section above it — not introduce a new topic the document never mentioned.
+- **No question in "What we are asking" restates an item from "What is intentionally not in this slice".** For each closing question, find the exclusion item it would map to. If the question is essentially *"is this exclusion OK?"* with no new trade-off or alternative attached, remove it — the closing one-liner at the bottom of "What is intentionally not in this slice" already collects that confirmation. Every remaining question in "What we are asking" must present a named alternative, an unresolved framing call, or an open question the spec itself names.
 
-If any check in either pass fails, fix it with Edit and Read the file again before re-running the affected pass. Do not present a summary that fails Pass A — a stakeholder who has to ask "what does X mean?" has already lost trust in the document.
+If any check in any pass fails, fix it with Edit and Read the file again before re-running the affected pass. If a Pass A edit changes content that Pass B or Pass C already cleared, re-run those passes against the new content — contradiction fixes can re-introduce language or reading-order issues that the earlier passes caught. Do not present a summary that fails Pass A or Pass B — a stakeholder who reads a contradiction or has to ask "what does X mean?" has already lost trust in the document.
 
 ## Step 6: Present the Summary
 

--- a/plugin/skills/stakeholder-summary/references/stakeholder-summary-template.md
+++ b/plugin/skills/stakeholder-summary/references/stakeholder-summary-template.md
@@ -31,6 +31,8 @@ flowchart TD
 
 ## How does the data flow today vs. after this change?
 
+**Diagram counts scale with the spec.** The example below shows one "Today" diagram and two "After this change" diagrams because that is the most common shape. Add or remove diagrams in each subsection to match the number of meaningfully distinct paths the spec describes. Single-path subsections do not get padded to two; multi-path subsections do not get collapsed into one.
+
 **Today** — {{one-sentence description of the current state and the pain it causes}}:
 
 ```mermaid
@@ -43,6 +45,8 @@ flowchart LR
     style D fill:#1e3a8a
 ```
 
+{{If the spec has only one meaningfully distinct current path (the common case), stop here — the one-sentence lead-in above is enough and no prose block goes below this diagram. If the spec has two or more meaningfully distinct current paths, replace this annotation with a 3-5 sentence prose block walking the reader through this path's flow, naming the pain point, and naming what makes this current path distinct from the other current paths. Then add a second "Today" diagram below — with its own one-sentence lead-in and its own 3-5 sentence prose block — for the next current path. Repeat for every current path the spec describes.}}
+
 **After this change — {{path A name}}** ({{one-sentence description}}):
 
 ```mermaid
@@ -53,6 +57,8 @@ flowchart LR
     C --> D[{{Resulting state}}]
     style D fill:#14532d
 ```
+
+{{3-5 sentence prose block walking the reader through path A. If path A is the only "after this change" path in the spec, walk the flow without manufacturing a contrast against absent siblings, then delete the path B example below. If path A is one of two or more "after this change" paths, name the trigger that sends the customer down this path rather than the others, describe what the customer does and what the system does in response, and name the outcome that is unique to path A.}}
 
 **After this change — {{path B name}}** ({{one-sentence description}}):
 
@@ -66,6 +72,8 @@ flowchart LR
     style E fill:#14532d
 ```
 
+{{3-5 sentence prose block walking the reader through path B. Mirror the contrast against path A — and any further paths — described above. Add more "After this change" diagrams here (path C, path D, etc.) as needed to cover every meaningfully distinct new path in the spec; delete this entire path B section if path A is the only new path.}}
+
 ## What is intentionally not in this slice?
 
 - **{{Item 1}}** — {{one sentence on why it is out of scope or where it lives instead}}.
@@ -73,8 +81,12 @@ flowchart LR
 - **{{Item 3}}** — {{one sentence}}.
 - **{{Item 4}}** — {{one sentence}}.
 
+{{One-line catch-all confirmation prompt directed at stakeholders, e.g. *If any of these cuts would block your team, flag it before we kick off.* This line replaces per-item "is this OK?" questions that would otherwise duplicate into the next section.}}
+
 ## What we are asking stakeholders
 
-- {{Open question 1 — phrased so a non-technical stakeholder can answer it}}
-- {{Open question 2}}
-- {{Open question 3}}
+Each item here must present a real trade-off, framing call, or unresolved question — not a yes/no confirmation of something already listed above. If the only thing you would ask is "is the exclusion of X acceptable?", drop it; the closing prompt in the previous section already covers that.
+
+- **{{Trade-off or framing call 1}}.** {{One sentence presenting the named alternatives or the framing the stakeholder must confirm.}}
+- **{{Trade-off or framing call 2}}.** {{One sentence.}}
+- **{{Trade-off or framing call 3}}.** {{One sentence.}}

--- a/plugin/skills/stakeholder-summary/references/stakeholder-summary-template.md
+++ b/plugin/skills/stakeholder-summary/references/stakeholder-summary-template.md
@@ -1,0 +1,80 @@
+# {{feature_name}} — Stakeholder Summary
+
+## What problem are we solving?
+
+{{One or two short paragraphs in plain language describing the user-visible problem this feature addresses. No technical detail — frame it from the customer's point of view. End with a short list of the high-level capabilities this feature introduces.}}
+
+- **{{Capability 1}}** — {{one-sentence description in the customer's voice}}
+- **{{Capability 2}}** — {{one-sentence description in the customer's voice}}
+
+## What does this open up?
+
+- **{{Outcome 1}}** {{— one sentence on why this matters to the business or to customers}}
+- **{{Outcome 2}}** {{— one sentence}}
+- **{{Outcome 3}}** {{— one sentence}}
+- **{{Outcome 4}}** {{— one sentence on what downstream work this unblocks}}
+
+## What will the user experience look like?
+
+{{One short paragraph describing what the customer sees and does. Stay at the level of screens, badges, and choices — not APIs or data models. May be omitted in rare cases}}
+
+```mermaid
+flowchart TD
+    A[{{Starting point the user encounters}}] --> B{{"{{Decision the user makes}}"}}
+    B -->|{{Option 1}}| C[{{Action / result}}]
+    B -->|{{Option 2}}| D[{{Action / result}}]
+    C --> E[{{Next step or outcome}}]
+    D --> F[{{Next step or outcome}}]
+    E --> G[{{Final outcome}}]
+    F --> G
+```
+
+## How does the data flow today vs. after this change?
+
+**Today** — {{one-sentence description of the current state and the pain it causes}}:
+
+```mermaid
+flowchart LR
+    A[{{Source system}}] -->|{{action}}| B[{{Intermediate}}]
+    B --> C[{{Current end state}}]
+    U[{{Actor}}] -.->|{{relationship}}| D[{{Other end state}}]
+    C -.->|{{problem}}| D
+    style C fill:#78350f
+    style D fill:#1e3a8a
+```
+
+**After this change — {{path A name}}** ({{one-sentence description}}):
+
+```mermaid
+flowchart LR
+    A[{{Source}}] -->|{{action}}| B[{{Intermediate}}]
+    B --> C[{{State}}]
+    U[{{Actor}}] -->|{{action}}| C
+    C --> D[{{Resulting state}}]
+    style D fill:#14532d
+```
+
+**After this change — {{path B name}}** ({{one-sentence description}}):
+
+```mermaid
+flowchart LR
+    A[{{Source}}] -->|{{action}}| B[{{Intermediate}}]
+    B --> C[{{State}}]
+    U[{{Actor}}] --> D[{{Other state}}]
+    C -->|{{action}}| D
+    D --> E[{{Resulting state}}]
+    style E fill:#14532d
+```
+
+## What is intentionally not in this slice?
+
+- **{{Item 1}}** — {{one sentence on why it is out of scope or where it lives instead}}.
+- **{{Item 2}}** — {{one sentence}}.
+- **{{Item 3}}** — {{one sentence}}.
+- **{{Item 4}}** — {{one sentence}}.
+
+## What we are asking stakeholders
+
+- {{Open question 1 — phrased so a non-technical stakeholder can answer it}}
+- {{Open question 2}}
+- {{Open question 3}}


### PR DESCRIPTION
## Summary

- New `/stakeholder-summary` skill: turns a feature specification into a plain-language stakeholder summary with Mermaid diagrams for user experience and before/after data flow. The summary lands next to the source spec.
- Output is shaped for non-technical stakeholders — customer-voice framing, capabilities as user-visible actions, explicit "intentionally not in this slice" deferrals, and closing questions phrased so a stakeholder can answer them.
- Includes a `references/stakeholder-summary-template.md` scaffold
- Adds the long-form operator doc under `docs/skills/stakeholder-summary.md` and updates the skill index, `CLAUDE.md` catalog, and skill-count references.

## Known divergence from documented standards

`docs/guidance/skill-building-guidance/skill-description-frontmatter.md` requires bidirectional boundary statements: when skill A names skill B in its boundary, B must also name A. This skill's description points at `/plan-a-feature`, `/plan-a-phased-build`, and `/plan-implementation`, but those three descriptions are not being updated to point back here in this PR.

Reason: those existing descriptions are already long, and adding another sibling pointer to each one increases token cost paid in every conversation. Skills in this plugin are typically invoked by slash command, so it is plausible the descriptions are doing less trigger-routing work than the rule assumes — and may be context bloat to begin with. A follow-up should either (a) trim the existing descriptions and then add the back-pointers, or (b) revise the bidirectional rule to acknowledge that slash-invoked skills weigh the trade-off differently. Holding off on making that call here.

## Test plan

- [x] Run `/stakeholder-summary` against an existing `feature-specification.md` in a planning folder and confirm the output lands in the same directory.
- [x] Verify the rendered Mermaid diagrams parse and read cleanly without the surrounding prose.
- [x] Confirm no file paths, function names, table names, or endpoints leak into the rendered summary.
- [x] Re-run on a spec with no UI impact and confirm the user-experience section can be omitted cleanly.
- [x] Ask Claude "When would you use the stakeholder-summary skill?" and confirm the description triggers on "stakeholder summary", "executive summary", and "business summary" phrasings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)