### PR TITLE
Update-pr-description Skill: Conform to repository PR template when present

### DIFF
--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -70,7 +70,7 @@ Skills for capturing operational knowledge in artifacts the next on-call enginee
 GitHub-facing skills that talk to GitHub through the `gh` CLI. Depends on `han.core`.
 
 - **[`/post-code-review-to-pr`](./post-code-review-to-pr.md).** Run `/code-review` against a GitHub PR and post the review as comments, after a `junior-developer` clarity check on the drafted review body.
-- **[`/update-pr-description`](./update-pr-description.md).** Generate a PR description from the current branch's changes.
+- **[`/update-pr-description`](./update-pr-description.md).** Generate a PR description from the current branch's changes, conforming to the repository's PR template when one exists.
 - **[`/work-items-to-issues`](./work-items-to-issues.md).** Publish each item in a `/plan-work-items` work-items file as a GitHub issue in its target repo, with within-repo blockers linked, screenshots copied into the repo, and no label or assignee by default.
 
 ## han.reporting

--- a/docs/skills/update-pr-description.md
+++ b/docs/skills/update-pr-description.md
@@ -6,13 +6,14 @@ Operator documentation for the `/update-pr-description` skill in the han plugin.
 
 ## TL;DR
 
-- **What it does.** Generates a PR description from the current branch's changes against a GitHub PR using the `gh` CLI.
+- **What it does.** Generates a PR description from the current branch's changes against a GitHub PR using the `gh` CLI. When the repository defines its own GitHub pull-request template, the description conforms to that template's structure.
 - **When to use it.** You have a branch with committed changes and want a thorough PR description that surfaces the central mechanism, key files, and a test plan.
 - **What you get back.** A markdown PR description in-channel, optionally pushed to the open PR via `gh pr edit`.
 
 ## Key concepts
 
 - **Central mechanism up front.** Feature flags, migrations, and behavioral changes lead the Summary. Code structure is summarized; runtime behavior is not.
+- **Repository PR template aware.** Before generating, the skill looks for a GitHub pull-request template (in the repo root, `.github/`, `docs/`, or a `PULL_REQUEST_TEMPLATE/` directory). If it finds one, the description conforms to that template's headings and order instead of the default structure. It reads the template's intent rather than assuming a shape: a template whose comments say "replace this with a description" is treated as a throwaway scaffold and replaced wholesale, while a structural template's sections are filled in and preserved. Checklist boxes are checked only when the diff unambiguously proves them; the rest are left for the author. If multiple templates exist in a `PULL_REQUEST_TEMPLATE/` directory, the skill asks which to use.
 - **Junior-developer authors the description.** A `junior-developer` agent writes the PR description directly. Authoring with a fresh-reviewer perspective (a teammate without full project context) means the result already anticipates what a reviewer needs to see, so no separate review pass is required.
 - **"How this was tested" is conditional.** If the branch only changes documentation, the section is omitted. If any code or config file changed, it is included.
 - **Files of interest is a bulleted list, capped at five.** This section is a bulleted list of at most 5 entries, never a table. Each entry is `` `path` `` followed by a one-phrase reason the file matters for review. Generated files, mechanical refactors, trivial changes, and non-central test helpers are skipped.
@@ -50,7 +51,7 @@ Example prompts:
 
 ## What you get back
 
-A PR description rendered in-channel, optionally pushed to the open PR. Sections appear in this fixed order: Summary, What to look at first, How this was tested (when included), Files of interest, Test scenario changes (when tests were added or edited).
+A PR description rendered in-channel, optionally pushed to the open PR. When the repository has no PR template, sections appear in this fixed order: Summary, What to look at first, How this was tested (when included), Files of interest, Test scenario changes (when tests were added or edited). When the repository defines a PR template, the description follows that template's headings and order instead, with "What to look at first" and "Files of interest" appended when the template has no home for them.
 
 - **Summary.** Opens with a single bolded TL;DR sentence (`**This PR <verb> <behavior>, so that <why>.**`), followed by 2–4 bullets covering user-visible or runtime behavior, scope, and reviewer-attention pointers. A `### Behavior changes` subsection appears only when runtime behavior changes (flag flips, migrations, state-machine edits, config changes, API contract changes).
 - **What to look at first.** A 2–4 bullet attention guide pointing at decisions, tradeoffs, or risks. Not a file list.
@@ -73,14 +74,15 @@ The skill reads the git diff, stat, log, and any source files needed to understa
 
 ## In more detail
 
-The skill walks a six-step process:
+The skill walks a seven-step process:
 
 1. **Validate branch state.** Require `origin/HEAD`, require at least one commit, require at least one changed file.
-2. **Analyze changes.** Read the diff, stat, and log. Identify the central mechanism. Classify the change type.
-3. **Determine "How this was tested" applicability.** If all changed files are documentation, omit the section. If any are code or config, include it.
-4. **Generate the PR description.** Dispatch a `junior-developer` agent with the branch context, the inclusion decision from Step 3, and the contents of [`references/template.md`](../../han.github/skills/update-pr-description/references/template.md) and [`references/formatting-rules.md`](../../han.github/skills/update-pr-description/references/formatting-rules.md). The agent authors the description with a fresh-reviewer perspective, anticipating what a teammate without full project context needs to see. No nested fenced code blocks. No "Generated with Claude Code" trailer.
-5. **Verify.** Section order, file-table caps, valid markdown, branch-specific content only.
-6. **Display and update PR.** Show the description. If a PR exists, ask whether to push. On yes, `gh pr edit --body`.
+2. **Discover the repository PR template.** Look in the repo root, `.github/`, `docs/`, and any `PULL_REQUEST_TEMPLATE/` directory for a GitHub pull-request template. If exactly one is found, read it in full (including HTML comments). If a `PULL_REQUEST_TEMPLATE/` directory holds several, ask which to conform to. If none exists, the skill uses its default structure.
+3. **Analyze changes.** Read the diff, stat, and log. Identify the central mechanism. Classify the change type.
+4. **Determine "How this was tested" applicability.** If all changed files are documentation, omit the section. If any are code or config, include it.
+5. **Generate the PR description.** Dispatch a `junior-developer` agent with the branch context, the inclusion decision from Step 4, the contents of [`references/formatting-rules.md`](../../han.github/skills/update-pr-description/references/formatting-rules.md), and a structure directive. With no template, the directive carries [`references/template.md`](../../han.github/skills/update-pr-description/references/template.md) and the fixed section order. With a template, it carries the discovered template and the conformance rules in [`references/template-conformance.md`](../../han.github/skills/update-pr-description/references/template-conformance.md). The agent authors the description with a fresh-reviewer perspective, anticipating what a teammate without full project context needs to see. No nested fenced code blocks. No "Generated with Claude Code" trailer.
+6. **Verify.** Structure (fixed order, or conformance to the discovered template), file-list caps, valid markdown, branch-specific content only.
+7. **Display and update PR.** Show the description. If a PR exists, ask whether to push. On yes, `gh pr edit --body`.
 
 ## Sources
 

--- a/docs/skills/update-pr-description.md
+++ b/docs/skills/update-pr-description.md
@@ -70,7 +70,7 @@ A PR description rendered in-channel, optionally pushed to the open PR. When the
 
 ## Cost and latency
 
-The skill reads the git diff, stat, log, and any source files needed to understand the change, then dispatches a single `junior-developer` agent in Step 4 to author the PR description. The agent runs on its default model. Typical runs are around a minute for a typical PR.
+The skill reads the git diff, stat, log, and any source files needed to understand the change, then dispatches a single `junior-developer` agent in Step 5 to author the PR description. The agent runs on its default model. Typical runs are around a minute for a typical PR.
 
 ## In more detail
 

--- a/han.github/skills/update-pr-description/SKILL.md
+++ b/han.github/skills/update-pr-description/SKILL.md
@@ -3,10 +3,12 @@ name: update-pr-description
 description: >
   Generate a PR description from the current branch's changes against a GitHub
   PR, using the gh CLI. Use when writing, drafting, or updating pull request
-  descriptions, PR summaries, or PR bodies. Requires the gh CLI to be installed
-  and a PR to already exist for the current branch. Does not review code or post
-  review comments — use code-review for local review or post-code-review-to-pr for posting
-  a review to GitHub.
+  descriptions, PR summaries, or PR bodies. When the repository defines a GitHub
+  pull-request template, the generated description conforms to that template's
+  structure. Requires the gh CLI to be installed and a PR to already exist for
+  the current branch. Does not review code or post review comments — use
+  code-review for local review or post-code-review-to-pr for posting a review to
+  GitHub.
 argument-hint: [optional context about the PR]
 allowed-tools: Read, Glob, Grep, Agent, Bash(git *), Bash(gh *)
 ---
@@ -37,55 +39,90 @@ Before generating a PR description, verify the branch has content to describe:
 
 3. **If `branch stats` is empty** — there are no file changes despite having commits (e.g., empty commits or fully reverted changes). Inform the user and stop.
 
-## Step 2: Analyze Changes
+## Step 2: Discover the Repository PR Template
+
+Determine whether the repository defines its own GitHub pull-request template. If it does, the generated description must conform to that template's structure (Step 5). Do not assume any particular template shape — discover it, read it, and let its structure drive the output.
+
+Use the `Glob` tool to look in GitHub's supported template locations. GitHub matches the filename case-insensitively; check both common casings since the working filesystem may be case-sensitive. Search these paths (most templates are `.md`; `.txt` is also valid):
+
+- Root of the repo: `pull_request_template.md`, `PULL_REQUEST_TEMPLATE.md` (and the `.txt` variants).
+- The `.github/` directory: `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md` (and `.txt`).
+- The `docs/` directory: `docs/pull_request_template.md`, `docs/PULL_REQUEST_TEMPLATE.md` (and `.txt`).
+- A multiple-template subdirectory: `.github/PULL_REQUEST_TEMPLATE/*.md`, `docs/PULL_REQUEST_TEMPLATE/*.md`, `PULL_REQUEST_TEMPLATE/*.md`.
+
+Then resolve to a single template (or none):
+
+1. **No template file found** — the repository has no PR template. Record "no repository template" and continue. Step 5 uses the default structure.
+2. **Exactly one single-file template found** — `Read` it in full, including HTML comments. Record its path and full contents.
+3. **A `PULL_REQUEST_TEMPLATE/` directory with multiple templates** — GitHub selects one per PR and the skill cannot know which applies. Use `AskUserQuestion` to ask which template to conform to, listing the filenames plus a "None — use the default structure" option. `Read` the chosen file in full and record its path and contents. If the user picks "None," record "no repository template."
+
+Carry the recorded result (the template path and full contents, or "no repository template") into Step 5. Preserve the template's HTML comments verbatim in what you carry forward — they often state how the template is meant to be used.
+
+## Step 3: Analyze Changes
 
 Review the branch diff, commits, and relevant source code to understand the PR. Identify the central mechanism — the primary purpose of the PR. If the PR is about feature flags, migrations, or behavioral changes, those ARE the point, not a side detail. Classify the change type (new feature, bug fix, refactoring, docs update, config change, etc.) and read related source files as needed to understand the full scope.
 
 When applicable (do not force these into every PR), collect specific details: feature flag gate names/values/interactions, actual config values per environment, before/after behavioral changes, migration phases/rollback/data flow, and state machine combinations.
 
-## Step 3: Determine "How this was tested" Applicability
+## Step 4: Determine "How this was tested" Applicability
 
 Inspect the changed files from `branch stats` and classify each by extension. Documentation files: `.md`, `.txt`, `.rst`, `.adoc`, `.rdoc`, `.textile`, `.wiki`, `.org`, `.asciidoc`, `.creole`, `.pod`, `.mediawiki`. Everything else is a code or configuration file. If ALL changed files are documentation → omit the "How this was tested" section. If ANY changed file is code or configuration → include the "How this was tested" section.
 
-## Step 4: Generate the PR Description
+## Step 5: Generate the PR Description
 
 Launch a single `han.core:junior-developer` agent to write the PR description directly. Junior-developer's fresh-reviewer perspective is the asset here: by authoring the description with the eyes of a teammate who lacks full project context, the result already anticipates what a reviewer needs to see, removing the need for a separate reviewer-context edit pass.
 
-Construct the agent prompt to include all of the following inline (the skill already has this context loaded — pass the actual values, not references):
+First, compose the **structure directive** based on the Step 2 result. The structure directive is the only part of the prompt that differs between the two cases; everything else is shared.
+
+- **Option A — no repository template** (Step 2 recorded "no repository template"). The structure directive is:
+  > **Structure (required):** Produce the description using this fixed structure and section order: Summary (with a `### Behavior changes` subsection only when runtime behavior changes) → What to look at first → How this was tested (only when included per the inclusion decision) → Files of interest → Test scenario changes (only if tests were added or edited). The first line under `## Summary` MUST be the bolded TL;DR sentence, before anything else is drafted. Include the `### Behavior changes` subsection only when runtime behavior changes (flag flips, migrations, state-machine edits, config changes, API contract changes); omit it for pure refactors and docs-only PRs; render interacting flags or modes as a small table.
+  >
+  > Default template to follow:
+  > {paste the contents of [template.md](references/template.md)}
+
+- **Option B — a repository template was found** (Step 2 recorded a template path and contents). The structure directive is:
+  > **Structure (required):** Conform to the repository's pull-request template, reproduced below, following the conformance rules exactly. The template's headings and their order are authoritative.
+  >
+  > Conformance rules:
+  > {paste the contents of [template-conformance.md](references/template-conformance.md)}
+  >
+  > Repository PR template ({template path from Step 2}):
+  > {paste the full contents of the discovered template, including its HTML comments}
+
+Then construct the agent prompt to include all of the following inline (the skill already has this context loaded — pass the actual values, not references):
 
 - **Branch context** — the values of `current branch`, `default branch`, `branch summary`, `branch stats`, and `branch changes` from the Project Context section.
-- **"How this was tested" inclusion decision from Step 3** — either "Include the How this was tested section" or "Omit the How this was tested section entirely (documentation-only PR)".
-- **Template** — paste the contents of [template.md](references/template.md) into the prompt so the agent does not need to read it.
+- **"How this was tested" inclusion decision from Step 4** — either "Include the How this was tested section" or "Omit the How this was tested section entirely (documentation-only PR)".
+- **Structure directive** — Option A or Option B as composed above.
 - **Formatting rules** — paste the contents of [formatting-rules.md](references/formatting-rules.md) into the prompt so the agent does not need to read it.
 
 Use this prompt body (with the context above interpolated):
 
 > "Author the pull-request description for this branch. This task repurposes your fresh-reviewer perspective for writing instead of reviewing: the audience is another human teammate reviewing on GitHub without full project context. Your job is to give them a behavioral mental model in roughly thirty seconds of scanning, then point them at where the interesting decisions live. Lead with plain human language about behavior and feature changes — not file-list mechanics. Do not produce a review report, question log, or findings — produce only the final PR description in markdown.
 >
-> **Section order (required):** Summary (with `### Behavior changes` subsection when applicable) → What to look at first → How this was tested (only when included per the inclusion decision below) → Files of interest → Test scenario changes (only if tests were added or edited).
->
-> **Summary section rules:**
-> - The first line under `## Summary` MUST be a single bolded TL;DR sentence in the form `**This PR <verb> <behavior>, so that <why>.**` — fill it before drafting anything else.
-> - Follow the TL;DR with 2-4 bullets covering user-visible or runtime behavior, scope, and reviewer-attention pointers. Do not list files in the Summary.
-> - Include a `### Behavior changes` subsection only when runtime behavior changes (flag flips, migrations, state-machine edits, config changes, API contract changes). Omit the subsection entirely for pure refactors and docs-only PRs. Use it for plain-language before/after narration; render flag/state interactions as a small table when multiple flags or modes interact.
+> Follow the structure directive below for how the description is organized and laid out. Follow the content rules below for what goes in it. When the structure directive provides a repository template, the template's structure wins over the default section names referenced in the content rules; map the content into the template's sections per the conformance rules.
 >
 > **Content rules across all sections:**
+> - Lead the primary summary or description section with a single bolded TL;DR sentence in the form `**This PR <verb> <behavior>, so that <why>.**` — fill it before drafting anything else.
+> - Follow the TL;DR with 2-4 bullets covering user-visible or runtime behavior, scope, and reviewer-attention pointers. Do not list files in the summary.
 > - Identify the central mechanism (feature flags, migrations, behavioral changes) from the diff and commits before drafting, and put it in the bolded TL;DR sentence.
 > - Include specific configuration values (environment settings, flag combinations, thresholds, defaults) — not "added config for X."
 > - Never over-summarize behavioral changes — code structure can be summarized, but runtime behavior cannot. Include per-environment values, migration phases, and flag enabled/disabled behavior.
 > - Explain how components work together, not just what each one does.
 > - Only describe changes unique to the PR branch — never include changes merged from the default branch.
 > - Do not rely on internal flag names, service names, or acronyms without a brief inline definition on first use.
-> - "What to look at first" is a 2-4 bullet attention guide pointing at decisions, tradeoffs, or risks — it is NOT a file list. The file list lives in "Files of interest" below.
-> - "How this was tested" uses past-tense author-self-check items prefixed with `- ✅` describing scenarios the author already verified. Do not use unchecked `[ ]` boxes. Items must be verifiable from the PR alone.
+> - "What to look at first" is a 2-4 bullet attention guide pointing at decisions, tradeoffs, or risks — it is NOT a file list. The file list lives in "Files of interest."
+> - "How this was tested" uses past-tense author-self-check items prefixed with `- ✅` describing scenarios the author already verified. Do not use unchecked `[ ]` boxes for these. Items must be verifiable from the PR alone.
 >
 > **Files of interest rules:** This section is a bulleted list of at most 5 entries — never a table, never more than 5. Each entry is `` `path` — one phrase about why this file matters for review ``. Skip generated files, mechanical refactors, trivial changes (imports, typos), and test helpers unless central. Do not add a "+N more files" continuation row — GitHub's Files Changed tab is one click away. Apply the truncation rules from the formatting rules below to paths longer than 50 characters.
 >
 > **Test scenario changes rules:** Behavioral scenarios only, in plain language. Do not include file paths in this section — test files (when central) appear in "Files of interest."
 >
-> **Formatting:** Never nest fenced code blocks inside the PR description — use inline backticks for short references, indented 4-space blocks for short snippets, prose descriptions, or small tables instead. Use `##`/`###` headers for sections. Do not leave HTML comments or template placeholder braces in the rendered output. Never include any form of 'Generated with Claude Code.'
+> **Formatting:** Never nest fenced code blocks inside the PR description — use inline backticks for short references, indented 4-space blocks for short snippets, prose descriptions, or small tables instead. Use `##`/`###` headers for sections. Do not leave authoring-instruction HTML comments or template placeholder braces in the rendered output. Never include any form of 'Generated with Claude Code.'
 >
-> **Test Plan inclusion decision (controls the "How this was tested" section):** {value from Step 3 — "Include the How this was tested section" or "Omit the How this was tested section entirely (documentation-only PR)"}
+> **Test Plan inclusion decision (controls the "How this was tested" section):** {value from Step 4 — "Include the How this was tested section" or "Omit the How this was tested section entirely (documentation-only PR)"}
+>
+> **Structure directive:** {Option A or Option B from above}
 >
 > **Branch context:**
 > - Current branch: {current branch}
@@ -95,9 +132,6 @@ Use this prompt body (with the context above interpolated):
 > - Diff:
 > {branch changes}
 >
-> **Template:**
-> {contents of references/template.md}
->
 > **Formatting rules:**
 > {contents of references/formatting-rules.md}
 >
@@ -105,20 +139,26 @@ Use this prompt body (with the context above interpolated):
 
 If the agent returns anything other than a PR description (a review report, question log, etc.), discard it and re-issue the prompt with an explicit reminder to return only the description text.
 
-## Step 5: Verify the PR Description
+## Step 6: Verify the PR Description
 
-Before displaying the PR description, read it back and confirm:
+Before displaying the PR description, read it back and confirm. Use the checklist that matches the Step 2 result.
 
-1. The first line under `## Summary` is a single bolded TL;DR sentence leading with behavior. No file lists in the Summary.
-2. Sections appear in the required order: Summary (with `### Behavior changes` subsection when applicable) → What to look at first → How this was tested (when included) → Files of interest → Test scenario changes (when included). "How this was tested" inclusion/omission matches Step 3.
-3. "Files of interest" is a bulleted list with 5 or fewer entries — never a table, no "+N more files" continuation row. Paths >50 chars are truncated per the formatting rules.
-4. "What to look at first" is an attention guide of 2-4 bullets pointing at decisions or risks — not a file list.
-5. "How this was tested" items use past-tense `- ✅` markers (not unchecked `[ ]` boxes). "Test scenario changes" contains behavioral scenarios in plain language with no file paths.
-6. Valid markdown, no nested fenced code blocks, no leftover HTML comments or template placeholder braces (`{...}`), no "Generated with Claude Code."
-7. Only branch-specific changes described.
-8. Fix any issues directly before proceeding to Step 6.
+**Always confirm (both cases):**
 
-## Step 6: Display and Update PR
+1. The primary summary or description section opens with a single bolded TL;DR sentence leading with behavior. No file lists in that section.
+2. "Files of interest" (wherever it lands) is a bulleted list with 5 or fewer entries — never a table, no "+N more files" continuation row. Paths >50 chars are truncated per the formatting rules.
+3. "What to look at first" is an attention guide of 2-4 bullets pointing at decisions or risks — not a file list.
+4. "How this was tested" inclusion/omission matches Step 4. When included, its items use past-tense `- ✅` markers. "Test scenario changes" contains behavioral scenarios in plain language with no file paths.
+5. Valid markdown, no nested fenced code blocks, no leftover authoring-instruction HTML comments or template placeholder braces (`{...}`), no "Generated with Claude Code."
+6. Only branch-specific changes described.
+
+**When Step 2 recorded "no repository template" (Option A), also confirm:** the sections appear in the fixed order — Summary (with `### Behavior changes` subsection when applicable) → What to look at first → How this was tested (when included) → Files of interest → Test scenario changes (when included).
+
+**When Step 2 found a repository template (Option B), also confirm:** unless the template was a replace-scaffold per the conformance rules, every heading the template defines is present and in the template's original order; "What to look at first" and "Files of interest" appear only as appended sections after the template's sections (or filled into an equivalent the template already had), never interleaved out of order; the template's checklists are reproduced verbatim with only diff-provable boxes checked and no fabricated attestations; the template's instructional comments and placeholder prompts are stripped from the output.
+
+Fix any issues directly before proceeding to Step 7.
+
+## Step 7: Display and Update PR
 
 1. **Display the PR description** — Show the full result to the user, parsed and formatted for display.
 

--- a/han.github/skills/update-pr-description/references/formatting-rules.md
+++ b/han.github/skills/update-pr-description/references/formatting-rules.md
@@ -1,6 +1,6 @@
 ## File Path Truncation
 
-When displaying file paths in tables, truncate paths longer than 50 characters: keep the first path segment, add `/...`, then fill remaining characters from the end to produce a 45-50 character result. Never include the character count in the output.
+When displaying file paths (in a bulleted list or a table), truncate paths longer than 50 characters: keep the first path segment, add `/...`, then fill remaining characters from the end to produce a 45-50 character result. Never include the character count in the output.
 
 Example: `ui/src/pages/GearDetails/components/GearInfo/GearInfoContentFields/GearInfoContentFieldsReorderable.tsx` → `ui/...fo/GearInfoContentFieldsReorderable.tsx`
 

--- a/han.github/skills/update-pr-description/references/template-conformance.md
+++ b/han.github/skills/update-pr-description/references/template-conformance.md
@@ -1,0 +1,33 @@
+# Conforming to a repository PR template
+
+The repository ships its own pull-request template. The final description must read as that template, filled in — not a generic description bolted on top. The template's headings and their order are authoritative. Do not assume any particular template shape; infer the structure and intent from the template you are given.
+
+## 1. Read the whole template, including HTML comments
+
+Comments often carry the repo's authoring instructions: what each section is for, what to delete, whether to replace the scaffold entirely. Treat those comments as guidance while drafting, then strip every authoring-instruction comment and placeholder prompt from the final output. The rendered description must not contain the template's instructional comments, `<describe here>`-style prompts, or leftover placeholder braces.
+
+## 2. Determine the template's intent
+
+- **Replace-scaffold.** If the template (or a comment in it) instructs the author to replace its content with a written PR description — for example, "replace this content with a generated PR description" — it is a throwaway scaffold, not a structure to preserve. Discard the scaffold and produce the default structure instead: Summary (bolded TL;DR sentence + 2-4 bullets, plus a `### Behavior changes` subsection when runtime behavior changes) → What to look at first → How this was tested (only when the inclusion decision includes it) → Files of interest → Test scenario changes (only when tests were added or edited). Honoring the instruction is the point.
+- **Structural template.** Otherwise, the template's sections are the structure. Keep its headings and their order, and fill each section with the matching content below.
+
+## 3. Map content into the template's sections
+
+For each template section, infer its purpose from its heading and any placeholder text, then fill it:
+
+- A description / summary / "what does this PR do" section gets the bolded TL;DR sentence (`**This PR <verb> <behavior>, so that <why>.**`) followed by the behavioral summary bullets.
+- A motivation / "why" / context section gets the rationale.
+- A testing / "how was this tested" / QA section gets the `- ✅` past-tense self-check items — but only when the inclusion decision includes them. When the decision omits them (documentation-only branch), write a short honest note in the template's tone (for example, "Documentation-only change; no tests.") rather than leaving the section blank.
+- Before/after behavioral detail goes in the section closest to a description or details section, rendered as a small table when multiple flags or modes interact.
+
+## 4. Checkboxes: check only what the diff unambiguously proves
+
+Many templates carry checklists. Check a box only when the branch diff unambiguously proves it (for example, tests were added → check "I added tests"; documentation was updated → check "I updated the docs"). Leave every box the diff cannot prove unchecked: attestations of human action ("I have read the contributing guide", "I tested this manually in staging", "I requested review from the right team") are the author's to make. Never fabricate one. When in doubt, leave the box unchecked. Reproduce the full checklist verbatim either way, never dropping items.
+
+## 5. Add high-value sections only when the template has no home for them
+
+The reviewer attention guide ("What to look at first") and "Files of interest" earn their place in any review. If the template already has an equivalent section (a "Reviewer notes", "Files changed", or similar), fill that instead of adding a duplicate. If the template has no equivalent, append each as its own `##` section after the template's sections — never interleaved out of the template's order.
+
+## 6. Additional information is welcome; structure is not optional
+
+You may add detail beyond what the template asks for, but every section the template defines must remain present and in its original order. Do not silently drop a template section because there is nothing to say. Fill it, or write a short honest note ("Not applicable: this PR changes documentation only."). The template's structure is the contract; your content is the fill.


### PR DESCRIPTION
## Summary

**This PR teaches `/update-pr-description` to detect a repository's own GitHub pull-request template and conform its output to that template's structure, so that generated descriptions read as the repo's template filled in rather than a generic shape bolted on top.**

- Before this change, the skill always emitted one fixed section order (Summary → What to look at first → How this was tested → Files of interest → Test scenario changes). Now it first looks for a repo PR template; if it finds one, the template's headings and their order become authoritative and the generated content maps into them.
- Template discovery searches GitHub's supported locations: repo root, `.github/`, `docs/`, and any `PULL_REQUEST_TEMPLATE/` subdirectory, matching both common filename casings and both `.md` and `.txt`. No template found means the old default structure still applies, so existing behavior is unchanged for repos without a template.
- Template handling reads intent, not just shape. A scaffold template whose HTML comment says "replace this content" is discarded wholesale and replaced with the default structure; a structural template has its sections preserved and filled. Checklist boxes are checked only when the diff unambiguously proves them (tests added, docs updated); attestations of human action are left unchecked. When a `PULL_REQUEST_TEMPLATE/` directory holds multiple templates, the skill asks which one to use.
- This is a documentation and skill-definition change only. No runtime/product code paths change; the skill itself is markdown-defined.

## What to look at first

- The conformance contract in the new `template-conformance.md` reference: the replace-scaffold-vs-structural distinction (rule 2) and the checkbox rule (rule 4, "check only what the diff unambiguously proves") are the load-bearing decisions a reviewer should sanity-check.
- The new Step 2 (template discovery) and the Option A / Option B branch in Step 5 of `SKILL.md`: confirm the glob locations cover GitHub's real precedence and that the single-template / multiple-template / no-template paths each resolve cleanly.
- The step renumbering ripple: the old six-step process became seven steps. Worth confirming every cross-reference to a step number was updated (the second commit fixes one stale reference in the Cost and latency section).

## Files of interest

- `han.github/skills/update-pr-description/SKILL.md` — the behavior change: new discovery step, the structure-directive composition, and the renumbered seven-step process.
- `.../update-pr-description/references/template-conformance.md` — new file; the full conformance rules the agent follows when a template exists.
- `docs/skills/update-pr-description.md` — operator-facing doc updated for template awareness and the new step count.
- `.../update-pr-description/references/formatting-rules.md` — path-truncation rule widened to cover bulleted lists, not just tables.
- `docs/skills/README.md` — one-line scent update for the skill's index entry.

## Test scenario changes

No tests were added or changed; this branch updates a markdown-defined skill and its documentation only.