### PR TITLE
Support Codex marketplace

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "plugins": [
     {
-      "name": "han.core",
+      "name": "han-core",
       "source": {
         "source": "local",
         "path": "./han.core"
@@ -17,7 +17,7 @@
       "category": "Developer Tools"
     },
     {
-      "name": "han.planning",
+      "name": "han-planning",
       "source": {
         "source": "local",
         "path": "./han.planning"
@@ -29,7 +29,7 @@
       "category": "Developer Tools"
     },
     {
-      "name": "han.coding",
+      "name": "han-coding",
       "source": {
         "source": "local",
         "path": "./han.coding"
@@ -41,7 +41,7 @@
       "category": "Developer Tools"
     },
     {
-      "name": "han.github",
+      "name": "han-github",
       "source": {
         "source": "local",
         "path": "./han.github"
@@ -53,7 +53,7 @@
       "category": "Developer Tools"
     },
     {
-      "name": "han.reporting",
+      "name": "han-reporting",
       "source": {
         "source": "local",
         "path": "./han.reporting"
@@ -65,7 +65,7 @@
       "category": "Developer Tools"
     },
     {
-      "name": "han.feedback",
+      "name": "han-feedback",
       "source": {
         "source": "local",
         "path": "./han.feedback"
@@ -77,7 +77,7 @@
       "category": "Developer Tools"
     },
     {
-      "name": "han.atlassian",
+      "name": "han-atlassian",
       "source": {
         "source": "local",
         "path": "./han.atlassian"
@@ -89,7 +89,7 @@
       "category": "Developer Tools"
     },
     {
-      "name": "han.plugin-builder",
+      "name": "han-plugin-builder",
       "source": {
         "source": "local",
         "path": "./han.plugin-builder"

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,104 @@
+{
+  "name": "han",
+  "interface": {
+    "displayName": "Han"
+  },
+  "plugins": [
+    {
+      "name": "han.core",
+      "source": {
+        "source": "local",
+        "path": "./han.core"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "han.planning",
+      "source": {
+        "source": "local",
+        "path": "./han.planning"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "han.coding",
+      "source": {
+        "source": "local",
+        "path": "./han.coding"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "han.github",
+      "source": {
+        "source": "local",
+        "path": "./han.github"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "han.reporting",
+      "source": {
+        "source": "local",
+        "path": "./han.reporting"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "han.feedback",
+      "source": {
+        "source": "local",
+        "path": "./han.feedback"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "han.atlassian",
+      "source": {
+        "source": "local",
+        "path": "./han.atlassian"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "han.plugin-builder",
+      "source": {
+        "source": "local",
+        "path": "./han.plugin-builder"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ does not use that Claude-only dependency metadata, so install the
 resource-bearing Han packages directly:
 
 ```
-codex plugin add han.core@han
-codex plugin add han.planning@han
-codex plugin add han.coding@han
-codex plugin add han.github@han
-codex plugin add han.reporting@han
+codex plugin add han-core@han
+codex plugin add han-planning@han
+codex plugin add han-coding@han
+codex plugin add han-github@han
+codex plugin add han-reporting@han
 ```
 
-Install `han.feedback`, `han.atlassian`, or `han.plugin-builder` separately
+Install `han-feedback`, `han-atlassian`, or `han-plugin-builder` separately
 when you want those opt-in packages.
 
 Han ships as multiple plugins:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,30 @@ Add the Test Double skills marketplace to Claude Code, then install the plugin:
 /plugin install han@han
 ```
 
+### Codex
+
+Han also ships a Codex marketplace file at `.agents/plugins/marketplace.json`.
+Add this repo as a Codex marketplace:
+
+```
+codex plugin marketplace add oppegard/han
+```
+
+Claude Code resolves the `han` meta-plugin dependencies automatically. Codex
+does not use that Claude-only dependency metadata, so install the
+resource-bearing Han packages directly:
+
+```
+codex plugin add han.core@han
+codex plugin add han.planning@han
+codex plugin add han.coding@han
+codex plugin add han.github@han
+codex plugin add han.reporting@han
+```
+
+Install `han.feedback`, `han.atlassian`, or `han.plugin-builder` separately
+when you want those opt-in packages.
+
 Han ships as multiple plugins:
 
 | Plugin | Type | What it brings |

--- a/README.md
+++ b/README.md
@@ -28,36 +28,14 @@ Han's positioning and what it does not bring to the table.
 
 ## Installation
 
+## Claude Code
+
 Add the Test Double skills marketplace to Claude Code, then install the plugin:
 
 ```
 /plugin marketplace add testdouble/han
 /plugin install han@han
 ```
-
-### Codex
-
-Han also ships a Codex marketplace file at `.agents/plugins/marketplace.json`.
-Add this repo as a Codex marketplace:
-
-```
-codex plugin marketplace add oppegard/han
-```
-
-Claude Code resolves the `han` meta-plugin dependencies automatically. Codex
-does not use that Claude-only dependency metadata, so install the
-resource-bearing Han packages directly:
-
-```
-codex plugin add han-core@han
-codex plugin add han-planning@han
-codex plugin add han-coding@han
-codex plugin add han-github@han
-codex plugin add han-reporting@han
-```
-
-Install `han-feedback`, `han-atlassian`, or `han-plugin-builder` separately
-when you want those opt-in packages.
 
 Han ships as multiple plugins:
 
@@ -79,6 +57,27 @@ not want the planning, coding, GitHub, or reporting skills, install `han.core@ha
 specific plugins as desired.
 
 For the full picture and a quick "which one do you need?" guide, see [Choosing a Han plugin](./docs/choosing-a-han-plugin.md).
+
+### Codex
+
+Add this repo as a Codex marketplace:
+
+```
+codex plugin marketplace add oppegard/han
+```
+
+Codex does not yet support meta-plugins like `han@han` (see openai/codex#23531,) so install the Han packages directly:
+
+```
+codex plugin add han-core@han
+codex plugin add han-planning@han
+codex plugin add han-coding@han
+codex plugin add han-github@han
+codex plugin add han-reporting@han
+```
+
+Install `han-feedback`, `han-atlassian`, or `han-plugin-builder` separately
+when you want those opt-in packages.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For the full picture and a quick "which one do you need?" guide, see [Choosing a
 Add this repo as a Codex marketplace:
 
 ```
-codex plugin marketplace add oppegard/han
+codex plugin marketplace add testdouble/han
 ```
 
 Codex does not yet support meta-plugins like `han@han` (see openai/codex#23531,) so install the Han packages directly:

--- a/han.atlassian/.codex-plugin/plugin.json
+++ b/han.atlassian/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "han.atlassian",
+  "name": "han-atlassian",
   "version": "1.1.0",
   "description": "Atlassian-facing Han skills for publishing Markdown and plans to Confluence and Jira.",
   "author": {

--- a/han.atlassian/.codex-plugin/plugin.json
+++ b/han.atlassian/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "han.atlassian",
+  "version": "1.1.0",
+  "description": "Atlassian-facing Han skills for publishing Markdown and plans to Confluence and Jira.",
+  "author": {
+    "name": "Test Double",
+    "url": "https://testdouble.com"
+  },
+  "homepage": "https://github.com/oppegard/han#readme",
+  "repository": "https://github.com/oppegard/han",
+  "license": "MIT",
+  "keywords": ["han", "atlassian", "confluence", "jira", "documentation"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Han Atlassian",
+    "shortDescription": "Publish documentation to Confluence and work items to Jira.",
+    "longDescription": "Atlassian-facing Han skills for publishing Markdown and plans to Confluence and work items to Jira.",
+    "developerName": "Test Double",
+    "category": "Developer Tools",
+    "capabilities": ["Skills"],
+    "websiteURL": "https://github.com/oppegard/han",
+    "defaultPrompt": [
+      "Publish this Markdown to Confluence.",
+      "Create Jira tickets from work items.",
+      "Plan a feature and publish it."
+    ]
+  }
+}

--- a/han.atlassian/.codex-plugin/plugin.json
+++ b/han.atlassian/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Test Double",
     "url": "https://testdouble.com"
   },
-  "homepage": "https://github.com/oppegard/han#readme",
-  "repository": "https://github.com/oppegard/han",
+  "homepage": "https://github.com/testdouble/han#readme",
+  "repository": "https://github.com/testdouble/han",
   "license": "MIT",
   "keywords": ["han", "atlassian", "confluence", "jira", "documentation"],
   "skills": "./skills/",
@@ -18,7 +18,7 @@
     "developerName": "Test Double",
     "category": "Developer Tools",
     "capabilities": ["Skills"],
-    "websiteURL": "https://github.com/oppegard/han",
+    "websiteURL": "https://github.com/testdouble/han",
     "defaultPrompt": [
       "Publish this Markdown to Confluence.",
       "Create Jira tickets from work items.",

--- a/han.atlassian/skills/markdown-to-confluence/SKILL.md
+++ b/han.atlassian/skills/markdown-to-confluence/SKILL.md
@@ -8,7 +8,7 @@ description: >
   file, or use project-documentation-to-confluence for the document-then-publish flow, or
   plan-a-feature-to-confluence for the plan-then-publish flow. Does not publish to Jira — use
   work-items-to-jira.
-argument-hint: [path to markdown file] [confluence location: page URL or space + parent] [--mode draft|live (default draft)]
+argument-hint: "[path to markdown file] [confluence location: page URL or space + parent] [--mode draft|live (default draft)]"
 allowed-tools: Read, Glob, Grep, Bash(find *), mcp__claude_ai_Atlassian__getAccessibleAtlassianResources, mcp__claude_ai_Atlassian__atlassianUserInfo, mcp__claude_ai_Atlassian__getConfluenceSpaces, mcp__claude_ai_Atlassian__getConfluencePage, mcp__claude_ai_Atlassian__getPagesInConfluenceSpace, mcp__claude_ai_Atlassian__getConfluencePageDescendants, mcp__claude_ai_Atlassian__createConfluencePage, mcp__claude_ai_Atlassian__updateConfluencePage
 ---
 

--- a/han.atlassian/skills/project-documentation-to-confluence/SKILL.md
+++ b/han.atlassian/skills/project-documentation-to-confluence/SKILL.md
@@ -10,7 +10,7 @@ description: >
   plan-a-feature-to-confluence for that. Does not create architectural decision records — use
   architectural-decision-record. Does not create coding standards — use coding-standard. Does not
   produce runbooks — use runbook.
-argument-hint: [feature-name or doc-path] [confluence location: page URL or space + parent]
+argument-hint: "[feature-name or doc-path] [confluence location: page URL or space + parent]"
 allowed-tools: Read, Glob, Grep, Skill, Agent, Bash(date *), Bash(git config *), Bash(whoami), Bash(mkdir *), Bash(find *), mcp__claude_ai_Atlassian__getAccessibleAtlassianResources
 ---
 

--- a/han.atlassian/skills/work-items-to-jira/SKILL.md
+++ b/han.atlassian/skills/work-items-to-jira/SKILL.md
@@ -7,7 +7,7 @@ description: >
   be worked on and tracked in Jira. Requires a configured Atlassian MCP server. Does not produce
   the work-items file itself — use plan-work-items to break a plan into work items first. Does not
   post to GitHub — use work-items-to-issues for GitHub issues.
-argument-hint: [path to work-items.md] [--project <KEY> or --board <name>] [--parent <KEY> epic or story (optional; --epic is a deprecated alias)] [--type <issue type, default Story>] [--assignee <accountId/email> (optional)] [--column <name, default Backlog>]
+argument-hint: "[path to work-items.md] [--project <KEY> or --board <name>] [--parent <KEY> epic or story (optional; --epic is a deprecated alias)] [--type <issue type, default Story>] [--assignee <accountId/email> (optional)] [--column <name, default Backlog>]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), mcp__claude_ai_Atlassian__getAccessibleAtlassianResources, mcp__claude_ai_Atlassian__atlassianUserInfo, mcp__claude_ai_Atlassian__getVisibleJiraProjects, mcp__claude_ai_Atlassian__getJiraProjectIssueTypesMetadata, mcp__claude_ai_Atlassian__lookupJiraAccountId, mcp__claude_ai_Atlassian__createJiraIssue, mcp__claude_ai_Atlassian__editJiraIssue, mcp__claude_ai_Atlassian__getJiraIssue, mcp__claude_ai_Atlassian__getTransitionsForJiraIssue, mcp__claude_ai_Atlassian__transitionJiraIssue, mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql
 ---
 

--- a/han.coding/.codex-plugin/plugin.json
+++ b/han.coding/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "han.coding",
+  "name": "han-coding",
   "version": "1.0.0",
   "description": "Coding-facing skills for writing, reviewing, testing, investigating, and refactoring code.",
   "author": {

--- a/han.coding/.codex-plugin/plugin.json
+++ b/han.coding/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Test Double",
     "url": "https://testdouble.com"
   },
-  "homepage": "https://github.com/oppegard/han#readme",
-  "repository": "https://github.com/oppegard/han",
+  "homepage": "https://github.com/testdouble/han#readme",
+  "repository": "https://github.com/testdouble/han",
   "license": "MIT",
   "keywords": ["han", "coding", "tdd", "code-review", "refactoring"],
   "skills": "./skills/",
@@ -18,7 +18,7 @@
     "developerName": "Test Double",
     "category": "Developer Tools",
     "capabilities": ["Skills"],
-    "websiteURL": "https://github.com/oppegard/han",
+    "websiteURL": "https://github.com/testdouble/han",
     "defaultPrompt": [
       "Build this behavior test-first.",
       "Review my current branch with Han.",

--- a/han.coding/.codex-plugin/plugin.json
+++ b/han.coding/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "han.coding",
+  "version": "1.0.0",
+  "description": "Coding-facing skills for writing, reviewing, testing, investigating, and refactoring code.",
+  "author": {
+    "name": "Test Double",
+    "url": "https://testdouble.com"
+  },
+  "homepage": "https://github.com/oppegard/han#readme",
+  "repository": "https://github.com/oppegard/han",
+  "license": "MIT",
+  "keywords": ["han", "coding", "tdd", "code-review", "refactoring"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Han Coding",
+    "shortDescription": "TDD, review, investigation, refactoring, and test planning.",
+    "longDescription": "Coding-facing skills for writing, reviewing, testing, investigating, refactoring, and standardizing code.",
+    "developerName": "Test Double",
+    "category": "Developer Tools",
+    "capabilities": ["Skills"],
+    "websiteURL": "https://github.com/oppegard/han",
+    "defaultPrompt": [
+      "Build this behavior test-first.",
+      "Review my current branch with Han.",
+      "Investigate this bug with Han."
+    ]
+  }
+}

--- a/han.core/.codex-plugin/plugin.json
+++ b/han.core/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "han.core",
+  "name": "han-core",
   "version": "1.2.0",
   "description": "Evidence-based research, architecture, and documentation skills for software projects.",
   "author": {

--- a/han.core/.codex-plugin/plugin.json
+++ b/han.core/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "han.core",
+  "version": "1.2.0",
+  "description": "Evidence-based research, architecture, and documentation skills for software projects.",
+  "author": {
+    "name": "Test Double",
+    "url": "https://testdouble.com"
+  },
+  "homepage": "https://github.com/oppegard/han#readme",
+  "repository": "https://github.com/oppegard/han",
+  "license": "MIT",
+  "keywords": ["han", "research", "architecture", "documentation"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Han Core",
+    "shortDescription": "Research, architecture, documentation, and core Han guidance.",
+    "longDescription": "Evidence-based research, architecture, and documentation skills for software projects, plus the specialist agent instructions the rest of Han uses.",
+    "developerName": "Test Double",
+    "category": "Developer Tools",
+    "capabilities": ["Skills"],
+    "websiteURL": "https://github.com/oppegard/han",
+    "defaultPrompt": [
+      "Research an implementation approach with Han.",
+      "Create project documentation with Han.",
+      "Analyze gaps between two artifacts."
+    ]
+  }
+}

--- a/han.core/.codex-plugin/plugin.json
+++ b/han.core/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Test Double",
     "url": "https://testdouble.com"
   },
-  "homepage": "https://github.com/oppegard/han#readme",
-  "repository": "https://github.com/oppegard/han",
+  "homepage": "https://github.com/testdouble/han#readme",
+  "repository": "https://github.com/testdouble/han",
   "license": "MIT",
   "keywords": ["han", "research", "architecture", "documentation"],
   "skills": "./skills/",
@@ -18,7 +18,7 @@
     "developerName": "Test Double",
     "category": "Developer Tools",
     "capabilities": ["Skills"],
-    "websiteURL": "https://github.com/oppegard/han",
+    "websiteURL": "https://github.com/testdouble/han",
     "defaultPrompt": [
       "Research an implementation approach with Han.",
       "Create project documentation with Han.",

--- a/han.feedback/.codex-plugin/plugin.json
+++ b/han.feedback/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "han.feedback",
+  "name": "han-feedback",
   "version": "1.1.1",
   "description": "Post-session feedback skill for capturing structured observations about Han skill runs.",
   "author": {

--- a/han.feedback/.codex-plugin/plugin.json
+++ b/han.feedback/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "han.feedback",
+  "version": "1.1.1",
+  "description": "Post-session feedback skill for capturing structured observations about Han skill runs.",
+  "author": {
+    "name": "Test Double",
+    "url": "https://testdouble.com"
+  },
+  "homepage": "https://github.com/oppegard/han#readme",
+  "repository": "https://github.com/oppegard/han",
+  "license": "MIT",
+  "keywords": ["han", "feedback", "skills", "issues"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Han Feedback",
+    "shortDescription": "Capture structured feedback after Han skill runs.",
+    "longDescription": "Post-session feedback skill for capturing structured observations and improvement ideas about Han skill runs.",
+    "developerName": "Test Double",
+    "category": "Developer Tools",
+    "capabilities": ["Skills"],
+    "websiteURL": "https://github.com/oppegard/han",
+    "defaultPrompt": [
+      "Capture feedback on this Han run.",
+      "Write Han feedback as an issue.",
+      "Record what worked and what did not."
+    ]
+  }
+}

--- a/han.feedback/.codex-plugin/plugin.json
+++ b/han.feedback/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Test Double",
     "url": "https://testdouble.com"
   },
-  "homepage": "https://github.com/oppegard/han#readme",
-  "repository": "https://github.com/oppegard/han",
+  "homepage": "https://github.com/testdouble/han#readme",
+  "repository": "https://github.com/testdouble/han",
   "license": "MIT",
   "keywords": ["han", "feedback", "skills", "issues"],
   "skills": "./skills/",
@@ -18,7 +18,7 @@
     "developerName": "Test Double",
     "category": "Developer Tools",
     "capabilities": ["Skills"],
-    "websiteURL": "https://github.com/oppegard/han",
+    "websiteURL": "https://github.com/testdouble/han",
     "defaultPrompt": [
       "Capture feedback on this Han run.",
       "Write Han feedback as an issue.",

--- a/han.github/.codex-plugin/plugin.json
+++ b/han.github/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "han.github",
+  "name": "han-github",
   "version": "1.2.0",
   "description": "GitHub-facing Han skills for PR descriptions, code review comments, and publishing issues.",
   "author": {

--- a/han.github/.codex-plugin/plugin.json
+++ b/han.github/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Test Double",
     "url": "https://testdouble.com"
   },
-  "homepage": "https://github.com/oppegard/han#readme",
-  "repository": "https://github.com/oppegard/han",
+  "homepage": "https://github.com/testdouble/han#readme",
+  "repository": "https://github.com/testdouble/han",
   "license": "MIT",
   "keywords": ["han", "github", "pull-requests", "issues", "code-review"],
   "skills": "./skills/",
@@ -18,7 +18,7 @@
     "developerName": "Test Double",
     "category": "Developer Tools",
     "capabilities": ["Skills"],
-    "websiteURL": "https://github.com/oppegard/han",
+    "websiteURL": "https://github.com/testdouble/han",
     "defaultPrompt": [
       "Update this PR description.",
       "Post this review to my PR.",

--- a/han.github/.codex-plugin/plugin.json
+++ b/han.github/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "han.github",
+  "version": "1.2.0",
+  "description": "GitHub-facing Han skills for PR descriptions, code review comments, and publishing issues.",
+  "author": {
+    "name": "Test Double",
+    "url": "https://testdouble.com"
+  },
+  "homepage": "https://github.com/oppegard/han#readme",
+  "repository": "https://github.com/oppegard/han",
+  "license": "MIT",
+  "keywords": ["han", "github", "pull-requests", "issues", "code-review"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Han GitHub",
+    "shortDescription": "PR description, PR review, and issue publishing skills.",
+    "longDescription": "GitHub-facing Han skills for PR descriptions, code review comments, and publishing work items as issues.",
+    "developerName": "Test Double",
+    "category": "Developer Tools",
+    "capabilities": ["Skills"],
+    "websiteURL": "https://github.com/oppegard/han",
+    "defaultPrompt": [
+      "Update this PR description.",
+      "Post this review to my PR.",
+      "Publish these work items as issues."
+    ]
+  }
+}

--- a/han.github/skills/work-items-to-issues/SKILL.md
+++ b/han.github/skills/work-items-to-issues/SKILL.md
@@ -7,7 +7,7 @@ description: >
   can be worked on and tracked on GitHub. Does not produce the work-items file itself — use
   plan-work-items to break a plan into work items first. Does not review code or post pull request
   comments — use post-code-review-to-pr for that.
-argument-hint: [path to work-items.md] [target repo(s), e.g. org/repo] [--label <name> (optional)] [--assignee <user> (optional)]
+argument-hint: "[path to work-items.md] [target repo(s), e.g. org/repo] [--label <name> (optional)] [--assignee <user> (optional)]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(gh *), Bash(git *), Bash(find *)
 ---
 

--- a/han.planning/.codex-plugin/plugin.json
+++ b/han.planning/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "han.planning",
+  "name": "han-planning",
   "version": "1.0.0",
   "description": "Planning-facing skills for specifying, sequencing, and stress-testing work before implementation.",
   "author": {

--- a/han.planning/.codex-plugin/plugin.json
+++ b/han.planning/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "han.planning",
+  "version": "1.0.0",
+  "description": "Planning-facing skills for specifying, sequencing, and stress-testing work before implementation.",
+  "author": {
+    "name": "Test Double",
+    "url": "https://testdouble.com"
+  },
+  "homepage": "https://github.com/oppegard/han#readme",
+  "repository": "https://github.com/oppegard/han",
+  "license": "MIT",
+  "keywords": ["han", "planning", "feature-specification", "implementation-plan"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Han Planning",
+    "shortDescription": "Feature planning and implementation planning skills.",
+    "longDescription": "Planning-facing skills for specifying, planning, sequencing, breaking down, and stress-testing work before implementation.",
+    "developerName": "Test Double",
+    "category": "Developer Tools",
+    "capabilities": ["Skills"],
+    "websiteURL": "https://github.com/oppegard/han",
+    "defaultPrompt": [
+      "Plan a feature with Han.",
+      "Turn a spec into an implementation plan.",
+      "Break this plan into work items."
+    ]
+  }
+}

--- a/han.planning/.codex-plugin/plugin.json
+++ b/han.planning/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Test Double",
     "url": "https://testdouble.com"
   },
-  "homepage": "https://github.com/oppegard/han#readme",
-  "repository": "https://github.com/oppegard/han",
+  "homepage": "https://github.com/testdouble/han#readme",
+  "repository": "https://github.com/testdouble/han",
   "license": "MIT",
   "keywords": ["han", "planning", "feature-specification", "implementation-plan"],
   "skills": "./skills/",
@@ -18,7 +18,7 @@
     "developerName": "Test Double",
     "category": "Developer Tools",
     "capabilities": ["Skills"],
-    "websiteURL": "https://github.com/oppegard/han",
+    "websiteURL": "https://github.com/testdouble/han",
     "defaultPrompt": [
       "Plan a feature with Han.",
       "Turn a spec into an implementation plan.",

--- a/han.plugin-builder/.codex-plugin/plugin.json
+++ b/han.plugin-builder/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "han.plugin-builder",
+  "name": "han-plugin-builder",
   "version": "1.1.0",
   "description": "Guidance and tooling for building Han-compatible skills, agents, and plugins.",
   "author": {

--- a/han.plugin-builder/.codex-plugin/plugin.json
+++ b/han.plugin-builder/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "han.plugin-builder",
+  "version": "1.1.0",
+  "description": "Guidance and tooling for building Han-compatible skills, agents, and plugins.",
+  "author": {
+    "name": "Test Double",
+    "url": "https://testdouble.com"
+  },
+  "homepage": "https://github.com/oppegard/han#readme",
+  "repository": "https://github.com/oppegard/han",
+  "license": "MIT",
+  "keywords": ["han", "plugin-builder", "skills", "agents", "guidance"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Han Plugin Builder",
+    "shortDescription": "Guidance for building skills, agents, and plugins.",
+    "longDescription": "Guidance and tooling for building Han-compatible skills, agents, and plugins.",
+    "developerName": "Test Double",
+    "category": "Developer Tools",
+    "capabilities": ["Skills"],
+    "websiteURL": "https://github.com/oppegard/han",
+    "defaultPrompt": [
+      "Guide me through writing a skill.",
+      "Initialize Han plugin guidance.",
+      "Review my plugin structure."
+    ]
+  }
+}

--- a/han.plugin-builder/.codex-plugin/plugin.json
+++ b/han.plugin-builder/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Test Double",
     "url": "https://testdouble.com"
   },
-  "homepage": "https://github.com/oppegard/han#readme",
-  "repository": "https://github.com/oppegard/han",
+  "homepage": "https://github.com/testdouble/han#readme",
+  "repository": "https://github.com/testdouble/han",
   "license": "MIT",
   "keywords": ["han", "plugin-builder", "skills", "agents", "guidance"],
   "skills": "./skills/",
@@ -18,7 +18,7 @@
     "developerName": "Test Double",
     "category": "Developer Tools",
     "capabilities": ["Skills"],
-    "websiteURL": "https://github.com/oppegard/han",
+    "websiteURL": "https://github.com/testdouble/han",
     "defaultPrompt": [
       "Guide me through writing a skill.",
       "Initialize Han plugin guidance.",

--- a/han.reporting/.codex-plugin/plugin.json
+++ b/han.reporting/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "han.reporting",
+  "name": "han-reporting",
   "version": "1.0.1",
   "description": "Reporting and summary skills for stakeholder-facing summaries and HTML reports.",
   "author": {

--- a/han.reporting/.codex-plugin/plugin.json
+++ b/han.reporting/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "han.reporting",
+  "version": "1.0.1",
+  "description": "Reporting and summary skills for stakeholder-facing summaries and HTML reports.",
+  "author": {
+    "name": "Test Double",
+    "url": "https://testdouble.com"
+  },
+  "homepage": "https://github.com/oppegard/han#readme",
+  "repository": "https://github.com/oppegard/han",
+  "license": "MIT",
+  "keywords": ["han", "reporting", "stakeholder-summary", "html-report"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Han Reporting",
+    "shortDescription": "Stakeholder summaries and self-contained HTML reports.",
+    "longDescription": "Reporting and summary skills that turn technical plans into stakeholder-facing summaries and HTML reports.",
+    "developerName": "Test Double",
+    "category": "Developer Tools",
+    "capabilities": ["Skills"],
+    "websiteURL": "https://github.com/oppegard/han",
+    "defaultPrompt": [
+      "Write a stakeholder summary.",
+      "Create an HTML summary report.",
+      "Summarize this plan for non-engineers."
+    ]
+  }
+}

--- a/han.reporting/.codex-plugin/plugin.json
+++ b/han.reporting/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Test Double",
     "url": "https://testdouble.com"
   },
-  "homepage": "https://github.com/oppegard/han#readme",
-  "repository": "https://github.com/oppegard/han",
+  "homepage": "https://github.com/testdouble/han#readme",
+  "repository": "https://github.com/testdouble/han",
   "license": "MIT",
   "keywords": ["han", "reporting", "stakeholder-summary", "html-report"],
   "skills": "./skills/",
@@ -18,7 +18,7 @@
     "developerName": "Test Double",
     "category": "Developer Tools",
     "capabilities": ["Skills"],
-    "websiteURL": "https://github.com/oppegard/han",
+    "websiteURL": "https://github.com/testdouble/han",
     "defaultPrompt": [
       "Write a stakeholder summary.",
       "Create an HTML summary report.",


### PR DESCRIPTION
## Summary

- add Codex marketplace metadata for the Han package set
- add Codex plugin manifests for the resource-bearing Han packages
- document the current Codex install flow and upstream limitations around meta-plugin installs

## Validation

- validated Codex plugin manifests locally with the plugin creator validator
- verified no fork-specific `oppegard/han` references remain outside Git metadata