### PR TITLE
Update /investigate output ordering

### DIFF
--- a/docs/skills/han.coding/investigate.md
+++ b/docs/skills/han.coding/investigate.md
@@ -89,7 +89,7 @@ The skill walks a five-step process:
 2. **Document root cause.** The skill writes Problem Statement, Evidence Summary, and Root Cause Analysis into the plan file using the template at [`references/template.md`](../../../han.coding/skills/investigate/references/template.md).
 3. **Plan the fix.** The skill resolves project config (CLAUDE.md → project-discovery.md → docs/ Glob fallback), reads ADRs and coding standards relevant to the fix, and writes the Planned Fix section with file-level changes justified by specific evidence items.
 4. **Adversarial validation.** `adversarial-validator` agents receive the full evidence summary, root cause analysis, and planned fix. They challenge evidence, challenge the fix, and challenge assumptions. Counter-evidence becomes `V#` findings that reshape the plan.
-5. **Final summary and user review.** The skill adds the one-sentence-per-section summary and presents the plan for approval.
+5. **Summary and user review.** The skill writes the Summary section at the top of the report and presents the plan for approval.
 
 ## Sources
 

--- a/docs/skills/han.coding/investigate.md
+++ b/docs/skills/han.coding/investigate.md
@@ -56,7 +56,7 @@ Example prompts:
 
 ## What you get back
 
-An investigation plan file, plus an in-channel summary. The plan leads with the bottom line and keeps the supporting detail near the end, so it reads conclusion-first. It covers, in order:
+An investigation plan file, plus an in-channel summary. The plan leads with the bottom line and keeps the supporting detail near the end, so it reads conclusion-first. Sections appear only when the investigation produced meaningful content for them; one that would be empty is omitted, and the rest keep the order below. So a given report covers some or all of, in order:
 
 - **Summary.** One sentence each for root cause, fix, why correct, validation outcome, remaining risks. Up top so a reader gets the verdict before the backing detail.
 - **Problem Statement.** Symptoms, expected behavior, conditions under which it occurs, impact.

--- a/docs/skills/han.coding/investigate.md
+++ b/docs/skills/han.coding/investigate.md
@@ -56,17 +56,15 @@ Example prompts:
 
 ## What you get back
 
-An investigation plan file, plus an in-channel summary. The plan covers:
+An investigation plan file, plus an in-channel summary. The plan leads with the bottom line and keeps the supporting detail near the end, so it reads conclusion-first. It covers, in order:
 
+- **Summary.** One sentence each for root cause, fix, why correct, validation outcome, remaining risks. Up top so a reader gets the verdict before the backing detail.
 - **Problem Statement.** Symptoms, expected behavior, conditions under which it occurs, impact.
-- **Evidence Summary.** A numbered list (E1, E2, E3, …) consolidated from the parallel `evidence-based-investigator` agents. Duplicates merged; conflicts resolved with explicit citations.
 - **Root Cause Analysis.** One to three sentences summarizing the root cause, followed by a detailed analysis that references evidence items by number.
-- **Coding Standards Reference.** For each standard that applies, what it says, where it was found (path, ADR number, or *"inferred from surrounding code"*), and which files the fix will touch. This keeps the fix consistent with how the project already works.
 - **Planned Fix.** Per-file changes: full path, what will be modified, which evidence items justify the change, which standards apply, and implementation specifics (new function signatures, changed logic, updated tests).
-- **Validation Findings.** Numbered `V1, V2, …` entries from `adversarial-validator`. Each records the challenge attempted, whether counter-evidence was found, and what changed in response.
-- **Adjustments Made.** What the investigation changed after validation, cross-referenced to the `V#` that drove each change.
-- **Confidence Assessment and Remaining Risks.** The validator's closing judgment.
-- **Final Summary.** One sentence each for root cause, fix, why correct, validation outcome, remaining risks.
+- **Evidence Summary.** A numbered list (E1, E2, E3, …) consolidated from the parallel `evidence-based-investigator` agents. Duplicates merged; conflicts resolved with explicit citations.
+- **Validation Findings.** Numbered `V1, V2, …` entries from `adversarial-validator`. Each records the challenge attempted, whether counter-evidence was found, and what changed in response. Followed by **Adjustments Made** (what changed after validation, cross-referenced to the `V#` that drove it) and the **Confidence Assessment and Remaining Risks** that close the validator's judgment.
+- **Coding Standards Reference.** For each standard that applies, what it says, where it was found (path, ADR number, or *"inferred from surrounding code"*), and which files the fix will touch. This keeps the fix consistent with how the project already works.
 
 The plan is presented for approval before any code is written. Approve to trigger implementation; push back with feedback to revise.
 

--- a/han.coding/skills/investigate/SKILL.md
+++ b/han.coding/skills/investigate/SKILL.md
@@ -71,9 +71,9 @@ When counter-evidence is found, document it as a validation finding (V1, V2, ...
 
 After all validation is complete, incorporate the `han.core:adversarial-validator` agents' Confidence Assessment and Remaining Risks into the plan.
 
-## Step 5: Final Summary and User Review
+## Step 5: Summary and User Review
 
-Add the final summary to the plan file with one sentence each for: root cause (what caused the problem), fix (what the planned changes will do), why correct (reference the strongest evidence), validation outcome (what validation confirmed or changed), and remaining risks (reference the Confidence Assessment).
+Add the **Summary** section at the top of the plan file with one sentence each for: root cause (what caused the problem), fix (what the planned changes will do), why correct (reference the strongest evidence), validation outcome (what validation confirmed or changed), and remaining risks (reference the Confidence Assessment).
 
 Present the plan file to the user for approval. The user can approve the plan (triggering implementation) or provide feedback for revisions.
 

--- a/han.coding/skills/investigate/SKILL.md
+++ b/han.coding/skills/investigate/SKILL.md
@@ -24,6 +24,7 @@ allowed-tools: Read, Glob, Grep, Agent
 - Add one or more specialist analysts **in parallel with** the investigators when the bug type calls for it (concurrency, data flow across boundaries, database or query behavior). Specialist analysts find root causes generalists miss.
 - The `han.core:adversarial-validator` agent handles all three validation strategies (challenge evidence, challenge fix, challenge assumptions) internally.
 - Apply the evidence rule from [../../references/evidence-rule.md](../../references/evidence-rule.md) to every finding. Codebase findings (file path, line number, log line, test output) carry the trust-class label "codebase" and stand on their citation. Web-source context (RFCs, vendor docs, Stack Overflow, blog posts) carries the trust-class label "web" and is subject to the corroboration gate when it drives the proposed fix. When the investigation hits a point where no evidence at any tier resolves a question, label the no-evidence state rather than guessing.
+- Lazy-create the output sections. Include a section in the plan file only when the investigation produced meaningful content for it; omit any section that would be empty, and keep the sections that remain in the template's order. Never emit a heading with placeholder or "N/A" content.
 
 # Investigate
 
@@ -59,7 +60,7 @@ Resolve project config: read CLAUDE.md's `## Project Discovery` section for docs
 
 Design a fix that **directly addresses the root cause** from Step 2 — fix the underlying problem, not symptoms. Then fill in the remaining sections of [template.md](./references/template.md) in the plan file:
 
-1. **Coding Standards Reference** — for each applicable standard, document what the standard is, where it was found (file path, ADR number, or "inferred from surrounding code"), and which files or changes it governs. If none were found, note that explicitly and document inferred patterns.
+1. **Coding Standards Reference** — for each standard, convention, ADR, or pattern inferred from surrounding code that governs the fix, document what it is, where it was found (file path, ADR number, or "inferred from surrounding code"), and which files or changes it governs. If nothing governs the fix, omit the section per the lazy-create rule.
 2. **Planned Fix** — write a one-sentence summary, then for each file that needs to change: full path from repo root, what will be modified/added/removed, which evidence items (E1, E2, ...) justify the change, which coding standards apply, and implementation specifics (new function signatures, changed logic, updated tests).
 
 ## Step 4: Validation (CRITICAL)

--- a/han.coding/skills/investigate/SKILL.md
+++ b/han.coding/skills/investigate/SKILL.md
@@ -47,7 +47,7 @@ After all agents complete (investigators and specialists), compile an **evidence
 
 ## Step 2: Document Root Cause
 
-Write to the plan file using the template at [template.md](./references/template.md). Fill in these sections:
+Write to the plan file using the template at [template.md](./references/template.md). Fill the sections in the workflow order below; this is deliberately not the template's on-page order, which leads with the Summary and places the supporting Evidence Summary, Validation Results, and Coding Standards Reference near the end for the reader. Fill in these sections:
 
 1. **Problem Statement** — document the symptoms, expected behavior, conditions under which it occurs, and impact.
 2. **Evidence Summary** — consolidate evidence from all agents into a unified numbered list (E1, E2, E3, ...); merge duplicates and resolve conflicting findings while preserving each item's output structure.

--- a/han.coding/skills/investigate/references/template.md
+++ b/han.coding/skills/investigate/references/template.md
@@ -3,7 +3,7 @@
 <!-- Section rule: include a section only when this investigation produced meaningful content for it. Omit any section (its heading and body) that would otherwise be empty or "N/A", and keep the sections that remain in the order shown below. Sections marked CONDITIONAL are the ones most often omitted, but the rule applies to every section. -->
 
 <!-- One-line orientation: what this report is and the decision it asks for. -->
-<!-- E.g. "Investigation report — read the Summary, then approve the Planned Fix or push back." -->
+<!-- E.g. "Investigation report. Read the Summary, then approve the Planned Fix or push back." -->
 
 ## Summary
 

--- a/han.coding/skills/investigate/references/template.md
+++ b/han.coding/skills/investigate/references/template.md
@@ -1,5 +1,7 @@
 # Investigation: {Issue Title}
 
+<!-- Section rule: include a section only when this investigation produced meaningful content for it. Omit any section (its heading and body) that would otherwise be empty or "N/A", and keep the sections that remain in the order shown below. Sections marked CONDITIONAL are the ones most often omitted, but the rule applies to every section. -->
+
 <!-- One-line orientation: what this report is and the decision it asks for. -->
 <!-- E.g. "Investigation report — read the Summary, then approve the Planned Fix or push back." -->
 
@@ -130,9 +132,7 @@
 
 ## Coding Standards Reference
 
-<!-- CONDITIONAL: Include this section if coding standards, conventions, or ADRs were found that apply to the fix. -->
-<!-- These are the standards the fix was written against. -->
-<!-- If no explicit standards were found, note that and document patterns inferred from surrounding code. -->
+<!-- CONDITIONAL: Include this section only when standards, conventions, ADRs, or patterns inferred from surrounding code govern the fix. These are the standards the fix was written against. If nothing governs the fix, omit the section per the section rule at the top. -->
 
 | Standard | Source | Applies To |
 |----------|--------|------------|

--- a/han.coding/skills/investigate/references/template.md
+++ b/han.coding/skills/investigate/references/template.md
@@ -2,6 +2,16 @@
 
 <!-- One-sentence summary of the problem being investigated. -->
 
+## Summary
+
+<!-- One sentence for each field. Reference evidence (E1, E2, ...) and validation (V1, V2, ...) where appropriate. -->
+
+- **Root Cause:** <!-- What caused the problem -->
+- **Fix:** <!-- What the planned changes will do -->
+- **Why Correct:** <!-- Reference the strongest evidence supporting the fix -->
+- **Validation Outcome:** <!-- What validation confirmed or changed -->
+- **Remaining Risks:** <!-- See Confidence Assessment under Validation Results. -->
+
 ## Problem Statement
 
 <!-- Describe the problem in concrete terms. Include: -->
@@ -9,6 +19,86 @@
 <!-- - Expected behavior: What should happen instead? -->
 <!-- - Conditions: When does it occur? (specific inputs, environments, timing) -->
 <!-- - Impact: Who/what is affected? (users, builds, deployments, other features) -->
+
+## Root Cause Analysis
+
+### Summary
+
+<!-- One sentence stating the root cause. -->
+
+### Detailed Analysis
+
+<!-- Explain the root cause in detail. Reference evidence items by number: (E1), (E2), etc. -->
+<!-- Trace the causal chain from root cause to symptom, showing how each piece of evidence supports the conclusion. -->
+
+## Planned Fix
+
+### Summary
+
+<!-- One sentence describing what the fix will do. -->
+
+### Changes
+
+<!-- List every file that needs to change. Reference evidence (E1, E2, ...) and standards to justify each change. -->
+
+#### `path/to/first-file.ext`
+
+- **Change:** <!-- What will be modified, added, or removed -->
+- **Evidence:** <!-- Which evidence items justify this change, e.g., (E1), (E3) -->
+- **Standards:** <!-- Which coding standards apply -->
+- **Details:** <!-- Implementation specifics — new function signatures, changed logic, updated tests -->
+
+#### `path/to/second-file.ext`
+
+- **Change:** <!-- What will be modified, added, or removed -->
+- **Evidence:** <!-- Which evidence items justify this change -->
+- **Standards:** <!-- Which coding standards apply -->
+- **Details:** <!-- Implementation specifics -->
+
+<!-- Add more file entries as needed -->
+
+## Coding Standards Reference
+
+<!-- CONDITIONAL: Include this section if coding standards, conventions, or ADRs were found that apply to the fix. -->
+<!-- If no explicit standards were found, note that and document patterns inferred from surrounding code. -->
+
+| Standard | Source | Applies To |
+|----------|--------|------------|
+| Description of standard or convention | File path, ADR number, or "inferred from surrounding code" | Which files or changes this governs |
+
+## Validation Results
+
+<!-- Document the results of adversarial validation from Step 4. -->
+
+### Counter-Evidence Investigated
+
+<!-- Number each validation finding (V1, V2, ...) so they can be referenced in the summary. -->
+
+#### V1: {Hypothesis tested}
+
+- **Hypothesis:** <!-- What was assumed to be wrong or what could fail -->
+- **Investigation:** <!-- What was checked — file paths, code searched, tests run -->
+- **Result:** Confirmed / Refuted / Partially Refuted <!-- Did the original analysis hold up? -->
+- **Impact:** <!-- If refuted: what changed in the plan. If confirmed: why this supports the original analysis. -->
+
+#### V2: {Hypothesis tested}
+
+- **Hypothesis:** <!-- What was assumed to be wrong or what could fail -->
+- **Investigation:** <!-- What was checked -->
+- **Result:** Confirmed / Refuted / Partially Refuted
+- **Impact:** <!-- Effect on the plan -->
+
+<!-- Add more validation findings as needed (V3, V4, ...) -->
+
+### Adjustments Made
+
+<!-- CONDITIONAL: Include only if validation findings caused changes to the plan. -->
+<!-- List what changed and which validation finding (V1, V2, ...) triggered each change. -->
+
+### Confidence Assessment
+
+- **Confidence:** High / Medium / Low
+- **Remaining Risks:** <!-- Known risks, areas not fully validated, or assumptions that could not be verified -->
 
 ## Evidence Summary
 
@@ -44,93 +134,3 @@
 - **Relevance:** <!-- How this evidence connects to the problem -->
 
 <!-- Add more evidence items as needed (E4, E5, ...) -->
-
-## Root Cause Analysis
-
-### Summary
-
-<!-- One sentence stating the root cause. -->
-
-### Detailed Analysis
-
-<!-- Explain the root cause in detail. Reference evidence items by number: (E1), (E2), etc. -->
-<!-- Trace the causal chain from root cause to symptom, showing how each piece of evidence supports the conclusion. -->
-
-## Coding Standards Reference
-
-<!-- CONDITIONAL: Include this section if coding standards, conventions, or ADRs were found that apply to the fix. -->
-<!-- If no explicit standards were found, note that and document patterns inferred from surrounding code. -->
-
-| Standard | Source | Applies To |
-|----------|--------|------------|
-| Description of standard or convention | File path, ADR number, or "inferred from surrounding code" | Which files or changes this governs |
-
-## Planned Fix
-
-### Summary
-
-<!-- One sentence describing what the fix will do. -->
-
-### Changes
-
-<!-- List every file that needs to change. Reference evidence (E1, E2, ...) and standards to justify each change. -->
-
-#### `path/to/first-file.ext`
-
-- **Change:** <!-- What will be modified, added, or removed -->
-- **Evidence:** <!-- Which evidence items justify this change, e.g., (E1), (E3) -->
-- **Standards:** <!-- Which coding standards apply -->
-- **Details:** <!-- Implementation specifics — new function signatures, changed logic, updated tests -->
-
-#### `path/to/second-file.ext`
-
-- **Change:** <!-- What will be modified, added, or removed -->
-- **Evidence:** <!-- Which evidence items justify this change -->
-- **Standards:** <!-- Which coding standards apply -->
-- **Details:** <!-- Implementation specifics -->
-
-<!-- Add more file entries as needed -->
-
-## Validation Results
-
-<!-- Document the results of adversarial validation from Step 5. -->
-
-### Counter-Evidence Investigated
-
-<!-- Number each validation finding (V1, V2, ...) so they can be referenced in the final summary. -->
-
-#### V1: {Hypothesis tested}
-
-- **Hypothesis:** <!-- What was assumed to be wrong or what could fail -->
-- **Investigation:** <!-- What was checked — file paths, code searched, tests run -->
-- **Result:** Confirmed / Refuted / Partially Refuted <!-- Did the original analysis hold up? -->
-- **Impact:** <!-- If refuted: what changed in the plan. If confirmed: why this supports the original analysis. -->
-
-#### V2: {Hypothesis tested}
-
-- **Hypothesis:** <!-- What was assumed to be wrong or what could fail -->
-- **Investigation:** <!-- What was checked -->
-- **Result:** Confirmed / Refuted / Partially Refuted
-- **Impact:** <!-- Effect on the plan -->
-
-<!-- Add more validation findings as needed (V3, V4, ...) -->
-
-### Adjustments Made
-
-<!-- CONDITIONAL: Include only if validation findings caused changes to the plan. -->
-<!-- List what changed and which validation finding (V1, V2, ...) triggered each change. -->
-
-### Confidence Assessment
-
-- **Confidence:** High / Medium / Low
-- **Remaining Risks:** <!-- Known risks, areas not fully validated, or assumptions that could not be verified -->
-
-## Final Summary
-
-<!-- One sentence for each field. Reference evidence (E1, E2, ...) and validation (V1, V2, ...) where appropriate. -->
-
-- **Root Cause:** <!-- What caused the problem -->
-- **Fix:** <!-- What the planned changes will do -->
-- **Why Correct:** <!-- Reference the strongest evidence supporting the fix -->
-- **Validation Outcome:** <!-- What validation confirmed or changed -->
-- **Remaining Risks:** <!-- See Confidence Assessment above -->

--- a/han.coding/skills/investigate/references/template.md
+++ b/han.coding/skills/investigate/references/template.md
@@ -1,10 +1,12 @@
 # Investigation: {Issue Title}
 
-<!-- One-sentence summary of the problem being investigated. -->
+<!-- One-line orientation: what this report is and the decision it asks for. -->
+<!-- E.g. "Investigation report — read the Summary, then approve the Planned Fix or push back." -->
 
 ## Summary
 
 <!-- One sentence for each field. Reference evidence (E1, E2, ...) and validation (V1, V2, ...) where appropriate. -->
+<!-- Reader key: (E#) items are defined under Evidence Summary and (V#) items under Validation Results, both near the end of this report. -->
 
 - **Root Cause:** <!-- What caused the problem -->
 - **Fix:** <!-- What the planned changes will do -->
@@ -22,7 +24,7 @@
 
 ## Root Cause Analysis
 
-### Summary
+### Root Cause
 
 <!-- One sentence stating the root cause. -->
 
@@ -33,7 +35,7 @@
 
 ## Planned Fix
 
-### Summary
+### Approach
 
 <!-- One sentence describing what the fix will do. -->
 
@@ -56,49 +58,6 @@
 - **Details:** <!-- Implementation specifics -->
 
 <!-- Add more file entries as needed -->
-
-## Coding Standards Reference
-
-<!-- CONDITIONAL: Include this section if coding standards, conventions, or ADRs were found that apply to the fix. -->
-<!-- If no explicit standards were found, note that and document patterns inferred from surrounding code. -->
-
-| Standard | Source | Applies To |
-|----------|--------|------------|
-| Description of standard or convention | File path, ADR number, or "inferred from surrounding code" | Which files or changes this governs |
-
-## Validation Results
-
-<!-- Document the results of adversarial validation from Step 4. -->
-
-### Counter-Evidence Investigated
-
-<!-- Number each validation finding (V1, V2, ...) so they can be referenced in the summary. -->
-
-#### V1: {Hypothesis tested}
-
-- **Hypothesis:** <!-- What was assumed to be wrong or what could fail -->
-- **Investigation:** <!-- What was checked — file paths, code searched, tests run -->
-- **Result:** Confirmed / Refuted / Partially Refuted <!-- Did the original analysis hold up? -->
-- **Impact:** <!-- If refuted: what changed in the plan. If confirmed: why this supports the original analysis. -->
-
-#### V2: {Hypothesis tested}
-
-- **Hypothesis:** <!-- What was assumed to be wrong or what could fail -->
-- **Investigation:** <!-- What was checked -->
-- **Result:** Confirmed / Refuted / Partially Refuted
-- **Impact:** <!-- Effect on the plan -->
-
-<!-- Add more validation findings as needed (V3, V4, ...) -->
-
-### Adjustments Made
-
-<!-- CONDITIONAL: Include only if validation findings caused changes to the plan. -->
-<!-- List what changed and which validation finding (V1, V2, ...) triggered each change. -->
-
-### Confidence Assessment
-
-- **Confidence:** High / Medium / Low
-- **Remaining Risks:** <!-- Known risks, areas not fully validated, or assumptions that could not be verified -->
 
 ## Evidence Summary
 
@@ -134,3 +93,47 @@
 - **Relevance:** <!-- How this evidence connects to the problem -->
 
 <!-- Add more evidence items as needed (E4, E5, ...) -->
+
+## Validation Results
+
+<!-- Document how the fix was stress-tested by adversarial validation and the resulting confidence. -->
+
+### Counter-Evidence Investigated
+
+<!-- Number each validation finding (V1, V2, ...) so they can be referenced in the Summary. -->
+
+#### V1: {Hypothesis tested}
+
+- **Hypothesis:** <!-- What was assumed to be wrong or what could fail -->
+- **Investigation:** <!-- What was checked — file paths, code searched, tests run -->
+- **Result:** Confirmed / Refuted / Partially Refuted <!-- Did the original analysis hold up? -->
+- **Impact:** <!-- If refuted: what changed in the plan. If confirmed: why this supports the original analysis. -->
+
+#### V2: {Hypothesis tested}
+
+- **Hypothesis:** <!-- What was assumed to be wrong or what could fail -->
+- **Investigation:** <!-- What was checked -->
+- **Result:** Confirmed / Refuted / Partially Refuted
+- **Impact:** <!-- Effect on the plan -->
+
+<!-- Add more validation findings as needed (V3, V4, ...) -->
+
+### Adjustments Made
+
+<!-- CONDITIONAL: Include only if validation findings caused changes to the plan. -->
+<!-- List what changed and which validation finding (V1, V2, ...) triggered each change. -->
+
+### Confidence Assessment
+
+- **Confidence:** High / Medium / Low
+- **Remaining Risks:** <!-- Known risks, areas not fully validated, or assumptions that could not be verified -->
+
+## Coding Standards Reference
+
+<!-- CONDITIONAL: Include this section if coding standards, conventions, or ADRs were found that apply to the fix. -->
+<!-- These are the standards the fix was written against. -->
+<!-- If no explicit standards were found, note that and document patterns inferred from surrounding code. -->
+
+| Standard | Source | Applies To |
+|----------|--------|------------|
+| Description of standard or convention | File path, ADR number, or "inferred from surrounding code" | Which files or changes this governs |


### PR DESCRIPTION
## Summary

**This PR reorders the `/investigate` skill's output report to bottom-line-up-front and only emits sections that have real content, so that a reader sees the verdict first and never wades through empty placeholders.**

- The investigation report now leads with the conclusion: the new top-level order is Summary -> Problem Statement -> Root Cause Analysis -> Planned Fix -> Evidence Summary -> Validation Results -> Coding Standards Reference. Previously the summary came last and the evidence dump sat near the top.
- The old `## Final Summary` is renamed `## Summary` and moved to the top; it carries the root cause, the fix, why the fix is correct, the validation outcome, and remaining risks. A one-line reader key explains that `(E#)` items are defined later under Evidence Summary and `(V#)` items under Validation Results, since the conclusion now precedes its backing detail.
- New "lazy-create" rule: a section appears only when it has meaningful content. Empty sections are dropped entirely (heading and body) instead of being emitted with "N/A" placeholders, and surviving sections keep template order. This is the change most likely to alter what a real report looks like.
- These are template/authoring changes to a Claude Code plugin skill. There is no runtime code; the only "behavior" change is the shape and ordering of the Markdown report `/investigate` produces.

## What to look at first

- The BLUF reorder is the central decision: confirm that putting the verdict before its evidence reads well, given the report now references `(E#)`/`(V#)` markers above where they are defined. The reader key in the Summary section is the mitigation for that forward-reference.
- The lazy-create rule is stated in three places that must agree: the template top, an Investigation Approach bullet in SKILL.md, and the Coding Standards Reference guidance (which previously forced a "no standards found" note and now must allow omission). Check those three do not contradict each other.
- Note the deliberate split between two orderings: SKILL.md says sections are filled in workflow order, which is intentionally not the template's on-page reader order. Worth confirming that distinction is clear enough that an author will not "fix" it.
- A nested heading collision was resolved by the top-level rename: the `### Summary` subsections inside Root Cause Analysis and Planned Fix became `### Root Cause` and `### Approach`. Quick check that those new labels read correctly in context.

## Files of interest

- `han.coding/...investigate/references/template.md` — the actual report template; carries the reorder, rename, reader key, and lazy-create rule.
- `han.coding/skills/investigate/SKILL.md` — adds the lazy-create enforcement bullet and the workflow-order-vs-reader-order note.
- `docs/skills/han.coding/investigate.md` — operator-facing "What you get back" list, updated to match the new order, rename, and lazy-create behavior.
