### PR TITLE
Lead /project-documentation output with behavior, demote technical reference

### DIFF
--- a/docs/skills/project-documentation.md
+++ b/docs/skills/project-documentation.md
@@ -57,9 +57,10 @@ Example prompts:
 
 A feature doc under the project's documentation root plus integration:
 
-- **`docs/{feature-name}.md`.** The feature doc, following the template at [`references/template.md`](../../han.core/skills/project-documentation/references/template.md). Structural sections: title + one-sentence description, Overview, Key Files, Behavior, Configuration, Error Handling, Testing, and Related Documentation. Template sections marked CONDITIONAL are omitted when they do not apply.
-- **Absolute file paths** from the repo root in every code example.
-- **Concrete, annotated code examples** (10–30 lines) drawn from real files.
+- **`docs/{feature-name}.md`.** The feature doc, following the template at [`references/template.md`](../../han.core/skills/project-documentation/references/template.md). The doc leads with behavior: a plain-language Summary, an Architecture diagram, a How It Works overview, and Primary Flows that narrate the main paths step by step. Reference detail (data model, core types, constants, implementation notes, API endpoints, components) sits below under a `## Technical Reference` region for the reader who needs it. Template sections marked CONDITIONAL are omitted when they do not apply.
+- **Behavioral overview first.** A reader who only needs to understand what the feature does and how it behaves can stop after Primary Flows and never read the Technical Reference.
+- **Absolute file paths** from the repo root.
+- **Reference code as pointers and short snippets.** Technical Reference points to the file and function and shows a short snippet only where the source is non-obvious, rather than reproducing long source blocks.
 - **Language-specific code fences** matching the project's actual language.
 - **`CLAUDE.md` / `AGENTS.md` reference.** A line added in the section most relevant to the feature.
 - **Bidirectional cross-references** to related docs.
@@ -84,7 +85,7 @@ The skill walks an eight-step process:
 
 1. **Evaluate and gather context.** Guard check for ADR/coding-standard topics, resolve the docs directory, derive the target filename, resolve author info, flag whether the content audit will run.
 2. **Explore the codebase.** Two to three `codebase-explorer` agents in parallel; merge into a unified D1/D2/D3 discovery summary.
-3. **Write the documentation.** Follow the template; absolute paths; concrete code examples; language-specific fences; conditional sections omitted; update mode preserves existing structure and flags provisional removals.
+3. **Write the documentation.** Follow the template, leading with behavior (Summary, How It Works, Primary Flows) before the Technical Reference; absolute paths; reference code as pointers and short snippets; language-specific fences; conditional sections omitted; update mode preserves existing structure and flags provisional removals.
 4. **Update agent configuration files.** Add the `CLAUDE.md` / `AGENTS.md` reference in the right section with the project's existing pattern.
 5. **Cross-reference.** Grep for the feature name across existing docs; add bidirectional references.
 6. **Content audit** (when updating). Dispatch `content-auditor`; restore facts classified Missing.
@@ -109,7 +110,7 @@ URL: https://www.writethedocs.org/guide/
 
 ### JoAnn Hackos: Information Development
 
-Hackos's work on topic-based authoring and DITA concept/task/reference distinctions underlies the template's structure: an Overview section is concept, a Behavior section is task-like, Configuration and Key Files are reference.
+Hackos's work on topic-based authoring and DITA concept/task/reference distinctions underlies the template's structure: the Summary and How It Works sections are concept, Primary Flows are task-like, and the Technical Reference region (data model, core types, constants, API endpoints) is reference.
 
 URL: https://en.wikipedia.org/wiki/Darwin_Information_Typing_Architecture
 

--- a/han.core/skills/project-documentation/SKILL.md
+++ b/han.core/skills/project-documentation/SKILL.md
@@ -51,15 +51,23 @@ Use the template at [template.md](references/template.md) as the structural guid
 **File location:** `docs/{feature-name}.md` (in the directory determined in Step 1)
 
 **Writing rules:**
-1. **Absolute file paths** from repo root (e.g., `src/services/auth.ts`, not `./auth.ts`)
-2. **Concrete code examples** — 10-30 lines, annotated, copied or adapted from actual source code
-3. **Code fence language identifiers** must match the project's actual languages (from Step 1)
-4. **Document constants and magic numbers** with their actual values
-5. **Skip CONDITIONAL sections** from the template that don't apply — don't include empty sections
-6. **One-sentence description** in the title area summarizing what the feature does
-7. **Separate backend and frontend content** — use `### Backend` / `### Frontend` sub-headings for cross-cutting features; skip sub-headings for single-layer features
 
-**Updating existing documents:** Read the entire existing document first and note all content sources (existing doc, content migrated from CLAUDE.md or other files, any other inputs). Preserve the existing structure — don't reorganize unless requested. Identify sections needing changes based on Step 2 exploration. Add new sections where the template suggests them. Flag removals as provisional for the Content Audit (Step 6). Update code examples to match current source and update cross-references in both directions.
+Lead with behavior. These rules make the doc an overview first and a reference second:
+1. **Lead with behavior.** Write the Summary, How It Works, and Primary Flows in plain language before any reference section. Describe what the feature does and what happens when it runs, in functional terms. Name files and types only where it aids understanding.
+2. **Summary is prose plus bullets.** Open the Summary with a 2-4 sentence plain-language paragraph for a reader who has not seen the code, then the scannable bullets. The paragraph carries no code, type names, or paths.
+3. **Primary Flows narrate the main paths.** Cover the 1-3 flows that matter, not every branch. Name the actor or trigger, give numbered plain-language steps (what happens and why, not which function is called), state the outcome, and narrate the main failure path.
+4. **Reference is supporting detail.** Place schema, core types, constants, implementation notes, API bodies, and component listings under the `## Technical Reference` region, below the behavioral spine. Treat them as lookup material, not the document's main body.
+
+Apply to every section:
+5. **Absolute file paths** from repo root (e.g., `src/services/auth.ts`, not `./auth.ts`).
+6. **Prefer pointers over long code.** In Technical Reference, point to the file and function and include a short illustrative snippet only where the source is non-obvious. Do not reproduce long (10-30 line) source blocks; link to the source instead.
+7. **Code fence language identifiers** must match the project's actual languages (from Step 1).
+8. **Document constants and magic numbers** with their actual values in the Constants table.
+9. **Skip CONDITIONAL sections** from the template that don't apply. Don't include empty sections.
+10. **One plain-language description** in the title area summarizing what the feature does.
+11. **Separate backend and frontend content.** Use `### Backend` / `### Frontend` sub-headings for cross-cutting features; skip sub-headings for single-layer features.
+
+**Updating existing documents:** Read the entire existing document first and note all content sources (existing doc, content migrated from CLAUDE.md or other files, any other inputs). Preserve the existing structure; don't reorganize unless requested. Identify sections needing changes based on Step 2 exploration. Add new sections where the template suggests them. If the existing doc has no plain-language behavioral layer (no Summary, How It Works, or Primary Flows), add those sections at the top so the updated doc leads with behavior. Flag removals as provisional for the Content Audit (Step 6). Update code examples to match current source and update cross-references in both directions.
 
 **Metadata:** Fill in **Last Updated** (current date/time) and **Authors** (from project context or Step 1 user input).
 
@@ -88,15 +96,15 @@ Present the audit summary to the user: number of facts checked, number present, 
 
 ## Step 7: Information-Architecture Review
 
-Dispatch an `information-architect` agent against the written/updated doc before final verification. Pass it the document path, the docs directory root, and the intended audience (a developer who needs to understand or change this feature).
+Dispatch an `information-architect` agent against the written/updated doc before final verification. Pass it the document path, the docs directory root, and the intended audience (a developer or technically-literate stakeholder who needs to understand the feature's behavior before reading its code, and who may later modify it).
 
-Prompt: "Audit the feature doc at {doc_path} for findability, orientation, and comprehension. The intended audience is a developer who needs to understand or change this feature. Check: does the title + one-sentence description match what a reader scanning `{docs_directory}` would expect to find here? Is the Overview oriented at the right audience, and does it lead the reader to the next section they need? Are Behavior, Configuration, and Error Handling scannable and in the right order for the likely reading path? Does the Related Documentation section lead the reader to the next useful artifact, or dead-end them? Return a short list of structural edits; return an empty list if the document reads well."
+Prompt: "Audit the feature doc at {doc_path} for findability, orientation, and comprehension. The intended audience is a developer or technically-literate stakeholder who needs to understand the feature's behavior before reading its code, and who may later modify it. Check: (1) Does a plain-language Summary and a How It Works and Primary Flows narration appear before any code, schema, or type reference? If the behavioral content is missing or sits below the reference detail, that is a finding. (2) Does the heading list let a scanning reader see where the functional overview ends and the deep `## Technical Reference` begins? (3) Is the Summary a short prose paragraph plus bullets, oriented at the right audience, and does the title + one-sentence description match what a reader scanning `{docs_directory}` would expect to find here? (4) Are Configuration and Error Handling scannable and placed ahead of the raw reference detail? (5) Does the Related Documentation section lead the reader to the next useful artifact, or dead-end them? Return a list of structural edits. Do not return an empty list unless the document leads with behavior and defers code reference."
 
 Apply every actionable edit the agent returns. For findings that require a judgment only the author can make (scope, audience ambiguity), surface them to the user with a recommended resolution; do not silently resolve.
 
 ## Step 8: Verification
 
-1. **Documentation file:** Follows template structure, no `{placeholder}` values remain, absolute file paths, concrete code examples, no empty CONDITIONAL sections, ASCII diagrams render correctly
+1. **Documentation file:** Follows template structure and leads with behavior (Summary, How It Works, Primary Flows appear before the `## Technical Reference` region), no `{placeholder}` values remain, absolute file paths, reference code is short snippets or file pointers rather than long source blocks, no empty CONDITIONAL sections, ASCII diagrams render correctly
 2. **Agent config file:** Reference correctly formatted, link path valid, placed in right section
 3. **Cross-references:** Links point to real files, related docs link back to new doc
 4. **IA review applied:** Step 7 edits were applied, or any skipped edits were surfaced to the user

--- a/han.core/skills/project-documentation/SKILL.md
+++ b/han.core/skills/project-documentation/SKILL.md
@@ -66,6 +66,7 @@ Apply to every section:
 9. **Skip CONDITIONAL sections** from the template that don't apply. Don't include empty sections.
 10. **One plain-language description** in the title area summarizing what the feature does.
 11. **Separate backend and frontend content.** Use `### Backend` / `### Frontend` sub-headings for cross-cutting features; skip sub-headings for single-layer features.
+12. **Diagrams are Mermaid, not ASCII.** Render the Architecture diagram, any Primary Flow diagram, and the Component Hierarchy as Mermaid in a ```` ```mermaid ```` fence — `flowchart` for structure and trees, `sequenceDiagram` for actor-to-system exchanges. Label nodes with parts a reader recognizes and label edges with what passes between them. Keep each diagram to the parts that matter; a reader should grasp the shape at a glance.
 
 **Updating existing documents:** Read the entire existing document first and note all content sources (existing doc, content migrated from CLAUDE.md or other files, any other inputs). Preserve the existing structure; don't reorganize unless requested. Identify sections needing changes based on Step 2 exploration. Add new sections where the template suggests them. If the existing doc has no plain-language behavioral layer (no Summary, How It Works, or Primary Flows), add those sections at the top so the updated doc leads with behavior. Flag removals as provisional for the Content Audit (Step 6). Update code examples to match current source and update cross-references in both directions.
 
@@ -104,7 +105,7 @@ Apply every actionable edit the agent returns. For findings that require a judgm
 
 ## Step 8: Verification
 
-1. **Documentation file:** Follows template structure and leads with behavior (Summary, How It Works, Primary Flows appear before the `## Technical Reference` region), no `{placeholder}` values remain, absolute file paths, reference code is short snippets or file pointers rather than long source blocks, no empty CONDITIONAL sections, ASCII diagrams render correctly
+1. **Documentation file:** Follows template structure and leads with behavior (Summary, How It Works, Primary Flows appear before the `## Technical Reference` region), no `{placeholder}` values remain, absolute file paths, reference code is short snippets or file pointers rather than long source blocks, no empty CONDITIONAL sections, Mermaid diagrams are syntactically valid (open with ```` ```mermaid ````, declare a diagram type, and parse)
 2. **Agent config file:** Reference correctly formatted, link path valid, placed in right section
 3. **Cross-references:** Links point to real files, related docs link back to new doc
 4. **IA review applied:** Step 7 edits were applied, or any skipped edits were surfaced to the user

--- a/han.core/skills/project-documentation/references/template.md
+++ b/han.core/skills/project-documentation/references/template.md
@@ -6,30 +6,69 @@
 - **Authors:**
   - {name} ({email})
 
-## Overview
+## Summary
 
-<!-- 2-4 bullet points covering the most important facts a reader needs to orient themselves. -->
+<!-- Lead with plain language. Write 2-4 short sentences for a reader who has not seen -->
+<!-- the code: what this feature is for, who uses it, what problem it solves, and what it -->
+<!-- produces. No code, no type names, no file paths here. This is the paragraph someone -->
+<!-- reads to decide whether they are in the right place. -->
+
+{Plain-language summary paragraph.}
+
+<!-- Then the most important facts a reader needs to orient, as scannable bullets. -->
 
 - ...
 - ...
 
 Key files:
-<!-- List the 3-5 most important files. This is the quick-reference; the full table goes in Key Files below. -->
+<!-- The 3-5 files a reader would open first. The full table lives in Key Files below. -->
 - `path/to/primary-file` - Brief purpose
 - `path/to/secondary-file` - Brief purpose
 
 ## Architecture
 
-<!-- ASCII flow diagram showing the feature's high-level structure. -->
-<!-- Use box-drawing characters (┌─┐│└─┘) for boxes, arrows (→ ──▶ │ ▼) for flow -->
+<!-- ASCII block diagram showing the feature's high-level structure: the main parts and -->
+<!-- how they connect. Use box-drawing characters (┌─┐│└─┘) for boxes, arrows (→ ──▶ │ ▼) -->
+<!-- for connections. This shows what the parts are; How It Works and Primary Flows below -->
+<!-- explain what they do. -->
 
 ```
 Diagram here
 ```
 
+## How It Works
+
+<!-- Plain-language explanation of how the feature behaves. 2-4 short paragraphs. No code. -->
+<!-- Name the main moving parts in everyday terms and describe what each one does and how -->
+<!-- they work together. Set up the diagram above and the flows below. This is the spine -->
+<!-- of the document: a reader who only needs to understand the feature can stop after -->
+<!-- Primary Flows and never read the Technical Reference. -->
+
+{Behavioral overview prose.}
+
+## Primary Flows
+
+<!-- Narrate the feature's main paths step by step, in functional terms. Cover the 1-3 -->
+<!-- flows that matter, not every branch. Each flow gets an H3 named for what happens -->
+<!-- (e.g. "Submitting an order", "Retrying a failed webhook"). Name the actor or trigger, -->
+<!-- list the steps in plain language (what happens and why, not which function is called), -->
+<!-- and state the outcome. Narrate the main failure path too, as steps. Reference a file -->
+<!-- or type by name only when it aids understanding; the deep detail lives in Technical -->
+<!-- Reference below. Add a small diagram here if a flow needs one. -->
+
+### {Flow name}
+
+**Trigger:** {who or what starts this flow}
+
+1. **{What happens}** — {plain-language explanation of this step}
+2. **{What happens next}** — {explanation}
+3. **{Outcome}** — {what the reader ends up with}
+
+**When it fails:** {narrate the main failure path in plain steps, and what the reader sees.}
+
 ## Key Files
 
-<!-- Organize by layer. Include all files relevant to understanding or modifying this feature. -->
+<!-- Organize by layer. Include the files relevant to understanding or modifying this feature. -->
 
 ### Backend
 <!-- CONDITIONAL: Include only if the feature has backend files -->
@@ -49,84 +88,122 @@ Diagram here
 |------|---------|
 | `path/to/file` | ... |
 
-## Database Schema
+## Configuration
 
-<!-- CONDITIONAL: Include when the feature has its own tables or adds columns to existing tables. -->
+<!-- CONDITIONAL: Include when environment variables or config files change behavior. -->
+<!-- This sits with the behavioral content because it changes what the feature does. -->
+<!-- For cross-cutting features, split into Backend and Frontend sub-sections. For -->
+<!-- single-layer features, skip the sub-headings. -->
+
+### Backend
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ENV_VAR_NAME` | What it controls | `default_value` |
+
+### Frontend
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ENV_VAR_NAME` | What it controls | `default_value` |
+
+## Error Handling
+
+<!-- CONDITIONAL: Include when there are specific error scenarios worth documenting. -->
+<!-- This is the lookup table for failure behavior. The narrative failure path belongs -->
+<!-- in the relevant Primary Flow above; this table is where a reader looks up a specific -->
+<!-- scenario. For cross-cutting features, split into Backend and Frontend sub-sections. -->
+
+### Backend
+| Scenario | Error / HTTP Status | Behavior |
+|----------|---------------------|----------|
+| Description | `400 Bad Request` | What happens |
+
+### Frontend
+| Scenario | Error Handling | Behavior |
+|----------|----------------|----------|
+| Description | Error boundary / toast / fallback | What happens |
+
+---
+
+## Technical Reference
+
+<!-- Everything below is lookup detail, not required reading. A reader who only needs to -->
+<!-- understand what the feature does and how it behaves can stop above. Keep these -->
+<!-- sections, but treat them as supporting detail under the behavioral spine, not as the -->
+<!-- main body. Prefer short, illustrative snippets and file pointers over reproducing -->
+<!-- long source. Skip any sub-section that does not apply. -->
+
+### Data Model
+
+<!-- CONDITIONAL: Include when the feature has its own tables or adds columns. -->
+<!-- Lead with one plain sentence on what is stored and why. Keep the schema concise; it -->
+<!-- is often the only written record of the data shape, so keep it, but trim to the -->
+<!-- columns that matter and comment only the non-obvious ones. -->
+
+{One sentence on what this stores and why.}
 
 ```sql
 CREATE TABLE TableName (
     id int(11) NOT NULL AUTO_INCREMENT,
-    -- ... columns with comments explaining non-obvious ones
+    -- ... columns that matter, with comments on the non-obvious ones
     PRIMARY KEY (id)
 );
 ```
 
-## Core Types
+### Core Types
 
-<!-- CONDITIONAL: Include when key interfaces, structs, or types define the feature's contract. -->
-<!-- For cross-cutting features, include both Backend and Frontend sub-headings. For single-layer features, use only the relevant sub-heading. -->
+<!-- CONDITIONAL: Include when key interfaces, structs, or types define the contract. -->
+<!-- Lead with one sentence on what these types represent. Show a short snippet of the -->
+<!-- key fields, or point to the source file rather than reproducing the full definition. -->
+<!-- For cross-cutting features, include Backend and Frontend sub-headings; otherwise use -->
+<!-- only the relevant one. -->
 
-### Backend
+{One sentence on what these types represent in the feature.}
+
+See `path/to/types-file` for the full definitions. Key fields:
 
 ```{language}
-// Type definitions from source with brief annotations
+// A short snippet of the most important fields, with brief annotations
 ```
 
-### Frontend
+### Constants
 
-```{language}
-// Type definitions from source with brief annotations
-```
+<!-- CONDITIONAL: Include when magic numbers, enum values, or named constants matter. -->
+<!-- A table is the written record of these values; keep it. For cross-cutting features, -->
+<!-- split into Backend and Frontend; otherwise skip the sub-headings. -->
 
-## Constants
-
-<!-- CONDITIONAL: Include when magic numbers, enum values, or named constants are important. -->
-<!-- For cross-cutting features, split into Backend and Frontend sub-sections. For single-layer features, skip the sub-headings. -->
-
-### Backend
 | Constant | Value | Description |
 |----------|-------|-------------|
 | `ConstantName` | `42` | What it means |
 
-### Frontend
-| Constant | Value | Description |
-|----------|-------|-------------|
-| `CONSTANT_NAME` | `"value"` | What it means |
+### Implementation Notes
 
-## Implementation Details
+<!-- CONDITIONAL: Include when there is non-obvious logic worth calling out. -->
+<!-- Reference-level detail. The behavioral spine lives in How It Works and Primary Flows -->
+<!-- above; do not reproduce long source here. Point to the file and function, and include -->
+<!-- a short snippet only where the source is non-obvious and a reader needs to see it. -->
+<!-- Sub-head by operation or feature area. -->
 
-<!-- The main body of the document. Sub-head by operation, feature area, or logical grouping. -->
-<!-- For cross-cutting features, split into Backend and Frontend sub-sections. For single-layer features, skip the sub-headings and organize directly by operation. -->
-
-### Backend
 #### {Operation or Feature Area}
 
-```{language}
-// Annotated code example from actual source
-```
-
-### Frontend
-#### {Operation or Feature Area}
+{Plain-language note on the non-obvious part, with a pointer to `path/to/file`.}
 
 ```{language}
-// Annotated code example from actual source
+// Short snippet only if the source is non-obvious; otherwise omit and link to the file
 ```
 
-## API Endpoints
+### API Endpoints
 
 <!-- CONDITIONAL: Include when the feature exposes API endpoints. -->
+<!-- The endpoint table is the reference. Include request/response bodies only when the -->
+<!-- shape is non-obvious; otherwise the table and a pointer to the schema suffice. -->
 
 | Method | Path | Handler | Description |
 |--------|------|---------|-------------|
 | `GET` | `/v1/resource` | `ListResource` | List with pagination |
 | `POST` | `/v1/resource` | `CreateResource` | Create new |
 
-### {Endpoint Name}
-
-```
-POST /v1/resource
-Content-Type: application/json
-```
+<!-- CONDITIONAL: Include a request/response example only for endpoints whose payload -->
+<!-- shape is non-obvious. -->
 
 **Request:**
 ```json
@@ -142,56 +219,27 @@ Content-Type: application/json
 }
 ```
 
-## Events
+### Events
 
 <!-- CONDITIONAL: Include when the feature emits or subscribes to events. -->
 
-### Emitted Events
+#### Emitted Events
 | Event | Payload Type | When Emitted |
 |-------|-------------|--------------|
 | `domain.action` | `DomainActionPayload` | When ... |
 
-### Subscribed Events
+#### Subscribed Events
 | Event | Handler | Behavior |
 |-------|---------|----------|
 | `other.event` | `handleOtherEvent` | Does ... |
 
-## Configuration
-
-<!-- CONDITIONAL: Include when environment variables or config files are involved. -->
-<!-- For cross-cutting features, split into Backend and Frontend sub-sections. For single-layer features, skip the sub-headings. -->
-
-### Backend
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ENV_VAR_NAME` | What it controls | `default_value` |
-
-### Frontend
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ENV_VAR_NAME` | What it controls | `default_value` |
-
-## Error Handling
-
-<!-- CONDITIONAL: Include when there are specific error scenarios worth documenting. -->
-<!-- For cross-cutting features, split into Backend and Frontend sub-sections. For single-layer features, skip the sub-headings. -->
-
-### Backend
-| Scenario | Error / HTTP Status | Behavior |
-|----------|---------------------|----------|
-| Description | `400 Bad Request` | What happens |
-
-### Frontend
-| Scenario | Error Handling | Behavior |
-|----------|----------------|----------|
-| Description | Error boundary / toast / fallback | What happens |
-
-## Frontend Components
+### Frontend Components
 
 <!-- CONDITIONAL: Include when the feature has significant UI components. -->
 <!-- Include only the sub-sections below that apply. Each sub-section is CONDITIONAL. -->
+<!-- Prefer tables and the component tree over reproducing component source. -->
 
-### Component Hierarchy
+#### Component Hierarchy
 
 <!-- CONDITIONAL: Include when there's a meaningful page/component tree to illustrate. -->
 
@@ -203,16 +251,16 @@ PageComponent
         └── CellComponents
 ```
 
-### Routing
+#### Routing
 
-<!-- CONDITIONAL: Include when the feature defines its own routes or has multiple URL patterns. -->
+<!-- CONDITIONAL: Include when the feature defines its own routes or URL patterns. -->
 
 | Route | Page Component | Description |
 |-------|----------------|-------------|
 | `/feature` | `FeaturePage` | Main listing |
 | `/feature/:id` | `FeatureDetailsPage` | Detail view |
 
-### Custom Hooks
+#### Custom Hooks
 
 <!-- CONDITIONAL: Include when the feature has custom hooks beyond generated API hooks. -->
 
@@ -220,7 +268,7 @@ PageComponent
 |------|---------|------------|
 | `useFeatureState()` | Manages local feature state | `featureId` |
 
-### Context / Providers
+#### Context / Providers
 
 <!-- CONDITIONAL: Include when the feature defines or consumes contexts or providers. -->
 
@@ -228,58 +276,62 @@ PageComponent
 |---------|----------|---------|
 | `FeatureContext` | `FeatureProvider` | Shares feature state across component tree |
 
-### State Management
+#### State Management
 
-<!-- CONDITIONAL: Include when the feature has notable state management patterns (query caching, stores, reducers). -->
+<!-- CONDITIONAL: Include when the feature has notable state patterns (caching, stores, -->
+<!-- reducers). Describe the pattern in a sentence and point to the source; include a -->
+<!-- snippet only if the pattern is non-obvious. -->
 
-```{language}
-// State management patterns from actual source
-```
+{One sentence on the state pattern, with a pointer to `path/to/file`.}
 
-### Offline Support
+#### Offline Support
 
-<!-- CONDITIONAL: Include when the feature uses local storage, background sync, or offline-first patterns. -->
+<!-- CONDITIONAL: Include when the feature uses local storage, background sync, or -->
+<!-- offline-first patterns. -->
 
 | Component | Purpose |
 |-----------|---------|
 | `path/to/offline-service` | Local storage CRUD operations for offline cache |
 | `path/to/sync-component` | Background sync when connectivity restored |
 
-### Event Patterns
+#### Event Patterns
 
-<!-- CONDITIONAL: Include when the feature uses custom DOM events, editor events, or window events. -->
+<!-- CONDITIONAL: Include when the feature uses custom DOM events, editor events, or -->
+<!-- window events. -->
 
 | Event | Dispatched By | Handled By | Purpose |
 |-------|---------------|------------|---------|
 | `feature:updated` | `FeatureEditor` | `FeatureList` | Refresh list after inline edit |
 
-## Adding a New {Item}
+### Adding a New {Item}
 
-<!-- CONDITIONAL: Include when the feature has a repeatable extension pattern (new event type, new endpoint, new column, etc.). -->
+<!-- CONDITIONAL: Include when the feature has a repeatable extension pattern (new event -->
+<!-- type, new endpoint, new column, etc.). -->
 
 1. **Step one** — What to do and where
 2. **Step two** — What to do and where
 3. **Step three** — What to do and where
 
-## Testing
+### Testing
 
-<!-- CONDITIONAL: Include when there are notable test patterns, test file locations, or isolation requirements. -->
-<!-- For cross-cutting features, split into Backend and Frontend sub-sections. For single-layer features, skip the sub-headings. -->
+<!-- CONDITIONAL: Include when there are notable test patterns, file locations, or -->
+<!-- isolation requirements. For cross-cutting features, split into Backend and Frontend. -->
 
-### Backend
+#### Backend
 - `path/to/test_file` - What it tests
 
-### Frontend
+#### Frontend
 - `path/to/test_file` - What it tests
 
-### Test Patterns
-<!-- Describe any special setup, fixtures, or isolation needed, including patterns shared across layers. -->
+#### Test Patterns
+<!-- Describe any special setup, fixtures, or isolation needed, including patterns shared -->
+<!-- across layers. -->
 
-## Troubleshooting
+### Troubleshooting
 
 <!-- CONDITIONAL: Include when there are known issues, common mistakes, or debugging tips. -->
 
-### {Problem Description}
+#### {Problem Description}
 
 1. Check ...
 2. Verify ...

--- a/han.core/skills/project-documentation/references/template.md
+++ b/han.core/skills/project-documentation/references/template.md
@@ -27,13 +27,18 @@ Key files:
 
 ## Architecture
 
-<!-- ASCII block diagram showing the feature's high-level structure: the main parts and -->
-<!-- how they connect. Use box-drawing characters (┌─┐│└─┘) for boxes, arrows (→ ──▶ │ ▼) -->
-<!-- for connections. This shows what the parts are; How It Works and Primary Flows below -->
-<!-- explain what they do. -->
+<!-- Mermaid diagram showing the feature's high-level structure: the main parts and how -->
+<!-- they connect. Use a `flowchart` (TD for layered structure, LR for a pipeline). Label -->
+<!-- each node with a part a reader would recognize, and label the edges with what passes -->
+<!-- between them. This shows what the parts are; How It Works and Primary Flows below -->
+<!-- explain what they do. Keep it to the parts that matter — a reader should grasp the -->
+<!-- shape at a glance, not trace every wire. -->
 
-```
-Diagram here
+```mermaid
+flowchart TD
+    A[Component A] -->|sends request| B[Component B]
+    B --> C[(Data store)]
+    B -->|emits| D[Downstream consumer]
 ```
 
 ## How It Works
@@ -54,7 +59,8 @@ Diagram here
 <!-- list the steps in plain language (what happens and why, not which function is called), -->
 <!-- and state the outcome. Narrate the main failure path too, as steps. Reference a file -->
 <!-- or type by name only when it aids understanding; the deep detail lives in Technical -->
-<!-- Reference below. Add a small diagram here if a flow needs one. -->
+<!-- Reference below. Add a small Mermaid diagram here if a flow needs one — a -->
+<!-- `sequenceDiagram` for actor-to-system exchanges, or a `flowchart` for branching paths. -->
 
 ### {Flow name}
 
@@ -242,13 +248,14 @@ See `path/to/types-file` for the full definitions. Key fields:
 #### Component Hierarchy
 
 <!-- CONDITIONAL: Include when there's a meaningful page/component tree to illustrate. -->
+<!-- Use a Mermaid `flowchart TD` so the tree renders as nested boxes. -->
 
-```
-PageComponent
-└── ContainerComponent
-    ├── HeaderComponent
-    └── TableComponent
-        └── CellComponents
+```mermaid
+flowchart TD
+    Page[PageComponent] --> Container[ContainerComponent]
+    Container --> Header[HeaderComponent]
+    Container --> Table[TableComponent]
+    Table --> Cell[CellComponents]
 ```
 
 #### Routing


### PR DESCRIPTION
## Summary

**This PR restructures the \`project-documentation\` skill's output template so generated feature docs lead with plain-language behavior and demote code reference, so that a reader can understand what a feature does before wading into its implementation.**

- Generated feature docs now open with a behavioral spine: a prose Summary, an Architecture diagram, a How It Works overview, and Primary Flows that narrate the main paths step by step. All schema, type, constant, and implementation detail is collected below a new \`## Technical Reference\` region.
- A reader who only needs to know what a feature does can stop after Primary Flows and never read the Technical Reference. The reference layer becomes lookup material (file-and-function pointers with short snippets) rather than reproduced 10-30 line source blocks.
- Diagrams switch from ASCII box-drawing and tree art to Mermaid (\`flowchart\` for structure and trees, \`sequenceDiagram\` for actor-to-system exchanges), so they render as real diagrams on GitHub and in doc viewers.
- This changes the shape of every doc the skill produces going forward; it does not touch the skill's eight-step process flow or its agent dispatch. Existing docs are not rewritten by this PR, but update mode now adds the behavioral layer when an older doc lacks one.

### Behavior changes

The skill itself is a process that produces a document, so the runtime change is in what the skill writes, not in how Claude Code runs it.

- Before: generated docs led with \`## Overview\`, then reference sections (Database Schema, Core Types with full type definitions, Implementation Details with 10-30 line annotated code blocks), with ASCII diagrams.
- After: generated docs lead with \`## Summary\` (prose paragraph plus bullets plus a Key files quick list), \`## Architecture\` (Mermaid), \`## How It Works\`, and \`## Primary Flows\`. Configuration and Error Handling move up to sit with the behavioral content. Everything else moves below a \`## Technical Reference\` horizontal-rule region as H3 sub-sections (Data Model, Core Types, Constants, Implementation Notes, API Endpoints, Events, Frontend Components, Adding a New Item, Testing, Troubleshooting).
- Update mode change: when updating a doc that has no plain-language behavioral layer, the skill now adds Summary, How It Works, and Primary Flows at the top rather than only editing existing sections.
- The Step 7 information-architect review changes its target audience from "a developer who needs to understand or change this feature" to "a developer or technically-literate stakeholder who needs to understand the feature's behavior before reading its code," and now treats "behavior leads, code reference follows" as a pass/fail gate rather than returning an empty list when prose reads well.

## What to look at first

- The reorientation decision in \`SKILL.md\`: writing rules now lead with four "lead with behavior" rules (Summary as prose plus bullets, Primary Flows narrate main paths, reference is supporting detail) before the cross-cutting rules. This is the core behavioral contract for what the skill produces.
- The "pointers over long code" tradeoff: Technical Reference now points to file and function and shows a short snippet only where the source is non-obvious, instead of reproducing 10-30 line blocks. Worth a look at whether that loses useful detail for the reference-seeking reader.
- The Step 7 IA-review prompt change, which converts the audit into an explicit five-point check with a behavior-leads gate, so a doc that buries behavior below reference now fails the review.
- The DITA mapping note in the long-form doc: Summary and How It Works are "concept," Primary Flows are "task," and the Technical Reference region is "reference," which is the rationale for the new ordering.

## Files of interest

- \`han.core/...documentation/references/template.md\` — the restructured output template; the heart of the change (Overview to Summary, new How It Works and Primary Flows, Technical Reference region, Mermaid diagrams).
- \`han.core/skills/project-documentation/SKILL.md\` — the writing rules, update-mode behavior, Step 7 IA prompt, and Step 8 verification that enforce the new structure.
- \`docs/skills/project-documentation.md\` — operator-facing long-form doc updated to describe the behavior-first output and the DITA rationale.