### PR TITLE
fix(skills): guard context-injection commands so absent tools or refs can't abort a skill

### DIFF
--- a/.claude/skills/han-release/SKILL.md
+++ b/.claude/skills/han-release/SKILL.md
@@ -24,18 +24,18 @@ allowed-tools: Read, Edit, Write, Glob, Grep, Agent, AskUserQuestion, Bash(git *
 
 ## Pre-requisites
 
-- gh CLI: !`which gh || echo MISSING`
-- jq: !`which jq || echo MISSING`
+- gh CLI: !`which gh 2>/dev/null || echo "not installed"`
+- jq: !`which jq 2>/dev/null || echo "not installed"`
 - git repo: !`git rev-parse --is-inside-work-tree 2>/dev/null || echo NO`
 
-**If `gh` or `jq` is MISSING, or this is not a git repo:** tell the operator which prerequisite is missing and that it must be installed/configured before `/han-release` can run, then **immediately stop**. The skill cannot proceed without all three.
+**If `gh` or `jq` reads `not installed`, or this is not a git repo:** tell the operator which prerequisite is missing and that it must be installed/configured before `/han-release` can run, then **immediately stop**. The skill cannot proceed without all three.
 
 ## Project Context
 
 - repo: !`gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || git config --get remote.origin.url`
-- current branch: !`git branch --show-current`
+- current branch: !`git branch --show-current 2>/dev/null || echo unknown`
 - default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || echo unknown`
-- working tree: !`git status --porcelain`
+- working tree: !`git status --porcelain 2>/dev/null || echo NO`
 - parent plugin name: !`jq -r .name .claude-plugin/marketplace.json 2>/dev/null`
 - plugins (name source version): !`jq -r '.plugins[] | "\(.name)\t\(.source)\t\(.version)"' .claude-plugin/marketplace.json 2>/dev/null`
 - latest release tag: !`git fetch --tags --quiet >/dev/null 2>&1; git tag -l 'v*.*.*' --sort=-v:refname | head -n1`

--- a/.claude/skills/han-update-documentation/SKILL.md
+++ b/.claude/skills/han-update-documentation/SKILL.md
@@ -19,17 +19,17 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(git *), Bash(find *)
 
 ## Pre-requisites
 
-- git: !`which git`
+- git: !`which git 2>/dev/null || echo "not installed"`
 - repo root marker: !`find . -maxdepth 3 -name "plugin.json" -path "*/.claude-plugin/*" -type f`
 - skill roots: !`find . -maxdepth 2 -type d -name skills -path './han-*/skills' ! -path './han-plugin-builder/skills' 2>/dev/null | sed 's|^\./||' | sort`
 - agents directory: !`find . -maxdepth 2 -type d -name agents -path './han-*/agents' 2>/dev/null | sed 's|^\./||' | sort`
 
-**If any of the above are empty:** this skill is intended to run inside the Han plugin repository. Tell the operator which marker is missing and stop. Do not attempt to operate on a different repo.
+**If any of the above are empty or read `not installed`:** this skill is intended to run inside the Han plugin repository. Tell the operator which marker is missing and stop. Do not attempt to operate on a different repo.
 
 ## Project Context
 
-- current branch: !`git branch --show-current`
-- default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD`
+- current branch: !`git branch --show-current 2>/dev/null || echo unknown`
+- default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo unknown`
 
 ## Step 1: Detect mode and scope
 

--- a/han-coding/skills/architectural-analysis/SKILL.md
+++ b/han-coding/skills/architectural-analysis/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read, Glob, Grep, Agent, Bash(find *)
 
 ## Project Context
 
-- git installed: !`which git`
+- git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
 
@@ -37,7 +37,7 @@ Read these before dispatching anything. They constrain every step below.
 
 **Resolve project context.** If `CLAUDE.md` is present (see Project Context), read its `## Project Discovery` section for conventions. Fall back to `project-discovery.md` if present. These resolve language, framework, and convention questions so the agents infer less. If neither exists, the agents fall back to surrounding-code inference — note this in the agent briefs.
 
-**Note git availability.** Read the `git installed` value from Project Context. If it is empty, git is unavailable: the analysts will skip churn- and recency-based reasoning and the report must state this. If it is non-empty, the analysts may use git history for churn and likelihood evidence.
+**Note git availability.** Read the `git installed` value from Project Context. If it is empty or reads `not installed`, git is unavailable: the analysts will skip churn- and recency-based reasoning and the report must state this. If it shows a path, the analysts may use git history for churn and likelihood evidence.
 
 **State the driving concern, if any.** If the user named a concern ("I suspect a race in the retry queue", "we want to split this module"), capture it. It biases every agent's attention without narrowing scope. Pass it into every brief.
 

--- a/han-coding/skills/code-overview/SKILL.md
+++ b/han-coding/skills/code-overview/SKILL.md
@@ -18,8 +18,8 @@ allowed-tools: Read, Glob, Grep, Agent, Write, Bash(git *), Bash(gh *), Bash(fin
 
 ## Project Context
 
-- git installed: !`which git`
-- gh installed: !`which gh`
+- git installed: !`which git 2>/dev/null || echo "not installed"`
+- gh installed: !`which gh 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
 
@@ -45,11 +45,11 @@ Read these before doing anything. They constrain every step below.
 
 **Bind `$size`.** If the user passed `small`, `medium`, or `large` as the first positional argument, bind `$size` to it. Anything else is part of the target, not a size; bind `$size` to the literal `none provided`.
 
-**Note tool availability.** Read `git installed` and `gh installed` from Project Context. If `git installed` is empty, git is unavailable — see the degraded paths below.
+**Note tool availability.** Read `git installed` and `gh installed` from Project Context. If `git installed` is empty or reads `not installed`, git is unavailable — see the degraded paths below.
 
 **Resolve the target and mode by this fixed precedence**, so an ambiguous string never silently selects the wrong mode:
 
-1. **An explicit pull request reference or URL** (e.g. `#82`, `https://github.com/owner/repo/pull/82`) → **PR mode** against that pull request. Requires `gh`; if `gh installed` is empty, tell the user `gh` is needed to read a named pull request and offer code mode against a local target instead.
+1. **An explicit pull request reference or URL** (e.g. `#82`, `https://github.com/owner/repo/pull/82`) → **PR mode** against that pull request. Requires `gh`; if `gh installed` is empty or reads `not installed`, tell the user `gh` is needed to read a named pull request and offer code mode against a local target instead.
 2. **An existing file or directory path** (confirm it resolves with Glob or find) → **code mode** on that path.
 3. **A symbol** (a function, class, type, or other named code entity) → **code mode** on that symbol. Resolve it with Grep across the repository.
 4. **No target string given** → **PR mode** against the current branch's changes (the local diff). This requires git, not a remote pull request.

--- a/han-coding/skills/code-review/SKILL.md
+++ b/han-coding/skills/code-review/SKILL.md
@@ -10,7 +10,7 @@ When running a code review, follow the process outlined here.
 
 ## Project Context
 
-- git installed: !`which git`
+- git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
 
@@ -51,7 +51,7 @@ Resolve project config: read CLAUDE.md's `## Project Discovery` section for docs
 
 ### Detect review context
 
-Check the `git installed` value from Project Context above. If it is empty, skip directly to **Mode C** below.
+Check the `git installed` value from Project Context above. If it is empty or reads `not installed`, skip directly to **Mode C** below.
 
 1. Run `${CLAUDE_SKILL_DIR}/scripts/detect-review-context.sh` to detect the git environment. Capture the output — it contains key-value pairs describing git availability, branch name, default branch, and changed files.
 

--- a/han-coding/skills/refactor/SKILL.md
+++ b/han-coding/skills/refactor/SKILL.md
@@ -17,8 +17,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git *), Bash(find *), Bash(np
 
 ## Project Context
 
-- git installed: !`git --version 2>/dev/null`
-- current branch: !`git branch --show-current 2>/dev/null`
+- git installed: !`which git 2>/dev/null || echo "not installed"`
+- current branch: !`git branch --show-current 2>/dev/null || echo unknown`
 - working tree: !`git status --porcelain 2>/dev/null | head -5`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`

--- a/han-coding/skills/tdd/SKILL.md
+++ b/han-coding/skills/tdd/SKILL.md
@@ -17,8 +17,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(git *), Bash(find *), 
 
 ## Project Context
 
-- git installed: !`git --version 2>/dev/null`
-- current branch: !`git branch --show-current 2>/dev/null`
+- git installed: !`which git 2>/dev/null || echo "not installed"`
+- current branch: !`git branch --show-current 2>/dev/null || echo unknown`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
 

--- a/han-coding/skills/test-planning/SKILL.md
+++ b/han-coding/skills/test-planning/SKILL.md
@@ -19,7 +19,7 @@ allowed-tools: Bash(git *), Bash(find *), Bash(ls *), Read, Grep, Glob, Agent
 
 ## Project Context
 
-- git installed: !`which git`
+- git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
 
@@ -27,7 +27,7 @@ allowed-tools: Bash(git *), Bash(find *), Bash(ls *), Read, Grep, Glob, Agent
 
 Resolve project config: read CLAUDE.md's `## Project Discovery` section for test command (under `### Commands and Tests`, not `### Frameworks and Tooling`), language, and framework; fall back to project-discovery.md. Store found values for use in later steps.
 
-**Scope determination:** Check `git installed` from Project Context. If empty, skip to **Mode C** below.
+**Scope determination:** Check `git installed` from Project Context. If empty or `not installed`, skip to **Mode C** below.
 
 Run `${CLAUDE_SKILL_DIR}/scripts/detect-test-context.sh` and parse its output. If `git-available: false`, skip to **Mode C** below.
 

--- a/han-core/skills/project-discovery/SKILL.md
+++ b/han-core/skills/project-discovery/SKILL.md
@@ -13,7 +13,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(git symbolic-ref *), B
 
 ## Project Context
 
-- Default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD`
+- Default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo unknown`
 - AGENTS.md: !`find . -maxdepth 1 -name "AGENTS.md" -type f`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - README: !`find . -maxdepth 1 -name "README*" -type f`

--- a/han-core/skills/research/SKILL.md
+++ b/han-core/skills/research/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read, Glob, Grep, Agent, WebSearch, WebFetch, Bash(find *)
 
 ## Project Context
 
-- git installed: !`which git`
+- git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
 

--- a/han-core/skills/runbook/SKILL.md
+++ b/han-core/skills/runbook/SKILL.md
@@ -25,7 +25,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git config *), Bash(whoami), 
 
 ## Project Context
 
-- Git user: !`git config user.name` (!`git config user.email`)
+- Git user: !`git config user.name || echo unset` (!`git config user.email || echo unset`)
 - OS username: !`whoami`
 - Today's date: !`date +%Y-%m-%d`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
@@ -67,7 +67,7 @@ If the scenario does pass the preflight, capture the evidence — the user will 
 
 3. **Enumerate existing runbooks.** Use Glob to find existing `.md` files in the runbooks directory and any service subdirectories. Read filenames to detect whether the project organizes runbooks flat (`docs/runbooks/{scenario}.md`), per-service (`docs/runbooks/{service}/{scenario}.md`), or alert-keyed (`docs/runbooks/alerts/{AlertName}.md`).
 
-4. **Resolve author information.** If git user or email is empty in the project context above, ask the user for their name and email.
+4. **Resolve author information.** If git user or email is empty or reads `unset` in the project context above, ask the user for their name and email.
 
 5. **Check existing runbook format.** If existing runbooks were found, read one to understand the project's format. If it differs from [runbook-template.md](./references/runbook-template.md), ask the user whether to match the existing format or use this skill's template. Default to matching the existing format when the project already has more than two runbooks — consistency is the larger value.
 

--- a/han-github/skills/post-code-review-to-pr/SKILL.md
+++ b/han-github/skills/post-code-review-to-pr/SKILL.md
@@ -15,20 +15,20 @@ When running a PR code review, follow the process outlined here.
 
 ## Pre-requisites
 
-- gh CLI: !`which gh`
-- jq: !`which jq`
+- gh CLI: !`which gh 2>/dev/null || echo "not installed"`
+- jq: !`which jq 2>/dev/null || echo "not installed"`
 
 If `gh` is not found, inform the user it must be installed and configured; if `jq` is not found, inform the user it must be installed. In either case, immediately stop.
 
 ## Project Context
 
-- current branch: !`git branch --show-current`
-- default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD`
-- changed files: !`gh pr diff --name-only`
+- current branch: !`git branch --show-current 2>/dev/null || echo unknown`
+- default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo unknown`
+- changed files: !`gh pr diff --name-only 2>/dev/null || echo "no pr"`
 
 ## Step 1: Validate PR State
 
-If `changed files` is empty or `gh pr view --json number,url` fails, inform the user no reviewable PR exists for the current branch and stop.
+If `changed files` is empty or reads `no pr`, or `gh pr view --json number,url` fails, inform the user no reviewable PR exists for the current branch and stop.
 
 ## Step 2: Run Code Review
 

--- a/han-github/skills/update-pr-description/SKILL.md
+++ b/han-github/skills/update-pr-description/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Read, Glob, Grep, Agent, Bash(git *), Bash(gh *)
 
 ## Pre-requisites
 
-- gh CLI: !`which gh`
+- gh CLI: !`which gh 2>/dev/null || echo "not installed"`
 
 **If the gh CLI is not found:**
 - Inform the user that it needs to be installed and configured before this skill can be used
@@ -19,17 +19,17 @@ allowed-tools: Read, Glob, Grep, Agent, Bash(git *), Bash(gh *)
 
 ## Project Context
 
-- current branch: !`git branch --show-current`
-- default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD`
-- branch summary: !`git log origin/HEAD..HEAD --oneline`
-- branch stats: !`git diff origin/HEAD...HEAD --stat`
-- branch changes: !`git diff origin/HEAD...HEAD`
+- current branch: !`git branch --show-current 2>/dev/null || echo unknown`
+- default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo unknown`
+- branch summary: !`git log origin/HEAD..HEAD --oneline 2>/dev/null || echo unknown`
+- branch stats: !`git diff origin/HEAD...HEAD --stat 2>/dev/null || echo unknown`
+- branch changes: !`git diff origin/HEAD...HEAD 2>/dev/null || echo unknown`
 
 ## Step 1: Validate Branch State
 
 Before generating a PR description, verify the branch has content to describe:
 
-1. **If `default branch` is empty** — `origin/HEAD` is not set. Use `AskUserQuestion` to ask the user for the default branch name (e.g., `main`, `master`, `develop`). Use that branch as the base for all git commands in subsequent steps.
+1. **If `default branch` is empty or `unknown`** — `origin/HEAD` is not set. Use `AskUserQuestion` to ask the user for the default branch name (e.g., `main`, `master`, `develop`). Use that branch as the base for all git commands in subsequent steps, and recompute `branch summary`, `branch stats`, and `branch changes` against it — their Project Context values may read `unknown` because they were derived from the unset `origin/HEAD`.
 
 2. **If `branch summary` is empty** — there are no commits on this branch relative to the default branch. Inform the user and stop.
 

--- a/han-plugin-builder/skills/guidance/references/skill-building-guidance/context-injection-commands.md
+++ b/han-plugin-builder/skills/guidance/references/skill-building-guidance/context-injection-commands.md
@@ -92,21 +92,15 @@ See also: [Script Execution Instructions](./script-execution-instructions.md) fo
 
 Shell scripts can safely use pipes, redirects, subcommands, and complex logic because they run as normal bash processes, not through the skill context injection system.
 
-### Rule: Use `which` to check if a tool is installed
+### Rule: Use `which` (guarded) to check if a tool is installed
 
-Use `which {command}` as the preferred way to determine if an executable tool is installed. For example:
+Use `which {command} 2>/dev/null || echo "not installed"` to check whether a tool is installed:
 ```
-- gh CLI: !`which gh`
-- jq: !`which jq`
+- gh CLI: !`which gh 2>/dev/null || echo "not installed"`
+- jq: !`which jq 2>/dev/null || echo "not installed"`
 ```
 
-A `` !`gh --version` `` style check also runs, but it has two problems:
-1. It returns more output than needed (full version string vs just a path)
-2. If the tool is not installed, running `{command} --version` returns a non-zero exit code, which can cause the skill to exit immediately before it has a chance to inform the user
-
-`which` is preferred because:
-- It returns the path if found, or empty output if not — no error exit code
-- The skill's Pre-requisites gate logic can then check for empty output and stop gracefully with a user-facing message
+When the tool is missing, `which` exits non-zero and may print to stderr — either can abort the skill or dirty the injected value. `2>/dev/null` drops the stderr and `|| echo "not installed"` forces a clean exit plus a sentinel the Pre-requisites gate checks. Prefer this over `{command} --version`, which fails the same way. The same guard fits any command that fails when its subject is absent — e.g. `git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo unknown` when `origin/HEAD` may be unset.
 
 ### Rule: Use `find` instead of `ls` for file detection
 
@@ -164,7 +158,6 @@ This bites skills that document or analyze other skills. A skill whose SKILL.md 
 | Redirects | `command 2>/dev/null` | Unnecessary; empty output is valid |
 | Subcommand substitution | `$(command)` | Permissions/execution failures |
 | Chained commands | `cmd1 && cmd2` | Permissions/execution failures |
-| Fallback defaults | `command \|\| echo "X"` | Use empty checks in step logic instead |
 | Output limiting | `command \| head -N` | Let full output inject |
 | `ls` for detection | `ls filename` | Use `find` instead; `ls` fails on missing files |
 | Heredocs | `<<'EOF' ... EOF` | Extract to shell scripts |
@@ -218,18 +211,18 @@ Examples organized by purpose:
 - `` !`find . -maxdepth 4 -type d -path "*/.claude/rules/coding-standards"` `` — check for a path-scoped rules directory
 
 **Tool availability:**
-- `` !`which gh` `` — check for the gh CLI
-- `` !`which jq` `` — check for jq
-- `` !`which git` `` — check for git
+- `` !`which gh 2>/dev/null || echo "not installed"` `` — check for the gh CLI
+- `` !`which jq 2>/dev/null || echo "not installed"` `` — check for jq
+- `` !`which git 2>/dev/null || echo "not installed"` `` — check for git
 
 ## Summary Checklist
 
 1. Use `` !`command` `` in `## Pre-requisites` or `## Project Context`
 2. Single commands only — no pipes, redirects, subcommands, or chaining
-3. Use `which {command}` for tool availability checks
+3. Use `which {command} 2>/dev/null || echo "not installed"` for tool availability checks
 4. Use `find` for file/directory detection, not `ls`
 5. Extract complex operations into shell scripts
-6. Handle empty output in step logic — do not use `2>/dev/null`, `|| echo`, or `| head`
+6. Handle empty output in step logic — don't trim it with `| head`
 7. Do not duplicate commands across sections
 8. Use separate `Bash()` entries in `allowed-tools`
 9. Never use the literal bang-backtick pattern in SKILL.md prose — the loader parses raw text regardless of markdown escaping

--- a/han-plugin-builder/skills/guidance/references/skill-building-guidance/dynamic-project-discovery.md
+++ b/han-plugin-builder/skills/guidance/references/skill-building-guidance/dynamic-project-discovery.md
@@ -33,21 +33,20 @@ For context injection commands, use:
 ```
 This injects the actual default branch name at skill load time.
 
-### Rule: Use `which` for tool availability, not `--version`
+### Rule: Use `which` (guarded) for tool availability, not `--version`
 
-Check tool availability with `which {command}` in the Pre-requisites section.
+Check tool availability with `which {command} 2>/dev/null || echo "not installed"` in the Pre-requisites section.
 
 **Before (problematic):**
 ```
 - gh CLI: !`gh --version`
 ```
-Two problems: (1) it returns a verbose version string the skill doesn't need, and (2) if `gh` isn't installed, the non-zero exit code can cause the skill to fail before it can inform the user gracefully.
 
 **After (correct):**
 ```
-- gh CLI: !`which gh`
+- gh CLI: !`which gh 2>/dev/null || echo "not installed"`
 ```
-Returns the path if found, empty if not — no error exit code. The skill's Pre-requisites logic can check for empty output and stop with a user-facing message.
+A missing tool makes `which` (or `--version`) exit non-zero and print to stderr, which can abort the skill. `2>/dev/null` drops the stderr and `|| echo "not installed"` forces a clean exit plus a sentinel the Pre-requisites logic checks.
 
 ### Rule: Discover project structure dynamically
 
@@ -70,10 +69,10 @@ When a required external tool is missing, the skill should inform the user and s
 ```markdown
 ## Pre-requisites
 
-- gh CLI: !`which gh`
-- jq: !`which jq`
+- gh CLI: !`which gh 2>/dev/null || echo "not installed"`
+- jq: !`which jq 2>/dev/null || echo "not installed"`
 
-If any of the above are empty, inform the user which tool is missing and stop.
+If any of the above read `not installed` (or are empty), inform the user which tool is missing and stop.
 ```
 
 The Pre-requisites section runs before any substantive steps. If a required tool isn't found, the skill tells the user what to install rather than failing partway through execution.
@@ -81,7 +80,7 @@ The Pre-requisites section runs before any substantive steps. If a required tool
 ## Summary Checklist
 
 1. Never hardcode branch names — use `origin/HEAD` or `git symbolic-ref --short refs/remotes/origin/HEAD`
-2. Use `which {command}` for tool availability checks, not `{command} --version`
+2. Use `which {command} 2>/dev/null || echo "not installed"` for tool availability checks, not `{command} --version`
 3. Discover project structure with `find` — don't assume paths exist
 4. Gate execution on Pre-requisites and handle empty output gracefully
 


### PR DESCRIPTION
## Problem

Context-injection commands (the bang-backtick reads in `SKILL.md`) run at skill load, and a non-zero exit can abort the skill before its gate logic runs. Multiple skills used commands that exit non-zero when their subject is absent — most visibly the `which <tool>` availability checks, which exit `1` when the tool isn't installed (the failure seen when an executable under test is missing).

## What changed

**Tool-availability checks.** Every `which <tool>` context-injection read now uses `which <tool> || echo "not installed"` (exits 0, injects a clear sentinel). `tdd` and `refactor` used the `git --version` anti-pattern for their "git installed" check (exit 127 when git is absent); both now use the guarded `which` form.

**Git ref / repo / PR state.** Guarded the commands that exit non-zero when a precondition is absent, each with `2>/dev/null || echo <sentinel>`, and updated every consumer that gated on an empty value to also read the sentinel:

- `git symbolic-ref --short refs/remotes/origin/HEAD` and `git log/diff origin/HEAD...HEAD` — exit 128 when `origin/HEAD` is unset
- `git branch --show-current` / `git status --porcelain` — exit 128 outside a repo
- `gh pr diff --name-only` — fails with no PR
- `git config user.name/email` — exit 1 when the identity is unset

**han-release.** Standardized its prerequisite sentinel from `MISSING` to `not installed`.

**Guidance.** The plugin-builder guidance wrongly claimed `which` has "no error exit code" on not-found and listed `|| echo` as a pattern to avoid. Corrected to teach the guarded form and carve out the exception for any command that exits non-zero when its subject is absent.

## Evidence

- `which <missing>` → exit 1; `which <missing> || echo "not installed"` → exit 0.
- `git symbolic-ref --short refs/remotes/origin/HEAD` with no `origin/HEAD` → exit 128; `git log origin/HEAD..HEAD` → exit 128.

## Known residuals (intentionally not changed)

Three `han-release` reads of the han repo's own guaranteed-present files (`grep … CHANGELOG.md`, `jq … marketplace.json` ×2) are left as-is: a word-sentinel would corrupt their parsed output, and the clean fix is a file-existence prerequisite gate — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
