### PR TITLE
Simplify the update-pr-description skill's output

### DIFF
--- a/docs/skills/han-github/update-pr-description.md
+++ b/docs/skills/han-github/update-pr-description.md
@@ -7,7 +7,7 @@ Operator documentation for the `/update-pr-description` skill in the han plugin.
 ## TL;DR
 
 - **What it does.** Generates a PR description from the current branch's changes against a GitHub PR using the `gh` CLI. When the repository defines its own GitHub pull-request template, the description conforms to that template's structure.
-- **When to use it.** You have a branch with committed changes and want a thorough PR description that surfaces the central mechanism, key files, and a test plan.
+- **When to use it.** You have a branch with committed changes and want a focused PR description that surfaces the central behavioral change, with a reading-order guide for large changes.
 - **What you get back.** A markdown PR description in-channel, optionally pushed to the open PR via `gh pr edit`.
 
 ## Key concepts
@@ -15,8 +15,8 @@ Operator documentation for the `/update-pr-description` skill in the han plugin.
 - **Central mechanism up front.** Feature flags, migrations, and behavioral changes lead the Summary. Code structure is summarized; runtime behavior is not.
 - **Repository PR template aware.** Before generating, the skill looks for a GitHub pull-request template (in the repo root, `.github/`, `docs/`, or a `PULL_REQUEST_TEMPLATE/` directory). If it finds one, the description conforms to that template's headings and order instead of the default structure. It reads the template's intent rather than assuming a shape: a template whose comments say "replace this with a description" is treated as a throwaway scaffold and replaced wholesale, while a structural template's sections are filled in and preserved. Checklist boxes are checked only when the diff unambiguously proves them; the rest are left for the author. If multiple templates exist in a `PULL_REQUEST_TEMPLATE/` directory, the skill asks which to use.
 - **Junior-developer authors the description.** A `junior-developer` agent writes the PR description directly. Authoring with a fresh-reviewer perspective (a teammate without full project context) means the result already anticipates what a reviewer needs to see, so no separate review pass is required.
-- **"How this was tested" is conditional.** If the branch only changes documentation, the section is omitted. If any code or config file changed, it is included.
-- **Files of interest is a bulleted list, capped at five.** This section is a bulleted list of at most 5 entries, never a table. Each entry is `` `path` `` followed by a one-phrase reason the file matters for review. Generated files, mechanical refactors, trivial changes, and non-central test helpers are skipped.
+- **Lean output, no GitHub-duplicating sections.** The description is a one-sentence Summary, a Behavior changes section, and a conditional "What to look at first." It deliberately drops a test-results list, a files-of-interest list, and a test-scenario list — GitHub's Checks and Files Changed tabs already render those one click away.
+- **"What to look at first" is conditional on size.** It appears only when the PR has more than ~8-10 files with significant changes. "Significant" means code files; documentation and configuration files do not count by default, and even when one is judged significant it usually does not belong in the list.
 - **Branch-specific diff only.** The skill describes changes unique to the feature branch. Never changes pulled in from the default branch.
 - **gh CLI required.** Without `gh`, the skill stops immediately and tells you to install it.
 
@@ -51,13 +51,11 @@ Example prompts:
 
 ## What you get back
 
-A PR description rendered in-channel, optionally pushed to the open PR. When the repository has no PR template, sections appear in this fixed order: Summary, What to look at first, How this was tested (when included), Files of interest, Test scenario changes (when tests were added or edited). When the repository defines a PR template, the description follows that template's headings and order instead, with "What to look at first" and "Files of interest" appended when the template has no home for them.
+A PR description rendered in-channel, optionally pushed to the open PR. When the repository has no PR template, sections appear in this fixed order: Summary, Behavior changes (when runtime behavior changes), What to look at first (only for large code changes). When the repository defines a PR template, the description follows that template's headings and order instead, with "What to look at first" appended when the template has no home for it and the PR is large enough to warrant it.
 
-- **Summary.** Opens with a single bolded TL;DR sentence (`**This PR <verb> <behavior>, so that <why>.**`), followed by 2–4 bullets covering user-visible or runtime behavior, scope, and reviewer-attention pointers. A `### Behavior changes` subsection appears only when runtime behavior changes (flag flips, migrations, state-machine edits, config changes, API contract changes).
-- **What to look at first.** A 2–4 bullet attention guide pointing at decisions, tradeoffs, or risks. Not a file list.
-- **How this was tested.** Past-tense author-self-check items prefixed with `- ✅` describing scenarios the author already verified. Only present when at least one code or configuration file changed. Omitted for documentation-only branches.
-- **Files of interest.** A bulleted list of at most 5 entries, never a table. Each entry is `` `path` `` followed by a one-phrase reason the file matters for review.
-- **Test scenario changes.** Behavioral scenarios in plain language. No file paths in this section (test files, when central, appear in Files of interest). Only present when tests were added or edited.
+- **Summary.** A single bolded TL;DR sentence (`**This PR <verb> <behavior>, so that <why>.**`) and nothing else — no bullet list, no file mentions.
+- **Behavior changes.** The load-bearing section: a plain-language before/after of what the PR changes at runtime, leading with the central mechanism (flag flips, migrations, state-machine edits, config or API-contract changes), with specific per-environment values and a small table when flags or modes interact. Omitted for pure refactors and docs-only PRs.
+- **What to look at first.** A 2–4 bullet reading-order guide pointing at decisions, tradeoffs, or risks — not a file list. Present only when the PR has more than ~8-10 files with significant (code) changes; documentation and configuration files do not count as significant by default.
 - **An offer to push the description to the open PR.** The skill checks for an existing PR via `gh pr view`. If one exists, it asks before calling `gh pr edit --body`.
 
 ## How to get the most out of it
@@ -65,7 +63,7 @@ A PR description rendered in-channel, optionally pushed to the open PR. When the
 - **Commit the changes first.** The skill reads `git diff origin/HEAD...HEAD`. Uncommitted changes are not included.
 - **Surface the central mechanism in a context hint.** Feature flag name, migration phases, state-machine combinations. If you name these in the prompt, the Summary leads with them. Otherwise the skill infers from the diff (usually correctly, but a hint helps).
 - **Per-environment values matter.** *"Default off in prod, on in staging, toggle `billing_v2_enabled`"* is a better PR description than *"added feature flag."*
-- **Skip for doc-only branches.** The skill handles documentation-only branches correctly (omits the "How this was tested" section) but still writes a Summary. For pure formatting changes, a handwritten one-liner is probably faster.
+- **Skip for doc-only branches.** The skill handles documentation-only branches correctly (the Summary sentence stands alone, with no Behavior changes section) but still writes a description. For pure formatting changes, a handwritten one-liner is probably faster.
 - **Pair with `/post-code-review-to-pr`.** Description first, review second, both posted to the same PR.
 
 ## Cost and latency
@@ -74,21 +72,20 @@ The skill reads the git diff, stat, log, and any source files needed to understa
 
 ## In more detail
 
-The skill walks a seven-step process:
+The skill walks a six-step process:
 
 1. **Validate branch state.** Require `origin/HEAD`, require at least one commit, require at least one changed file.
 2. **Discover the repository PR template.** Look in the repo root, `.github/`, `docs/`, and any `PULL_REQUEST_TEMPLATE/` directory for a GitHub pull-request template. If exactly one is found, read it in full (including HTML comments). If a `PULL_REQUEST_TEMPLATE/` directory holds several, ask which to conform to. If none exists, the skill uses its default structure.
-3. **Analyze changes.** Read the diff, stat, and log. Identify the central mechanism. Classify the change type.
-4. **Determine "How this was tested" applicability.** If all changed files are documentation, omit the section. If any are code or config, include it.
-5. **Generate the PR description.** Dispatch a `junior-developer` agent with the branch context, the inclusion decision from Step 4, the contents of [`references/formatting-rules.md`](../../../han-github/skills/update-pr-description/references/formatting-rules.md), and a structure directive. With no template, the directive carries [`references/template.md`](../../../han-github/skills/update-pr-description/references/template.md) and the fixed section order. With a template, it carries the discovered template and the conformance rules in [`references/template-conformance.md`](../../../han-github/skills/update-pr-description/references/template-conformance.md). The agent authors the description with a fresh-reviewer perspective, anticipating what a teammate without full project context needs to see. No nested fenced code blocks. No "Generated with Claude Code" trailer.
-6. **Verify.** Structure (fixed order, or conformance to the discovered template), file-list caps, valid markdown, branch-specific content only.
-7. **Display and update PR.** Show the description. If a PR exists, ask whether to push. On yes, `gh pr edit --body`.
+3. **Analyze changes.** Read the diff, stat, and log. Identify the central mechanism. Classify the change type. Count the significant (code) files, since that count gates "What to look at first."
+4. **Generate the PR description.** Dispatch a `junior-developer` agent with the branch context and a structure directive. With no template, the directive carries [`references/template.md`](../../../han-github/skills/update-pr-description/references/template.md) and the fixed section order. With a template, it carries the discovered template and the conformance rules in [`references/template-conformance.md`](../../../han-github/skills/update-pr-description/references/template-conformance.md). The agent authors the description with a fresh-reviewer perspective, anticipating what a teammate without full project context needs to see. No nested fenced code blocks. No "Generated with Claude Code" trailer.
+5. **Verify.** Structure (fixed order, or conformance to the discovered template), the conditional "What to look at first" threshold, valid markdown, branch-specific content only.
+6. **Display and update PR.** Show the description. If a PR exists, ask whether to push. On yes, `gh pr edit --body`.
 
 ## Sources
 
 ### GitHub: Pull Request Description Best Practices
 
-GitHub's own guidance on PR descriptions recommends leading with the why, then the what, then verification steps. The skill's Summary-then-files-then-test-plan order reflects this.
+GitHub's own guidance on PR descriptions recommends leading with the why, then the what. The skill's lead-with-the-why-then-the-behavior order reflects this, and leaves verification and the file list to GitHub's native Checks and Files Changed tabs.
 
 URL: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/creating-and-reviewing-pull-requests/creating-a-pull-request
 

--- a/docs/skills/han-github/update-pr-description.md
+++ b/docs/skills/han-github/update-pr-description.md
@@ -69,7 +69,7 @@ A PR description rendered in-channel, optionally pushed to the open PR. When the
 
 ## Cost and latency
 
-The skill reads the git diff, stat, log, and any source files needed to understand the change, then dispatches a single `junior-developer` agent in Step 5 to author the PR description. The agent runs on its default model. Typical runs are around a minute for a typical PR.
+The skill reads the git diff, stat, log, and any source files needed to understand the change, then dispatches a single `junior-developer` agent in Step 4 to author the PR description. The agent runs on its default model. Typical runs are around a minute for a typical PR.
 
 ## In more detail
 

--- a/docs/skills/han-github/update-pr-description.md
+++ b/docs/skills/han-github/update-pr-description.md
@@ -7,15 +7,16 @@ Operator documentation for the `/update-pr-description` skill in the han plugin.
 ## TL;DR
 
 - **What it does.** Generates a PR description from the current branch's changes against a GitHub PR using the `gh` CLI. When the repository defines its own GitHub pull-request template, the description conforms to that template's structure.
-- **When to use it.** You have a branch with committed changes and want a focused PR description that surfaces the central behavioral change, with a reading-order guide for large changes.
+- **When to use it.** You have a branch with committed changes and want a short, focused PR description (a few short paragraphs) that surfaces the central behavioral change, with a reading-order guide for large changes.
 - **What you get back.** A markdown PR description in-channel, optionally pushed to the open PR via `gh pr edit`.
 
 ## Key concepts
 
-- **Central mechanism up front.** Feature flags, migrations, and behavioral changes lead the Summary. Code structure is summarized; runtime behavior is not.
+- **Short by design.** The whole description is at most 2-5 short paragraphs, with the behavioral detail in 1-3 of them. It stays at the altitude of behavior and intent and lets the diff carry the specifics, rather than restating config values, phases, or modes in prose.
+- **Central mechanism up front.** Feature flags, migrations, and behavioral changes lead the Summary. Behavior is named with its headline effect (a flag and its default, a migration's direction), not enumerated value by value.
 - **Repository PR template aware.** Before generating, the skill looks for a GitHub pull-request template (in the repo root, `.github/`, `docs/`, or a `PULL_REQUEST_TEMPLATE/` directory). If it finds one, the description conforms to that template's headings and order instead of the default structure. It reads the template's intent rather than assuming a shape: a template whose comments say "replace this with a description" is treated as a throwaway scaffold and replaced wholesale, while a structural template's sections are filled in and preserved. Checklist boxes are checked only when the diff unambiguously proves them; the rest are left for the author. If multiple templates exist in a `PULL_REQUEST_TEMPLATE/` directory, the skill asks which to use.
 - **Junior-developer authors the description.** A `junior-developer` agent writes the PR description directly. Authoring with a fresh-reviewer perspective (a teammate without full project context) means the result already anticipates what a reviewer needs to see, so no separate review pass is required.
-- **Lean output, no GitHub-duplicating sections.** The description is a one-sentence Summary, a Behavior changes section, and a conditional "What to look at first." It deliberately drops a test-results list, a files-of-interest list, and a test-scenario list — GitHub's Checks and Files Changed tabs already render those one click away.
+- **Lean output, no GitHub-duplicating sections.** The description is a one-sentence Summary, a short Behavior changes section, and a conditional "What to look at first." It deliberately drops a test-results list, a files-of-interest list, and a test-scenario list — GitHub's Checks and Files Changed tabs already render those one click away.
 - **"What to look at first" is conditional on size.** It appears only when the PR has more than ~8-10 files with significant changes. "Significant" means code files; documentation and configuration files do not count by default, and even when one is judged significant it usually does not belong in the list.
 - **Branch-specific diff only.** The skill describes changes unique to the feature branch. Never changes pulled in from the default branch.
 - **gh CLI required.** Without `gh`, the skill stops immediately and tells you to install it.
@@ -54,7 +55,7 @@ Example prompts:
 A PR description rendered in-channel, optionally pushed to the open PR. When the repository has no PR template, sections appear in this fixed order: Summary, Behavior changes (when runtime behavior changes), What to look at first (only for large code changes). When the repository defines a PR template, the description follows that template's headings and order instead, with "What to look at first" appended when the template has no home for it and the PR is large enough to warrant it.
 
 - **Summary.** A single bolded TL;DR sentence (`**This PR <verb> <behavior>, so that <why>.**`) and nothing else — no bullet list, no file mentions.
-- **Behavior changes.** The load-bearing section: a plain-language before/after of what the PR changes at runtime, leading with the central mechanism (flag flips, migrations, state-machine edits, config or API-contract changes), with specific per-environment values and a small table when flags or modes interact. Omitted for pure refactors and docs-only PRs.
+- **Behavior changes.** The load-bearing section, kept to 1-3 short paragraphs: a plain-language before/after of what the PR changes at runtime, leading with the central mechanism (flag flips, migrations, state-machine edits, config or API-contract changes) and its headline effect. A small table appears only when several flags or modes genuinely interact. Omitted for pure refactors and docs-only PRs.
 - **What to look at first.** A 2–4 bullet reading-order guide pointing at decisions, tradeoffs, or risks — not a file list. Present only when the PR has more than ~8-10 files with significant (code) changes; documentation and configuration files do not count as significant by default.
 - **An offer to push the description to the open PR.** The skill checks for an existing PR via `gh pr view`. If one exists, it asks before calling `gh pr edit --body`.
 

--- a/han-github/skills/update-pr-description/SKILL.md
+++ b/han-github/skills/update-pr-description/SKILL.md
@@ -37,7 +37,7 @@ Before generating a PR description, verify the branch has content to describe:
 
 ## Step 2: Discover the Repository PR Template
 
-Determine whether the repository defines its own GitHub pull-request template. If it does, the generated description must conform to that template's structure (Step 5). Do not assume any particular template shape — discover it, read it, and let its structure drive the output.
+Determine whether the repository defines its own GitHub pull-request template. If it does, the generated description must conform to that template's structure (Step 4). Do not assume any particular template shape — discover it, read it, and let its structure drive the output.
 
 Use the `Glob` tool to look in GitHub's supported template locations. GitHub matches the filename case-insensitively; check both common casings since the working filesystem may be case-sensitive. Search these paths (most templates are `.md`; `.txt` is also valid):
 
@@ -48,11 +48,11 @@ Use the `Glob` tool to look in GitHub's supported template locations. GitHub mat
 
 Then resolve to a single template (or none):
 
-1. **No template file found** — the repository has no PR template. Record "no repository template" and continue. Step 5 uses the default structure.
+1. **No template file found** — the repository has no PR template. Record "no repository template" and continue. Step 4 uses the default structure.
 2. **Exactly one single-file template found** — `Read` it in full, including HTML comments. Record its path and full contents.
 3. **A `PULL_REQUEST_TEMPLATE/` directory with multiple templates** — GitHub selects one per PR and the skill cannot know which applies. Use `AskUserQuestion` to ask which template to conform to, listing the filenames plus a "None — use the default structure" option. `Read` the chosen file in full and record its path and contents. If the user picks "None," record "no repository template."
 
-Carry the recorded result (the template path and full contents, or "no repository template") into Step 5. Preserve the template's HTML comments verbatim in what you carry forward — they often state how the template is meant to be used.
+Carry the recorded result (the template path and full contents, or "no repository template") into Step 4. Preserve the template's HTML comments verbatim in what you carry forward — they often state how the template is meant to be used.
 
 ## Step 3: Analyze Changes
 
@@ -60,18 +60,18 @@ Review the branch diff, commits, and relevant source code to understand the PR. 
 
 When applicable (do not force these into every PR), collect specific details: feature flag gate names/values/interactions, actual config values per environment, before/after behavioral changes, migration phases/rollback/data flow, and state machine combinations.
 
-## Step 4: Determine "How this was tested" Applicability
+While analyzing, count the **significant** changed files from `branch stats`, since that count gates the "What to look at first" section in Step 4. "Significant" means code files. Documentation and configuration files do not count as significant by default; one counts only when there is explicit justification for how it changes the behavior of the code changes in the PR.
 
-Inspect the changed files from `branch stats` and classify each by extension. Documentation files: `.md`, `.txt`, `.rst`, `.adoc`, `.rdoc`, `.textile`, `.wiki`, `.org`, `.asciidoc`, `.creole`, `.pod`, `.mediawiki`. Everything else is a code or configuration file. If ALL changed files are documentation → omit the "How this was tested" section. If ANY changed file is code or configuration → include the "How this was tested" section.
-
-## Step 5: Generate the PR Description
+## Step 4: Generate the PR Description
 
 Launch a single `han-core:junior-developer` agent to write the PR description directly. Junior-developer's fresh-reviewer perspective is the asset here: by authoring the description with the eyes of a teammate who lacks full project context, the result already anticipates what a reviewer needs to see, removing the need for a separate reviewer-context edit pass.
 
 First, compose the **structure directive** based on the Step 2 result. The structure directive is the only part of the prompt that differs between the two cases; everything else is shared.
 
 - **Option A — no repository template** (Step 2 recorded "no repository template"). The structure directive is:
-  > **Structure (required):** Produce the description using this fixed structure and section order: Summary (with a `### Behavior changes` subsection only when runtime behavior changes) → What to look at first → How this was tested (only when included per the inclusion decision) → Files of interest → Test scenario changes (only if tests were added or edited). The first line under `## Summary` MUST be the bolded TL;DR sentence, before anything else is drafted. Include the `### Behavior changes` subsection only when runtime behavior changes (flag flips, migrations, state-machine edits, config changes, API contract changes); omit it for pure refactors and docs-only PRs; render interacting flags or modes as a small table.
+  > **Structure (required):** Produce the description using this fixed structure and section order: Summary (the bolded TL;DR sentence only) → Behavior changes (its own `##` section, present only when runtime behavior changes; omit for pure refactors and docs-only PRs) → What to look at first (only when the PR has more than ~8-10 files with significant changes; see the threshold rule below). The first line under `## Summary` MUST be the bolded TL;DR sentence, and the Summary section contains nothing else — no bullet list, no file mentions. Include the `## Behavior changes` section only when runtime behavior changes (flag flips, migrations, state-machine edits, config changes, API contract changes); omit it for pure refactors and docs-only PRs; render interacting flags or modes as a small table.
+  >
+  > **"What to look at first" inclusion rule:** Include "What to look at first" only when the PR has more than ~8-10 files with *significant* changes. "Significant" means code files. Documentation and configuration files do **not** count as significant by default. A docs or config file counts as significant only when there is explicit justification for how that change affects the *behavior* of the code changes in the PR — and even when a docs/config file is deemed significant, it most likely should **not** be listed in "What to look at first" itself. When the count of significant (code) files is at or below ~8-10, **omit "What to look at first" entirely**, heading included. Only include it when a large code change genuinely needs a reading-order guide.
   >
   > Default template to follow:
   > {paste the contents of [template.md](./references/template.md)}
@@ -88,9 +88,7 @@ First, compose the **structure directive** based on the Step 2 result. The struc
 Then construct the agent prompt to include all of the following inline (the skill already has this context loaded — pass the actual values, not references):
 
 - **Branch context** — the values of `current branch`, `default branch`, `branch summary`, `branch stats`, and `branch changes` from the Project Context section.
-- **"How this was tested" inclusion decision from Step 4** — either "Include the How this was tested section" or "Omit the How this was tested section entirely (documentation-only PR)".
 - **Structure directive** — Option A or Option B as composed above.
-- **Formatting rules** — paste the contents of [formatting-rules.md](./references/formatting-rules.md) into the prompt so the agent does not need to read it.
 
 Use this prompt body (with the context above interpolated):
 
@@ -100,23 +98,16 @@ Use this prompt body (with the context above interpolated):
 >
 > **Content rules across all sections:**
 > - Lead the primary summary or description section with a single bolded TL;DR sentence in the form `**This PR <verb> <behavior>, so that <why>.**` — fill it before drafting anything else.
-> - Follow the TL;DR with 2-4 bullets covering user-visible or runtime behavior, scope, and reviewer-attention pointers. Do not list files in the summary.
-> - Identify the central mechanism (feature flags, migrations, behavioral changes) from the diff and commits before drafting, and put it in the bolded TL;DR sentence.
+> - Keep the Summary to that single sentence. No bullet list, no file mentions. Every other detail belongs in Behavior changes.
+> - Identify the central mechanism (feature flags, migrations, behavioral changes) from the diff and commits before drafting, and put it in the bolded TL;DR sentence and lead Behavior changes with it.
 > - Include specific configuration values (environment settings, flag combinations, thresholds, defaults) — not "added config for X."
 > - Never over-summarize behavioral changes — code structure can be summarized, but runtime behavior cannot. Include per-environment values, migration phases, and flag enabled/disabled behavior.
 > - Explain how components work together, not just what each one does.
 > - Only describe changes unique to the PR branch — never include changes merged from the default branch.
 > - Do not rely on internal flag names, service names, or acronyms without a brief inline definition on first use.
-> - "What to look at first" is a 2-4 bullet attention guide pointing at decisions, tradeoffs, or risks — it is NOT a file list. The file list lives in "Files of interest."
-> - "How this was tested" uses past-tense author-self-check items prefixed with `- ✅` describing scenarios the author already verified. Do not use unchecked `[ ]` boxes for these. Items must be verifiable from the PR alone.
->
-> **Files of interest rules:** This section is a bulleted list of at most 5 entries — never a table, never more than 5. Each entry is `` `path` — one phrase about why this file matters for review ``. Skip generated files, mechanical refactors, trivial changes (imports, typos), and test helpers unless central. Do not add a "+N more files" continuation row — GitHub's Files Changed tab is one click away. Apply the truncation rules from the formatting rules below to paths longer than 50 characters.
->
-> **Test scenario changes rules:** Behavioral scenarios only, in plain language. Do not include file paths in this section — test files (when central) appear in "Files of interest."
+> - "What to look at first" is a 2-4 bullet reading-order guide for a large change, pointing at decisions, tradeoffs, or risks in the order to read them — it is NOT a file list. Include it ONLY when the PR has more than ~8-10 files with significant (code) changes per the inclusion rule in the structure directive; otherwise omit the section, heading included.
 >
 > **Formatting:** Never nest fenced code blocks inside the PR description — use inline backticks for short references, indented 4-space blocks for short snippets, prose descriptions, or small tables instead. Use `##`/`###` headers for sections. Do not leave authoring-instruction HTML comments or template placeholder braces in the rendered output. Never include any form of 'Generated with Claude Code.'
->
-> **Test Plan inclusion decision (controls the "How this was tested" section):** {value from Step 4 — "Include the How this was tested section" or "Omit the How this was tested section entirely (documentation-only PR)"}
 >
 > **Structure directive:** {Option A or Option B from above}
 >
@@ -128,33 +119,29 @@ Use this prompt body (with the context above interpolated):
 > - Diff:
 > {branch changes}
 >
-> **Formatting rules:**
-> {contents of references/formatting-rules.md}
->
 > Read additional source files via your Read/Grep tools when the diff alone does not explain the change. Return only the final PR description text — no preamble, no review notes."
 
 If the agent returns anything other than a PR description (a review report, question log, etc.), discard it and re-issue the prompt with an explicit reminder to return only the description text.
 
-## Step 6: Verify the PR Description
+## Step 5: Verify the PR Description
 
 Before displaying the PR description, read it back and confirm. Use the checklist that matches the Step 2 result.
 
 **Always confirm (both cases):**
 
-1. The primary summary or description section opens with a single bolded TL;DR sentence leading with behavior. No file lists in that section.
-2. "Files of interest" (wherever it lands) is a bulleted list with 5 or fewer entries — never a table, no "+N more files" continuation row. Paths >50 chars are truncated per the formatting rules.
-3. "What to look at first" is an attention guide of 2-4 bullets pointing at decisions or risks — not a file list.
-4. "How this was tested" inclusion/omission matches Step 4. When included, its items use past-tense `- ✅` markers. "Test scenario changes" contains behavioral scenarios in plain language with no file paths.
-5. Valid markdown, no nested fenced code blocks, no leftover authoring-instruction HTML comments or template placeholder braces (`{...}`), no "Generated with Claude Code."
-6. Only branch-specific changes described.
+1. The primary summary or description section opens with a single bolded TL;DR sentence leading with behavior, and contains nothing else — no bullet list, no file mentions.
+2. "Behavior changes" carries the behavioral detail. It is present unless the PR is a pure refactor or docs-only change.
+3. "What to look at first" appears only when the PR has more than ~8-10 files with significant (code) changes — documentation and configuration files do not count as significant by default. Otherwise it is omitted entirely, heading included. When present, it is a 2-4 bullet reading-order guide pointing at decisions or risks, not a file list.
+4. Valid markdown, no nested fenced code blocks, no leftover authoring-instruction HTML comments or template placeholder braces (`{...}`), no "Generated with Claude Code."
+5. Only branch-specific changes described.
 
-**When Step 2 recorded "no repository template" (Option A), also confirm:** the sections appear in the fixed order — Summary (with `### Behavior changes` subsection when applicable) → What to look at first → How this was tested (when included) → Files of interest → Test scenario changes (when included).
+**When Step 2 recorded "no repository template" (Option A), also confirm:** the sections appear in the fixed order — Summary → Behavior changes (when applicable) → What to look at first (only when the significant-file threshold is met).
 
-**When Step 2 found a repository template (Option B), also confirm:** unless the template was a replace-scaffold per the conformance rules, every heading the template defines is present and in the template's original order; "What to look at first" and "Files of interest" appear only as appended sections after the template's sections (or filled into an equivalent the template already had), never interleaved out of order; the template's checklists are reproduced verbatim with only diff-provable boxes checked and no fabricated attestations; the template's instructional comments and placeholder prompts are stripped from the output.
+**When Step 2 found a repository template (Option B), also confirm:** unless the template was a replace-scaffold per the conformance rules, every heading the template defines is present and in the template's original order; "What to look at first" appears only as an appended section after the template's sections (or filled into an equivalent the template already had) and only when the significant-file threshold is met, never interleaved out of order; the template's checklists are reproduced verbatim with only diff-provable boxes checked and no fabricated attestations; the template's instructional comments and placeholder prompts are stripped from the output.
 
-Fix any issues directly before proceeding to Step 7.
+Fix any issues directly before proceeding to Step 6.
 
-## Step 7: Display and Update PR
+## Step 6: Display and Update PR
 
 1. **Display the PR description** — Show the full result to the user, parsed and formatted for display.
 

--- a/han-github/skills/update-pr-description/SKILL.md
+++ b/han-github/skills/update-pr-description/SKILL.md
@@ -58,7 +58,7 @@ Carry the recorded result (the template path and full contents, or "no repositor
 
 Review the branch diff, commits, and relevant source code to understand the PR. Identify the central mechanism — the primary purpose of the PR. If the PR is about feature flags, migrations, or behavioral changes, those ARE the point, not a side detail. Classify the change type (new feature, bug fix, refactoring, docs update, config change, etc.) and read related source files as needed to understand the full scope.
 
-When applicable (do not force these into every PR), collect specific details: feature flag gate names/values/interactions, actual config values per environment, before/after behavioral changes, migration phases/rollback/data flow, and state machine combinations.
+Find the headline behavioral effect — what changes for a user or caller and why — and the central mechanism's key facts (a flag and its default, a migration's direction, the new vs. old behavior). Do not catalog every config value, phase, or mode; the diff carries the specifics. The goal is a short description, not an exhaustive one.
 
 While analyzing, count the **significant** changed files from `branch stats`, since that count gates the "What to look at first" section in Step 4. "Significant" means code files. Documentation and configuration files do not count as significant by default; one counts only when there is explicit justification for how it changes the behavior of the code changes in the PR.
 
@@ -69,7 +69,9 @@ Launch a single `han-core:junior-developer` agent to write the PR description di
 First, compose the **structure directive** based on the Step 2 result. The structure directive is the only part of the prompt that differs between the two cases; everything else is shared.
 
 - **Option A — no repository template** (Step 2 recorded "no repository template"). The structure directive is:
-  > **Structure (required):** Produce the description using this fixed structure and section order: Summary (the bolded TL;DR sentence only) → Behavior changes (its own `##` section, present only when runtime behavior changes; omit for pure refactors and docs-only PRs) → What to look at first (only when the PR has more than ~8-10 files with significant changes; see the threshold rule below). The first line under `## Summary` MUST be the bolded TL;DR sentence, and the Summary section contains nothing else — no bullet list, no file mentions. Include the `## Behavior changes` section only when runtime behavior changes (flag flips, migrations, state-machine edits, config changes, API contract changes); omit it for pure refactors and docs-only PRs; render interacting flags or modes as a small table.
+  > **Structure (required):** Produce the description using this fixed structure and section order: Summary (the bolded TL;DR sentence only) → Behavior changes (its own `##` section, present only when runtime behavior changes; omit for pure refactors and docs-only PRs) → What to look at first (only when the PR has more than ~8-10 files with significant changes; see the threshold rule below). The first line under `## Summary` MUST be the bolded TL;DR sentence, and the Summary section contains nothing else — no bullet list, no file mentions. Include the `## Behavior changes` section only when runtime behavior changes (flag flips, migrations, state-machine edits, config changes, API contract changes); omit it for pure refactors and docs-only PRs.
+  >
+  > **Length (required):** The whole description is at most 2-5 short paragraphs (the Summary sentence is one of them), and Behavior changes is 1-3 short paragraphs. A small table is fine only when several flags or modes genuinely interact; prefer prose otherwise.
   >
   > **"What to look at first" inclusion rule:** Include "What to look at first" only when the PR has more than ~8-10 files with *significant* changes. "Significant" means code files. Documentation and configuration files do **not** count as significant by default. A docs or config file counts as significant only when there is explicit justification for how that change affects the *behavior* of the code changes in the PR — and even when a docs/config file is deemed significant, it most likely should **not** be listed in "What to look at first" itself. When the count of significant (code) files is at or below ~8-10, **omit "What to look at first" entirely**, heading included. Only include it when a large code change genuinely needs a reading-order guide.
   >
@@ -97,14 +99,12 @@ Use this prompt body (with the context above interpolated):
 > Follow the structure directive below for how the description is organized and laid out. Follow the content rules below for what goes in it. When the structure directive provides a repository template, the template's structure wins over the default section names referenced in the content rules; map the content into the template's sections per the conformance rules.
 >
 > **Content rules across all sections:**
-> - Lead the primary summary or description section with a single bolded TL;DR sentence in the form `**This PR <verb> <behavior>, so that <why>.**` — fill it before drafting anything else.
-> - Keep the Summary to that single sentence. No bullet list, no file mentions. Every other detail belongs in Behavior changes.
-> - Identify the central mechanism (feature flags, migrations, behavioral changes) from the diff and commits before drafting, and put it in the bolded TL;DR sentence and lead Behavior changes with it.
-> - Include specific configuration values (environment settings, flag combinations, thresholds, defaults) — not "added config for X."
-> - Never over-summarize behavioral changes — code structure can be summarized, but runtime behavior cannot. Include per-environment values, migration phases, and flag enabled/disabled behavior.
-> - Explain how components work together, not just what each one does.
+> - **Keep it short: the entire description is at most 2-5 short paragraphs** (the Summary sentence counts as one), and Behavior changes is 1-3 short paragraphs. If you are writing more, you are adding detail a reviewer should read from the diff, not the description.
+> - Lead the primary summary or description section with a single bolded TL;DR sentence in the form `**This PR <verb> <behavior>, so that <why>.**` — fill it before drafting anything else. Keep the Summary to that one sentence: no bullet list, no file mentions.
+> - Lead Behavior changes with the central mechanism (a feature flag, migration, or behavioral change) in plain language: name it and its headline effect — a flag and its default, a migration's direction, the new vs. old behavior. Do not enumerate every config value, phase, or mode; a reviewer reads the diff for specifics.
+> - Stay at the altitude of behavior and intent, not implementation. Say what changes for a user or caller and why, not how each file or function does it.
 > - Only describe changes unique to the PR branch — never include changes merged from the default branch.
-> - Do not rely on internal flag names, service names, or acronyms without a brief inline definition on first use.
+> - Define any internal flag, service, or acronym briefly on first use.
 > - "What to look at first" is a 2-4 bullet reading-order guide for a large change, pointing at decisions, tradeoffs, or risks in the order to read them — it is NOT a file list. Include it ONLY when the PR has more than ~8-10 files with significant (code) changes per the inclusion rule in the structure directive; otherwise omit the section, heading included.
 >
 > **Formatting:** Never nest fenced code blocks inside the PR description — use inline backticks for short references, indented 4-space blocks for short snippets, prose descriptions, or small tables instead. Use `##`/`###` headers for sections. Do not leave authoring-instruction HTML comments or template placeholder braces in the rendered output. Never include any form of 'Generated with Claude Code.'
@@ -131,9 +131,10 @@ Before displaying the PR description, read it back and confirm. Use the checklis
 
 1. The primary summary or description section opens with a single bolded TL;DR sentence leading with behavior, and contains nothing else — no bullet list, no file mentions.
 2. "Behavior changes" carries the behavioral detail. It is present unless the PR is a pure refactor or docs-only change.
-3. "What to look at first" appears only when the PR has more than ~8-10 files with significant (code) changes — documentation and configuration files do not count as significant by default. Otherwise it is omitted entirely, heading included. When present, it is a 2-4 bullet reading-order guide pointing at decisions or risks, not a file list.
-4. Valid markdown, no nested fenced code blocks, no leftover authoring-instruction HTML comments or template placeholder braces (`{...}`), no "Generated with Claude Code."
-5. Only branch-specific changes described.
+3. The whole description is concise — at most 2-5 short paragraphs (the Summary sentence is one), with Behavior changes at 1-3. Trim anything that restates the diff or drops to implementation-level detail.
+4. "What to look at first" appears only when the PR has more than ~8-10 files with significant (code) changes — documentation and configuration files do not count as significant by default. Otherwise it is omitted entirely, heading included. When present, it is a 2-4 bullet reading-order guide pointing at decisions or risks, not a file list.
+5. Valid markdown, no nested fenced code blocks, no leftover authoring-instruction HTML comments or template placeholder braces (`{...}`), no "Generated with Claude Code."
+6. Only branch-specific changes described.
 
 **When Step 2 recorded "no repository template" (Option A), also confirm:** the sections appear in the fixed order — Summary → Behavior changes (when applicable) → What to look at first (only when the significant-file threshold is met).
 

--- a/han-github/skills/update-pr-description/references/formatting-rules.md
+++ b/han-github/skills/update-pr-description/references/formatting-rules.md
@@ -1,7 +1,0 @@
-## File Path Truncation
-
-When displaying file paths (in a bulleted list or a table), truncate paths longer than 50 characters: keep the first path segment, add `/...`, then fill remaining characters from the end to produce a 45-50 character result. Never include the character count in the output.
-
-Example: `ui/src/pages/GearDetails/components/GearInfo/GearInfoContentFields/GearInfoContentFieldsReorderable.tsx` → `ui/...fo/GearInfoContentFieldsReorderable.tsx`
-
-Paths 50 characters or shorter should be displayed in full.

--- a/han-github/skills/update-pr-description/references/template-conformance.md
+++ b/han-github/skills/update-pr-description/references/template-conformance.md
@@ -8,17 +8,17 @@ Comments often carry the repo's authoring instructions: what each section is for
 
 ## 2. Determine the template's intent
 
-- **Replace-scaffold.** If the template (or a comment in it) instructs the author to replace its content with a written PR description — for example, "replace this content with a generated PR description" — it is a throwaway scaffold, not a structure to preserve. Discard the scaffold and produce the default structure instead: Summary (bolded TL;DR sentence + 2-4 bullets, plus a `### Behavior changes` subsection when runtime behavior changes) → What to look at first → How this was tested (only when the inclusion decision includes it) → Files of interest → Test scenario changes (only when tests were added or edited). Honoring the instruction is the point.
+- **Replace-scaffold.** If the template (or a comment in it) instructs the author to replace its content with a written PR description — for example, "replace this content with a generated PR description" — it is a throwaway scaffold, not a structure to preserve. Discard the scaffold and produce the default structure instead: Summary (the bolded TL;DR sentence only) → Behavior changes (its own `##` section; omit for pure refactors and docs-only PRs) → What to look at first (only when the PR has more than ~8-10 files with significant changes; see the threshold rule in section 5). Honoring the instruction is the point.
 - **Structural template.** Otherwise, the template's sections are the structure. Keep its headings and their order, and fill each section with the matching content below.
 
 ## 3. Map content into the template's sections
 
 For each template section, infer its purpose from its heading and any placeholder text, then fill it:
 
-- A description / summary / "what does this PR do" section gets the bolded TL;DR sentence (`**This PR <verb> <behavior>, so that <why>.**`) followed by the behavioral summary bullets.
+- A description / summary / "what does this PR do" section gets the bolded TL;DR sentence (`**This PR <verb> <behavior>, so that <why>.**`) only — no bullet list. The behavioral detail lives in Behavior changes.
 - A motivation / "why" / context section gets the rationale.
-- A testing / "how was this tested" / QA section gets the `- ✅` past-tense self-check items — but only when the inclusion decision includes them. When the decision omits them (documentation-only branch), write a short honest note in the template's tone (for example, "Documentation-only change; no tests.") rather than leaving the section blank.
-- Before/after behavioral detail goes in the section closest to a description or details section, rendered as a small table when multiple flags or modes interact.
+- A testing / "how was this tested" / QA section that the template already provides gets filled from the diff's CI and test evidence in the template's own tone. Do not invent a testing section the template does not provide.
+- Before/after behavioral detail goes in the section closest to a description or details section (or its own Behavior changes section when the template has no such home), rendered as a small table when multiple flags or modes interact.
 
 ## 4. Checkboxes: check only what the diff unambiguously proves
 
@@ -26,7 +26,7 @@ Many templates carry checklists. Check a box only when the branch diff unambiguo
 
 ## 5. Add high-value sections only when the template has no home for them
 
-The reviewer attention guide ("What to look at first") and "Files of interest" earn their place in any review. If the template already has an equivalent section (a "Reviewer notes", "Files changed", or similar), fill that instead of adding a duplicate. If the template has no equivalent, append each as its own `##` section after the template's sections — never interleaved out of the template's order.
+The reviewer attention guide ("What to look at first") earns its place on a large change. Include it only when the PR has more than ~8-10 files with *significant* changes. "Significant" means code files. Documentation and configuration files do **not** count as significant by default; a docs or config file counts only when there is explicit justification for how it changes the *behavior* of the code changes in the PR — and even then it most likely should **not** be listed in "What to look at first" itself. When the count of significant code files is at or below ~8-10, omit the section. When you do include it: if the template already has an equivalent section (a "Reviewer notes" or similar), fill that instead of adding a duplicate; otherwise append it as its own `##` section after the template's sections — never interleaved out of the template's order.
 
 ## 6. Additional information is welcome; structure is not optional
 

--- a/han-github/skills/update-pr-description/references/template-conformance.md
+++ b/han-github/skills/update-pr-description/references/template-conformance.md
@@ -8,7 +8,7 @@ Comments often carry the repo's authoring instructions: what each section is for
 
 ## 2. Determine the template's intent
 
-- **Replace-scaffold.** If the template (or a comment in it) instructs the author to replace its content with a written PR description — for example, "replace this content with a generated PR description" — it is a throwaway scaffold, not a structure to preserve. Discard the scaffold and produce the default structure instead: Summary (the bolded TL;DR sentence only) → Behavior changes (its own `##` section; omit for pure refactors and docs-only PRs) → What to look at first (only when the PR has more than ~8-10 files with significant changes; see the threshold rule in section 5). Honoring the instruction is the point.
+- **Replace-scaffold.** If the template (or a comment in it) instructs the author to replace its content with a written PR description — for example, "replace this content with a generated PR description" — it is a throwaway scaffold, not a structure to preserve. Discard the scaffold and produce the default structure instead: Summary (the bolded TL;DR sentence only) → Behavior changes (its own `##` section; omit for pure refactors and docs-only PRs) → What to look at first (only when the PR has more than ~8-10 files with significant changes; see the threshold rule in section 5). Keep it to 2-5 short paragraphs, as section 7 requires. Honoring the instruction is the point.
 - **Structural template.** Otherwise, the template's sections are the structure. Keep its headings and their order, and fill each section with the matching content below.
 
 ## 3. Map content into the template's sections
@@ -28,6 +28,10 @@ Many templates carry checklists. Check a box only when the branch diff unambiguo
 
 The reviewer attention guide ("What to look at first") earns its place on a large change. Include it only when the PR has more than ~8-10 files with *significant* changes. "Significant" means code files. Documentation and configuration files do **not** count as significant by default; a docs or config file counts only when there is explicit justification for how it changes the *behavior* of the code changes in the PR — and even then it most likely should **not** be listed in "What to look at first" itself. When the count of significant code files is at or below ~8-10, omit the section. When you do include it: if the template already has an equivalent section (a "Reviewer notes" or similar), fill that instead of adding a duplicate; otherwise append it as its own `##` section after the template's sections — never interleaved out of the template's order.
 
-## 6. Additional information is welcome; structure is not optional
+## 6. Structure is not optional
 
-You may add detail beyond what the template asks for, but every section the template defines must remain present and in its original order. Do not silently drop a template section because there is nothing to say. Fill it, or write a short honest note ("Not applicable: this PR changes documentation only."). The template's structure is the contract; your content is the fill.
+Every section the template defines must remain present and in its original order. Do not silently drop a template section because there is nothing to say. Fill it, or write a short honest note ("Not applicable: this PR changes documentation only."). The template's structure is the contract; your content is the fill.
+
+## 7. Keep the fill concise
+
+Whether you are replacing a scaffold or filling a structural template, keep the prose short: aim for 2-5 short paragraphs across the whole description, with the behavioral detail in 1-3 of them. Stay at the altitude of behavior and intent — name the central mechanism and its headline effect, and let the diff carry every config value, phase, and mode. A reviewer skims the description and reads the diff for specifics; do not restate the diff in prose.

--- a/han-github/skills/update-pr-description/references/template.md
+++ b/han-github/skills/update-pr-description/references/template.md
@@ -2,24 +2,18 @@
 
 **{One-sentence TL;DR: this PR &lt;verb&gt; &lt;behavior&gt; so that &lt;why&gt;.}**
 
-{2-4 bullets covering: what changed in user-visible or runtime behavior, what scope is affected, and what a reviewer should pay extra attention to. Include specific config values, flag names (with a brief definition on first use), and migration phases when present. Do not list files here.}
+## Behavior changes
 
-### Behavior changes
+{Plain-language description of before vs after — the load-bearing content of this PR. Lead with the central mechanism (feature flags, migrations, state-machine edits, config or API-contract changes). Include specific config values per environment, flag names and their enabled/disabled behavior, and migration phases. Name internal flags or services on first use with a brief inline definition. When multiple flags or modes interact, render as a small table. Omit this section entirely for pure refactors and docs-only PRs — in that case the Summary sentence stands alone.}
 
-{Plain-language description of before vs after. When multiple flags or modes interact, render as a small table. Name internal flags or services on first use. Omit this subsection entirely for pure refactors and docs-only PRs.}
+<!--
+Include "What to look at first" ONLY when this PR has more than ~8-10 files with SIGNIFICANT changes.
+"Significant" = code files. Documentation and configuration files do NOT count by default. A docs/config
+file counts as significant only with explicit justification for how it changes the BEHAVIOR of the code
+changes in this PR — and even then it usually does NOT belong in the list below. When the count of
+significant code files is at or below ~8-10, OMIT this whole section, heading included.
+-->
 
 ## What to look at first
 
-- {Pointer to a decision, tradeoff, or risk the reviewer should weight. 2-4 bullets max. This is not a file list — it is a "here is where the interesting decisions live" guide.}
-
-## How this was tested
-
-- ✅ {Scenario the author already verified, past tense.}
-
-## Files of interest
-
-- `{path}` — {one phrase about why this file matters for review}
-
-## Test scenario changes
-
-- {Behavioral scenario described in plain language, e.g., "Covers the case where the feature flag is on but the user is unauthenticated."}
+- {Pointer to a decision, tradeoff, or risk the reviewer should weight, in suggested reading order. 2-4 bullets max. This is a reading-order guide for a large change, not a file list — GitHub's Files Changed tab is one click away.}

--- a/han-github/skills/update-pr-description/references/template.md
+++ b/han-github/skills/update-pr-description/references/template.md
@@ -1,10 +1,15 @@
+<!--
+Keep the whole description to 2-5 short paragraphs at most. The Summary sentence is one of them;
+Behavior changes is 1-3. Stay at the altitude of behavior and intent — the diff carries the specifics.
+-->
+
 ## Summary
 
 **{One-sentence TL;DR: this PR &lt;verb&gt; &lt;behavior&gt; so that &lt;why&gt;.}**
 
 ## Behavior changes
 
-{Plain-language description of before vs after — the load-bearing content of this PR. Lead with the central mechanism (feature flags, migrations, state-machine edits, config or API-contract changes). Include specific config values per environment, flag names and their enabled/disabled behavior, and migration phases. Name internal flags or services on first use with a brief inline definition. When multiple flags or modes interact, render as a small table. Omit this section entirely for pure refactors and docs-only PRs — in that case the Summary sentence stands alone.}
+{1-3 short paragraphs, plain language, of what changes at runtime and why — the load-bearing content of this PR. Lead with the central mechanism (a feature flag, migration, state-machine edit, or config / API-contract change) and name its headline effect: a flag and its default, a migration's direction, the new vs. old behavior. Stay at the altitude of behavior and intent; do not enumerate every value, phase, or mode — the diff carries the specifics. Name internal flags or services on first use. A small table is fine only when several flags or modes genuinely interact. Omit this section entirely for pure refactors and docs-only PRs — in that case the Summary sentence stands alone.}
 
 <!--
 Include "What to look at first" ONLY when this PR has more than ~8-10 files with SIGNIFICANT changes.


### PR DESCRIPTION
## Summary

**This PR slims the `/update-pr-description` skill's output down to a single-sentence summary plus a short Behavior changes section, so that generated PR descriptions stop duplicating what GitHub's own tabs already show and stay scannable in about thirty seconds.**

## Behavior changes

The headline change is a hard length cap: descriptions the skill produces are now at most 2-5 short paragraphs (the Summary sentence counts as one, and Behavior changes is 1-3), where the skill previously aimed to be "thorough." The Summary section is now just one bolded TL;DR sentence — the old "2-4 bullets covering behavior, scope, and reviewer pointers" are gone — and the former `### Behavior changes` subsection is promoted to its own top-level section that carries the load-bearing content in plain language, leading with the central mechanism rather than enumerating every config value.

Three sections that the skill used to emit are dropped entirely: "How this was tested," "Files of interest" (the bulleted file list), and "Test scenario changes." The reasoning is that GitHub's native Checks and Files Changed tabs already render that information one click away, so repeating it in prose was noise. The "What to look at first" reading guide survives but is now conditional: it appears only when a PR has more than roughly 8-10 files with significant code changes, and documentation or config files do not count toward that threshold by default.

Mechanically, the skill drops from seven steps to six (the old "Determine 'How this was tested' Applicability" step is removed and a significant-file count folds into the Analyze Changes step to gate the conditional section), and `references/formatting-rules.md` is deleted because its only rule supported the now-removed file list. The remaining reference files, template, and long-form doc are updated to match the simplified output.