### PR TITLE
Fix/issue 11 skills not loading

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "han",
       "source": "./plugin",
       "description": "Evidence-based planning, investigation, and documentation skills for software projects. Includes issue triage, deep-dive investigations with root cause analysis, iterative plan refinement, architectural decision records (ADRs), project and feature documentation, coding standards, code reviews, test planning, PR descriptions, PR code reviews, and adversarial security vulnerability analysis.",
-      "version": "2.6.0"
+      "version": "2.6.1"
     }
   ]
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "han",
   "description": "Evidence-based planning, investigation, and documentation skills for software projects. Includes issue triage, deep-dive investigations with root cause analysis, iterative plan refinement, architectural decision records (ADRs), project and feature documentation, coding standards, code reviews, test planning, PR descriptions, PR code reviews, and adversarial security vulnerability analysis.",
-  "version": "2.6.0"
+  "version": "2.6.1"
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "han",
   "description": "Evidence-based planning, investigation, and documentation skills for software projects. Includes issue triage, deep-dive investigations with root cause analysis, iterative plan refinement, architectural decision records (ADRs), project and feature documentation, coding standards, code reviews, test planning, PR descriptions, PR code reviews, and adversarial security vulnerability analysis.",
-  "version": "2.6.0",
-  "skills": "./skills"
+  "version": "2.6.0"
 }


### PR DESCRIPTION
## Summary

**This PR removes the redundant `skills` field from the plugin manifest, so that Claude Code's default skill auto-discovery loads all 20 skills instead of registering zero.**

- Fixes issue #11: Han installed cleanly but registered 0 skills while agents loaded fine. Root cause was the manifest's `"skills": "./skills"` entry colliding with newer Claude Code loader behavior.
- Scope is a one-line manifest change plus a patch version bump (2.6.0 to 2.6.1). No skill, agent, or doc content changed.
- Reviewer attention: confirm the removal matches the documented auto-discovery contract — the `skills/` directory is auto-discovered the same way `agents/` already is, which is why agents worked in 2.6.0 and skills did not.
- Note on the reported diagnosis: the issue suggested moving the manifest to the repo root. That is not needed. The marketplace-plus-plugin-subdirectory layout (with `"source": "./plugin"` in `.claude-plugin/marketplace.json`) is officially supported; only the redundant field had to go.

### Behavior changes

Before: `plugin/.claude-plugin/plugin.json` declared `"skills": "./skills"`. Per the Claude Code plugin reference (code.claude.com/docs/en/plugins-reference), the `skills` field is meant to declare *additional* skill directories beyond the default `skills/`. Newer loader versions apply a special-case rule (reference line 555) where a `skills` path without a trailing slash is treated as a directory containing `SKILL.md` directly. The loader therefore looked for `plugin/skills/SKILL.md`, found nothing, and registered 0 skills. Agents were unaffected because the manifest never declared an `agents` field, so the default `agents/` auto-discovery ran normally.

After: with the `skills` field removed, default auto-discovery walks `plugin/skills/` the same way it walks `plugin/agents/`, finds all 20 `SKILL.md` files in their subdirectories, and registers them.

## What to look at first

- The premise that removing the field is the correct fix. The argument: the field's documented purpose is *additional* directories, pointing it at the default location is redundant in older loader versions and actively broken in newer ones, and the parallel `agents/` directory already works correctly via auto-discovery with no manifest entry.
- Whether the reporter's alternative fix (moving the manifest to the repo root) should be considered instead. The marketplace manifest at `.claude-plugin/marketplace.json` declares `"source": "./plugin"`, which is the documented pattern for plugins that live in a subdirectory. No structural move is required.
- The version bump choice: 2.6.0 to 2.6.1 as a patch. No new behavior shipped; this restores intended behavior, so semver patch fits.

## How this was tested

- ✅ Verified both JSON files still parse as valid JSON after the edit.
- ✅ Confirmed the field removal matches the auto-discovery pattern documented at code.claude.com/docs/en/plugins-reference.
- ✅ Cross-checked against the working precedent in the same manifest: `agents/` has no corresponding `"agents"` field and loads correctly in 2.6.0, so removing the `skills` field puts skill loading on the same footing.
- ⚠️ Full end-to-end validation requires Claude Code installing the plugin from a marketplace, which cannot be reproduced in a local working tree. Reviewers installing from this branch should confirm skill count is non-zero after install.

## Files of interest

- `plugin/.claude-plugin/plugin.json` — the actual fix; the `skills` field is removed and version bumped to 2.6.1.
- `.claude-plugin/marketplace.json` — version bump to 2.6.1 to keep the marketplace entry in sync with the plugin manifest.
