### PR TITLE
fix #90: quote argument-hint values so YAML parses them as strings

### DIFF
--- a/han-coding/skills/coding-standard/SKILL.md
+++ b/han-coding/skills/coding-standard/SKILL.md
@@ -7,7 +7,7 @@ description: >
   architectural-decision-record for ADRs. Does not write feature or system documentation — use
   project-documentation for that. Does not research open-ended options — use research. Does not
   produce runbooks for operational scenarios — use runbook for that.
-argument-hint: [standard-topic or document-path]
+argument-hint: "[standard-topic or document-path]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(mkdir *), Bash(find *)
 ---
 

--- a/han-core/skills/architectural-decision-record/SKILL.md
+++ b/han-core/skills/architectural-decision-record/SKILL.md
@@ -6,7 +6,7 @@ description: >
   into an ADR, recording an architecture or design decision, or updating the status of an existing
   ADR. Does not create or update enforceable coding standards or conventions — use coding-standard
   for that. Does not write feature or system documentation — use project-documentation instead.
-argument-hint: [topic-or-title or document-path]
+argument-hint: "[topic-or-title or document-path]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(mkdir *), Bash(find *)
 ---
 

--- a/han-core/skills/project-discovery/SKILL.md
+++ b/han-core/skills/project-discovery/SKILL.md
@@ -8,7 +8,7 @@ description: >
   tools, or repository structure. Does not create or update project
   documentation — use project-documentation for writing feature or system docs.
 
-argument-hint: [output-file-path]
+argument-hint: "[output-file-path]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(date *), Bash(mkdir *), Bash(git symbolic-ref *), Bash(find *)
 ---
 

--- a/han-core/skills/project-documentation/SKILL.md
+++ b/han-core/skills/project-documentation/SKILL.md
@@ -9,7 +9,7 @@ description: >
   coding-standard instead. Does not generate PR descriptions — use update-pr-description for that.
   Does not produce runbooks for operational scenarios — use runbook for that. Does not produce an
   ephemeral, understand-now overview of code or a PR — use code-overview for that.
-argument-hint: [feature-name or document-path]
+argument-hint: "[feature-name or document-path]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(date *), Bash(mkdir *), Bash(find *)
 ---
 

--- a/han-core/skills/runbook/SKILL.md
+++ b/han-core/skills/runbook/SKILL.md
@@ -8,7 +8,7 @@ description: >
   requiring the scenario to be real before producing the runbook. Does not produce feature or
   system documentation — use project-documentation. Does not record architectural decisions — use
   architectural-decision-record. Does not create coding standards — use coding-standard.
-argument-hint: [topic or scenario, or path to existing runbook to update]
+argument-hint: "[topic or scenario, or path to existing runbook to update]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git config *), Bash(whoami), Bash(date *), Bash(mkdir *), Bash(find *)
 ---
 

--- a/han-github/skills/post-code-review-to-pr/SKILL.md
+++ b/han-github/skills/post-code-review-to-pr/SKILL.md
@@ -7,7 +7,7 @@ description: >
   GitHub as PR comments. For local code review without posting to GitHub, use
   code-review instead. Does not write or update PR descriptions — use
   update-pr-description for that.
-argument-hint: [optional context about the PR or areas to focus on]
+argument-hint: "[optional context about the PR or areas to focus on]"
 allowed-tools: Bash(jq *), Bash(gh *), Bash(git *), Bash(make *), Bash(npm *), Read, Grep, Glob, Skill, Agent
 ---
 

--- a/han-github/skills/update-pr-description/SKILL.md
+++ b/han-github/skills/update-pr-description/SKILL.md
@@ -5,7 +5,7 @@ description: >
   CLI. Use when writing, drafting, or updating pull request descriptions, PR summaries, or PR
   bodies. Does not review code or post review comments — use code-review for local review or
   post-code-review-to-pr for posting a review to GitHub.
-argument-hint: [optional context about the PR]
+argument-hint: "[optional context about the PR]"
 allowed-tools: Read, Glob, Grep, Agent, Bash(git *), Bash(gh *)
 ---
 

--- a/han-linear/skills/work-items-to-linear/SKILL.md
+++ b/han-linear/skills/work-items-to-linear/SKILL.md
@@ -12,7 +12,7 @@ description: >
   re-runs resume cleanly. Does not produce the work-items file itself — use plan-work-items
   first. Does not post to Jira — use work-items-to-jira. Does not post to GitHub — use
   work-items-to-issues.
-argument-hint: [path to work-items.md] --team <team> [--project <Linear project>] [--parent <issue id>] [--state <name>] [--label <name> (repeatable)] [--assignee <name/email/me>]
+argument-hint: "[path to work-items.md] --team <team> [--project <Linear project>] [--parent <issue id>] [--state <name>] [--label <name> (repeatable)] [--assignee <name/email/me>]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), mcp__plugin_linear_linear__save_issue, mcp__plugin_linear_linear__get_issue, mcp__plugin_linear_linear__list_teams, mcp__plugin_linear_linear__list_issue_statuses, mcp__plugin_linear_linear__list_issue_labels, mcp__plugin_linear_linear__list_users, mcp__plugin_linear_linear__get_user, mcp__plugin_linear_linear__list_projects
 ---
 


### PR DESCRIPTION
Unquoted argument-hint values starting with '[' parse as YAML flow sequences (arrays) rather than strings. Copilot CLI rejects these with 'argument-hint must be a string', failing to load the affected skills. Quote every bare value so it parses as a string.

Fixes #90
