### PR TITLE
Prevent HITL over-gating on already-verified assumptions

### DIFF
--- a/han-planning/skills/plan-implementation/references/feature-implementation-plan-template.md
+++ b/han-planning/skills/plan-implementation/references/feature-implementation-plan-template.md
@@ -99,6 +99,15 @@ skipped step.
 
 ### Assumptions
 
+<!--
+Status is exactly one of: `Verified` (a source cite settles it: file:line, ADR,
+or standard), `Runtime-only` (cannot be known until it runs), or `Open` (not yet
+checked). One status per assumption. If it is confirmed from source, it is
+`Verified`. Do not tack on "but unverified at runtime". A separate runtime
+unknown gets its own row. Mixing the two hides a settled fact and makes later
+steps gate on it for no reason.
+-->
+
 | ID | Assumption | What Changes If Wrong | Verifier | Status |
 |----|------------|-----------------------|----------|--------|
 | A1 | … | … | … | … |

--- a/han-planning/skills/plan-work-items/SKILL.md
+++ b/han-planning/skills/plan-work-items/SKILL.md
@@ -84,6 +84,7 @@ Launch `han-core:project-manager` (`subagent_type: "han-core:project-manager"`) 
 - The artifact inventory from Step 4.
 - The Rules section of this skill verbatim.
 - A directive to draft vertical slices: each work item is a narrow but complete path through the appropriate layers (schema, API, UI, tests), demoable or verifiable on its own. Classify each work item as **HITL** (requires human interaction: an architectural decision, a design review) or **AFK** (can be implemented and merged without a sync). Prefer AFK over HITL. Prefer many thin work items over few thick ones.
+- A directive on unverified assumptions: do not mark a work item HITL only because the plan calls an assumption unverified. First check two things. (a) Can you settle it by reading the code? Do that, and move on if it holds. (b) If the assumption turns out wrong, does something break, or does it fall back to a safe default? Mark it HITL only when you cannot settle it from code **and** getting it wrong causes real breakage. Otherwise it is AFK. Reserve HITL for genuine architectural or design calls.
 - A directive to return the proposed breakdown as a numbered list. Do not write any files.
 
 Return the han-core:project-manager's output verbatim. Proceed to Step 6.


### PR DESCRIPTION
## Summary

Stops the planning skills from gating a work item behind human review when the assumption it rests on is already settlable from code.

In a real run, `plan-work-items` classified a work item as HITL (human-in-the-loop, merge-gated) because a supporting assumption was labeled "unverified." The assumption was in fact resolvable from the codebase in a few reads, and the genuinely-unverified part it got tangled with was benign either way. Two loose instructions let that happen:

1. **`plan-implementation`** records plan assumptions in a RAID table whose `Status` column is free-text. Nothing stopped a compound label like `Evidenced (claim 2), unverified at runtime`, which fused a fact confirmed from source with a separate runtime-only unknown into one status.
2. **`plan-work-items`** gave the project-manager subagent no procedure for assumption-driven gates, so it took the word "unverified" at face value and escalated to a human.

## Key file changes

- **`han-planning/skills/plan-implementation/references/feature-implementation-plan-template.md`** — constrains the Assumptions `Status` column to exactly one of `Verified` / `Runtime-only` / `Open`, one status per assumption, with an explicit ban on appending a runtime caveat to a verified assumption. A genuinely runtime-only unknown gets its own row.
- **`han-planning/skills/plan-work-items/SKILL.md`** — adds a directive to the classification step: before marking a work item HITL on an unverified assumption, first try to settle it from code, and check whether its open item is a correctness gate or a benign fallback. Gate only when the assumption resists cheap verification and getting it wrong causes real breakage.

Ten added lines total, no removals.

## Test Plan

Re-ran `plan-work-items` against a real plan that contains the exact failure case (an assumption marked "Evidenced… unverified at runtime" plus a benign open item). The target work item classified **AFK, not HITL** — the skill settled the assumption by reading the provider files and recognized the open item as a safe fallback, exactly the intended behavior.

Honest caveat on how it ran: a mid-session plugin cache swap does not hot-reload a skill body, so the run did not load the branch's `SKILL.md` off disk. Instead the edited classification directive (the branch's only behavioral change to `plan-work-items`) was passed to the project-manager subagent verbatim, faithfully reproducing the behavioral delta. A fully file-loaded run would require a fresh session after registering the local repo as a marketplace. Given the change is a single directive and it was exercised directly, the reproduction covers the delta.

The `plan-implementation` template change affects plan authoring, not classification, and was verified by inspection: it is a guidance comment on the Assumptions table, exercised whenever a plan renders that table.

Ran `/han-update-documentation` on the branch: no doc changes needed. The long-form docs describe HITL/AFK and the RAID log at a higher altitude than the specifics changed here, so nothing was contradicted or made stale.
