### PR TITLE
docs: align PR template checklist with the count-free index convention

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,13 +17,13 @@ Work through this checklist before marking the PR ready. Leave it in the PR body
 - [ ] Walk the [self-review checklist in CONTRIBUTING.md](../CONTRIBUTING.md#reviewing-your-own-changes): frontmatter validity, `allowed-tools` accuracy, context-injection simplicity, template adherence, index placement, link resolution, voice compliance.
 - [ ] Confirm the writing follows [`docs/writing-voice.md`](../docs/writing-voice.md). No em-dashes. No banned words ("actually", "just", "leverage", "utilize", "showcase", "robust" as vague positive, "It's worth noting", "Importantly").
 - [ ] If a new skill or agent was added or renamed, confirm the [coverage rule](../docs/templates/coverage-rule.md) is satisfied: long-form doc exists at `docs/skills/{name}.md` or `docs/agents/{name}.md`, and the index in `docs/skills/README.md` or `docs/agents/README.md` has a one-sentence scent line.
-- [ ] If a count changed (skills, agents, long-form docs), update the "Counts to verify when editing indexes" line in [CLAUDE.md](../CLAUDE.md), the count in [`docs/concepts.md`](../docs/concepts.md), and the counts in [README.md](../README.md).
+- [ ] If a skill or agent was added, removed, or renamed, confirm the indexes ([`docs/skills/README.md`](../docs/skills/README.md), [`docs/agents/README.md`](../docs/agents/README.md)), the [CLAUDE.md](../CLAUDE.md) catalog, and [`docs/concepts.md`](../docs/concepts.md) each list every current entity.
 - [ ] If the change touches plugin behavior, run the affected skill or agent locally and confirm it still works end-to-end.
 - [ ] If the change affects `plugin/.claude-plugin/plugin.json` or `.claude-plugin/marketplace.json`, confirm both are consistent.
 
 ### Refresh the documentation
 
-Run `/han-update-documentation` in Claude Code from this branch. The skill scopes its pass to the entities this branch touched, syncing the long-form docs, indexes, counts, and cross-references with the changes on disk so the PR ships with accurate documentation.
+Run `/han-update-documentation` in Claude Code from this branch. The skill scopes its pass to the entities this branch touched, syncing the long-form docs, indexes, and cross-references with the changes on disk so the PR ships with accurate documentation.
 
 ### Generate the PR description
 


### PR DESCRIPTION
## Summary

**This PR updates the contributor PR-template checklist to stop chasing entity counts that no longer exist, so that the template matches the "indexes stay complete, not counted" convention.**

- Rewrites the index-maintenance checklist item: instead of telling contributors to update a count line in `CLAUDE.md` plus hardcoded counts in `docs/concepts.md` and `README.md`, it now asks them to confirm the two indexes, the `CLAUDE.md` catalog, and `docs/concepts.md` each list every current skill and agent.
- Drops "counts" from the list of things `/han-update-documentation` syncs, since there are no longer any counts to sync.
- Scope is two lines in one file. Pure process/documentation text, with no skill, agent, or runtime behavior change.
- Follow-up to a triage that flagged this drift; the adjacent path-fix branch (PR #80) deliberately left this count-convention drift out of its scope.

## What to look at first

- The replacement checklist item (line 20): does it correctly name the four places that must each list every entity, and does the instruction read clearly to a contributor who has never seen the convention? It states the rule prospectively, with no reference to the old count-based wording (that history lives in the commit message, not the checklist).
- Whether the targets it points at are real: the old line referenced a "Counts to verify when editing indexes" line in `CLAUDE.md` and counts in `docs/concepts.md` and `README.md` that have already been removed. Worth a quick confirm that the new wording does not point anyone back at a count that no longer lives in those files.
- The `/han-update-documentation` paragraph (line 26): removing "counts" should leave the sentence accurate about what that skill still syncs (long-form docs, indexes, cross-references) and not imply it dropped real work.

## Files of interest

- `.github/pull_request_template.md` — the only file changed; two checklist lines realigned to the count-free index convention.
