### PR TITLE
Clarify skill invocation model in concepts.md (#54)

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -6,7 +6,7 @@ Han is built out of two kinds of things: **skills** and **agents**. If you read 
 
 ## TL;DR
 
-- A **skill** is a deterministic process you run with a slash command (like `/code-review`). Think: flowchart.
+- A **skill** is a deterministic process you usually run with a slash command (like `/code-review`), though Claude can also auto-invoke it when your request matches the skill's description. Think: flowchart.
 - An **agent** is a specialist persona with judgment, dispatched by a skill or by you (like `adversarial-security-analyst`). Think: teammate.
 - Skills dispatch agents. The skill follows its flowchart, sends the agent off to do a judgment-heavy subtask (investigate a bug, review architecture, critique a plan), then folds the finding back into its output.
 - **Sizing** decides how many agents get dispatched. The skills that fan out to a swarm classify the work as small, medium, or large first, default to small, and scale the team and the iteration depth from there. See [Sizing](./sizing.md) for the full model.
@@ -19,9 +19,10 @@ That is the whole model. Everything else is vocabulary.
 
 ## Skills: the process layer
 
-A skill is a fixed sequence of steps that Claude Code runs when you type its slash command.
+A skill is a fixed sequence of steps that Claude Code runs. Typing the slash command is the primary way to trigger it, but not the only one.
 
-- You invoke it: `/code-review`, `/plan-a-feature`, `/investigate`.
+- You invoke it: `/code-review`, `/plan-a-feature`, `/investigate`. This is the deliberate, primary path.
+- Claude may also auto-invoke it. Skill descriptions are written to match user intent, so a request like "can you make sure this code is solid?" can route into `/code-review` without you typing the command. This is on by default (the frontmatter field `disable-model-invocation` defaults to `false`); no Han skill turns it off. Either way the skill runs the same protocol.
 - It follows a defined protocol. Every reader who runs the same skill gets the same shape of output.
 - It is documented by a `SKILL.md` file inside `han.core/skills/{name}/` (or `han.github/skills/{name}/` for the GitHub skills).
 - It may dispatch one or more agents for the steps that need judgment.


### PR DESCRIPTION
## Summary

**This PR documents that Han skills can auto-invoke from natural-language requests (not just slash commands), so that readers understand the slash command is the primary trigger but not the only one.**

- Updates `docs/concepts.md` to explain that Claude can route a plain-language request like "can you make sure this code is solid?" into a skill such as `/code-review` without the user typing the command, because skill descriptions are written to match user intent.
- States the exact mechanism: auto-invocation is on by default via the `disable-model-invocation` frontmatter field defaulting to `false`, and no Han skill turns it off. Either trigger path runs the same protocol.
- Documentation-only, single-file change. Reviewer attention should go to whether the described default and field name match how skills actually behave, since this is a factual claim about skill invocation.

## What to look at first

- Verify the factual claim: the doc states `disable-model-invocation` defaults to `false` and that no Han skill sets it to `true`. Worth a quick check against the skill frontmatter to confirm the doc matches reality.
- Tone and accuracy of the "primary path vs. auto-invoke" framing. The doc deliberately keeps the slash command as the primary, deliberate path while introducing auto-invocation as a secondary one. Confirm that emphasis reads correctly for an operator audience.

## Files of interest

- `docs/concepts.md` — the only changed file; adds the auto-invocation explanation and the `disable-model-invocation` default to the skill model.