### PR TITLE
feat(plan-work-items): classify each item's implementation, review, and expected paths

### DIFF
--- a/docs/skills/han-planning/plan-work-items.md
+++ b/docs/skills/han-planning/plan-work-items.md
@@ -12,8 +12,10 @@ Operator documentation for the `/plan-work-items` skill in the han plugin. This 
 
 ## Key concepts
 
-- **Vertical slice.** Each work item is a narrow but complete path through the relevant layers (schema, API, UI, tests). A completed work item is demoable or verifiable on its own: not a layer, not a stub.
-- **HITL and AFK.** Every work item is classified as HITL (requires a human sync: an architectural decision, a design review) or AFK (can be implemented and merged without one). The skill prefers AFK and prefers many thin work items over few thick ones.
+- **Vertical slice.** Each work item is a narrow but complete path through the relevant layers (schema, API, UI, tests). A completed work item is demoable or verifiable on its own: not a layer, not a stub. The skill prefers many thin work items over few thick ones.
+- **Suggested implementation and review.** For each work item the skill selects a suggested implementation skill and a suggested review, chosen from the deliverable-skill catalog by the item's deliverable nature (testable code to `tdd` reviewed by `code-review`, documentation to `project-documentation` reviewed by a content audit, a new skill to `skill-builder` reviewed by a human read, and so on). Each suggestion carries an `AFK` marker (the part can run unattended) or a `HITL` marker (the part needs a human). You can override either one per item.
+- **Item type.** Each work item records a `Type`: `deliverable` (the default, which builds and commits), `audit` (a checks-only pass that may declare `Expected paths: None` and complete without a commit), or `spike` (an investigation that records a finding). Non-code, plugin-editing, audit, and spike work now have catalog homes, so a plan that mixes them with code classifies without a manual override.
+- **Derived autonomy.** AFK/HITL is no longer stored as a single field. A work item is fully autonomous only when its implementation and its review are both `AFK` and its separate `Requires pre-work decisions` field is `no`; otherwise it needs a human. From those signals the closing summary sorts every item into three buckets: driver-ready (a `tdd` build and a `code-review` review, both `AFK`, which [`/implement-work-items`](../han-coding/implement-work-items.md) can drive end to end), run-the-skill-yourself (both parts `AFK` but a combination the driver does not drive), and needs-a-human.
 - **Symbolic ID.** Each work item gets a stable identifier (`W-N`). IDs are for cross-referencing work items within the file and citing them in tickets, threads, and follow-up work. They are stable for the life of the file.
 - **One file, no repository awareness.** The output is exactly one `work-items.md`. The skill never splits work by repository, counts repositories, or reasons about cross-repository integration. The breakdown is driven only by the plan or context it is given.
 - **Dependencies.** A work item's `Depends on` line names other work items in the same file that must complete first, or `None`. Work items are written in dependency order.
@@ -55,8 +57,8 @@ Example prompts that work well:
 
 One file on disk plus an in-channel summary:
 
-- **`work-items.md`** in the resolved folder. The stakeholder-readable artifact. It opens with a title line and an intro paragraph that links the parent plan (or names the source context) and explains the `W-N` ID scheme. When a single reference artifact applies to more than one work item, a **Shared reference artifacts** preamble cites it once. Then one section per work item, in dependency order. Each work item carries: `Summary` (with an inline plan reference), `Description`, optional `Design references`, `References`, `Tests`, `Acceptance criteria`, and `Depends on`.
-- An **in-channel summary** with the file path, a count of work items by type (HITL / AFK), and the next concrete action.
+- **`work-items.md`** in the resolved folder. The stakeholder-readable artifact. It opens with a title line and an intro paragraph that links the parent plan (or names the source context) and explains the `W-N` ID scheme. When a single reference artifact applies to more than one work item, a **Shared reference artifacts** preamble cites it once. Then one section per work item, in dependency order. Each work item carries: `Type` (`deliverable`, `audit`, or `spike`), `Summary` (with an inline plan reference), `Description`, optional `Design references`, `References`, `Checks`, `Acceptance criteria`, `Requires pre-work decisions` (`yes` or `no`), `Suggested implementation` and `Suggested review` (each a skill, agent, or bare `none`, plus an `AFK` or `HITL` marker, so an autonomous driver knows which items it can build unattended), `Expected paths` (the repo-root-relative files the item is expected to touch, which an autonomous driver checks changed files against), and `Depends on`.
+- An **in-channel summary** with the file path, a count of how many items can run unattended versus how many need a human, the three-bucket sort (driver-ready, run-the-skill-yourself, needs-a-human), an install recommendation for any best-fit skill that is not installed, and the next concrete action.
 
 ## How to get the most out of it
 
@@ -64,12 +66,13 @@ One file on disk plus an in-channel summary:
 - **Pair with `/plan-implementation` upstream.** This skill depends on there being a plan to break down. `/plan-implementation` produces it.
 - **Pair with `/iterative-plan-review` upstream.** A highly-trusted, reviewed-and-battle-tested plan makes dividing it into work items much easier and the breakdown sharper. Do not break down a plan you do not yet trust.
 - **Pair with `/plan-a-phased-build` upstream when the work is large.** When the effort is big enough to ship in slices, phase it first, plan the implementation of a single phase, then run this skill against that phase's plan. Each work-items file then covers one phase.
-- **Pair with `/tdd` downstream.** Once the breakdown is written, `/tdd` implements a work item test-first. The work item's `Description`, `Tests`, and `Acceptance criteria` become the behavior test list.
+- **Pair with `/tdd` downstream.** Once the breakdown is written, `/tdd` implements a work item test-first. The work item's `Description`, `Checks`, and `Acceptance criteria` become the behavior test list.
+- **Pair with `/implement-work-items` downstream to build the breakdown.** `/implement-work-items` routes each item by its recorded markers: it builds, verifies, reviews, and commits a fully-autonomous item (an `AFK` build and `AFK` review, no pre-work decision) unattended in sub-agents, and pauses in-session for an item that needs you (a pre-work decision, a foreground build, or a human review). It drives a mixed breakdown end-to-end this way, halting only on an item it cannot finish or a named skill it cannot resolve.
 - **Pair with `/work-items-to-issues` downstream when you track work on GitHub.** Once the breakdown is written, `/work-items-to-issues` publishes each item as a GitHub issue in its target repo. It needs the `han-github` plugin and the `gh` CLI.
 
 ## YAGNI (when applicable)
 
-YAGNI does not gate this skill's output. The work-items file is a structural decomposition of an already-committed implementation plan: the work item boundaries, HITL/AFK classification, and reference artifact links derive from what the plan already decided. This skill does not introduce new behavioral commitments or speculative infrastructure. YAGNI enforcement belongs upstream, in `/plan-implementation` and `/iterative-plan-review`, before the plan reaches this stage.
+YAGNI does not gate this skill's output. The work-items file is a structural decomposition of an already-committed implementation plan: the work item boundaries, the per-item skill selection and derived autonomy, and reference artifact links derive from what the plan already decided. This skill does not introduce new behavioral commitments or speculative infrastructure. YAGNI enforcement belongs upstream, in `/plan-implementation` and `/iterative-plan-review`, before the plan reaches this stage.
 
 If the plan you are decomposing has not yet been through a YAGNI sweep, run `/iterative-plan-review` first.
 
@@ -87,7 +90,7 @@ The skill's input is a trusted implementation plan, or whatever context describe
 
 **Resolving the output location.** The skill writes exactly one `work-items.md`. It goes in the user-specified folder, the plan file's folder, or next to the source context. When none of those exist, it goes in a best-guess folder of two to four kebab-case words under an existing documentation root. It states which folder it chose and proceeds without waiting for confirmation. If a `work-items.md` already exists in the chosen folder, the skill does not overwrite it and does not stop to ask. It writes to a timestamp-suffixed name instead, and states which file it wrote. The existing file is always preserved.
 
-**The breakdown.** `project-manager` receives the full plan content, the reference artifact inventory, and the skill's Rules verbatim. Its directive is to draft vertical slices: each work item a narrow but complete path through the appropriate layers, demoable or verifiable on its own, classified HITL or AFK. It prefers AFK, and prefers many thin work items over few thick ones. It returns a numbered list and writes no files. The skill returns that list verbatim, assigns `W-N` IDs, prints the breakdown for visibility, and writes the file without waiting for approval.
+**The breakdown.** `project-manager` receives the full plan content, the reference artifact inventory, and the skill's Rules verbatim, with a directive to draft vertical slices: each work item a narrow but complete path through the appropriate layers, demoable or verifiable on its own, preferring many thin work items over few thick ones. For each item it selects a suggested implementation and a suggested review from the deliverable-skill catalog, records the `AFK` or `HITL` marker on each and the `Requires pre-work decisions` field, applies any operator override, and runs installed-skill detection so a best-fit skill that is not installed is reported rather than silently assigned. It returns a numbered list and writes no files. The skill returns that list verbatim, assigns `W-N` IDs, prints the breakdown for visibility, and closes with the three-bucket recommendation, writing the file without waiting for approval.
 
 **Incremental writing.** The skill writes the title and intro first, then appends each work item as it is finalized. Buffering the whole document in conversation memory and writing at the end is explicitly disallowed. If something interrupts the run, the work in progress is preserved on disk.
 
@@ -109,7 +112,7 @@ URL: https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary
 
 ### Mike Cohn: *User Stories Applied* (INVEST)
 
-Cohn's INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable) inform the per-work-item shape. Each work item is independent enough to grab on its own, small enough to ship as a unit, and testable through its `Tests` and `Acceptance criteria` fields. The HITL/AFK split is the skill's read of the Independent criterion: an AFK work item can be merged without a human sync.
+Cohn's INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable) inform the per-work-item shape. Each work item is independent enough to grab on its own, small enough to ship as a unit, and testable through its `Checks` and `Acceptance criteria` fields. The derived autonomy is the skill's read of the Independent criterion: a fully-autonomous item (both parts `AFK`, no required pre-work decision) can be built and merged without a human sync.
 
 URL: https://www.mountaingoatsoftware.com/books/user-stories-applied
 
@@ -123,7 +126,9 @@ URL: https://www.mountaingoatsoftware.com/books/user-stories-applied
 - [`/iterative-plan-review`](./iterative-plan-review.md). Pair upstream to harden a plan you do not yet trust before breaking it into work items.
 - [`/plan-a-phased-build`](./plan-a-phased-build.md). Pair upstream when the work is large enough to ship in phases. Phase first, plan one phase, then break that phase's plan into work items.
 - [`/tdd`](../han-coding/tdd.md). Pair downstream to implement a work item test-first.
+- [`/implement-work-items`](../han-coding/implement-work-items.md). Pair downstream to drive a set of driver-ready items (a `tdd` build and a `code-review` review, both `AFK`) to committed code unattended. Part of the `han-coding` plugin.
 - [`/work-items-to-issues`](../han-github/work-items-to-issues.md). Pair downstream to publish the work items as GitHub issues. Part of the `han-github` plugin.
 - [Work item template](../../../han-planning/skills/plan-work-items/references/work-item-template.md). The template the skill renders for each work item.
+- [Deliverable-skill catalog](../../../han-planning/skills/plan-work-items/references/deliverable-skill-catalog.md). The deliverable-nature map the skill uses to select each item's suggested implementation and review, plus the override, non-han, and not-installed rules.
 - [Work-items file format](../../../han-planning/skills/plan-work-items/references/work-items-file-format.md). The title, intro, and preamble structure of the output file.
 - [Reference artifact inventory](../../../han-planning/skills/plan-work-items/references/reference-artifact-inventory.md). The include list, exclude list, and screenshot-to-work-item mapping rules the skill applies in Step 4.

--- a/han-planning/skills/plan-work-items/SKILL.md
+++ b/han-planning/skills/plan-work-items/SKILL.md
@@ -83,8 +83,10 @@ Launch `han-core:project-manager` (`subagent_type: "han-core:project-manager"`) 
 - The full plan or context content from Step 1.
 - The artifact inventory from Step 4.
 - The Rules section of this skill verbatim.
-- A directive to draft vertical slices: each work item is a narrow but complete path through the appropriate layers (schema, API, UI, tests), demoable or verifiable on its own. Classify each work item as **HITL** (requires human interaction: an architectural decision, a design review) or **AFK** (can be implemented and merged without a sync). Prefer AFK over HITL. Prefer many thin work items over few thick ones.
-- A directive on unverified assumptions: do not mark a work item HITL only because the plan calls an assumption unverified. First check two things. (a) Can you settle it by reading the code? Do that, and move on if it holds. (b) If the assumption turns out wrong, does something break, or does it fall back to a safe default? Mark it HITL only when you cannot settle it from code **and** getting it wrong causes real breakage. Otherwise it is AFK. Reserve HITL for genuine architectural or design calls.
+- A directive to draft vertical slices: each work item is a narrow but complete path through the appropriate layers (schema, API, UI, tests), demoable or verifiable on its own. Prefer many thin work items over few thick ones.
+- A directive to select, for each work item, its **Suggested implementation** and **Suggested review** using [references/deliverable-skill-catalog.md](./references/deliverable-skill-catalog.md).
+- A directive to derive each work item's **Expected paths** (the repo-root-relative files the item is expected to create or modify) from the plan's named touch points and, where the plan does not name files, the codebase exploration from Step 3 (naming the intended path for a file the item creates). Expected paths is a best-effort declaration the operator confirms: when the plan gives no file-level detail for an item, flag that item's paths as low-confidence in the breakdown rather than inventing a precise set. Follow [references/work-item-template.md](./references/work-item-template.md).
+- A directive on unverified assumptions: do not set a work item's **Requires pre-work decisions** to `yes` only because the plan calls an assumption unverified. First check two things. (a) Can you settle it by reading the code? Do that, and move on if it holds. (b) If the assumption turns out wrong, does something break, or does it fall back to a safe default? Require a pre-work decision only when you cannot settle it from code **and** getting it wrong causes real breakage. Reserve it for genuine architectural or design calls.
 - A directive to return the proposed breakdown as a numbered list. Do not write any files.
 
 Return the han-core:project-manager's output verbatim. Proceed to Step 6.
@@ -102,10 +104,11 @@ Work item title format: `<W-N> — <short descriptive name>` (em-dash separator)
 Print a numbered list for visibility. For each work item show:
 
 - **Title**: `<W-N> — <short descriptive name>`
-- **Type**: HITL or AFK
+- **Suggested implementation** and **Suggested review**
 - **Depends on**: other work items in this file that must complete first, or `None`
 - **Plan reference**: the decisions or work units from the parent plan this work item satisfies (e.g., `D-3, D-7, Work Unit 2`)
 - **Reference artifacts**: contract sections, design frame IDs, ADRs, and other references from Step 4
+- **Flags**: any low-confidence classification, non-han skill suggestion, not-installed note, skill override mismatch, or skill override-resolution note
 - **Design references**: when `ui-designs/` exists and the work item is UI-bearing, the screenshot filenames that will be referenced
 
 This report is for visibility, not approval. Do not wait for the user's confirmation — proceed directly to Step 8 and write the file.
@@ -116,4 +119,4 @@ Write one `work-items.md` in the folder resolved in Step 2. The file layout (tit
 
 Write incrementally per the operating principle: write the title and intro first, then append each work item as it is finalized. Save after each.
 
-When the file is complete, give the user a short in-channel summary: the file path, the count of work items by type (HITL / AFK), and the next concrete action (typically "review the breakdown, then start the first AFK work item").
+When the file is complete, give the user a short in-channel summary: the file path, a count of how many items run unattended (both `Suggested implementation` and `Suggested review` are `AFK`, with no required pre-work decision) versus how many pause for a human, and the next concrete action. `implement-work-items` drives the whole set, routing each item by its recorded markers: it runs an unattended item in sub-agents and pauses in-session for one that needs a human (a pre-work decision, a foreground `HITL` or bare `none` build, or a `HITL` or `none` review). Name which items will pause so the operator knows where they are needed, and note that the driver aborts only on a named skill it cannot resolve. Offer driving the set with `/implement-work-items` when that skill is available; otherwise the default next action is "review the breakdown, then start the first item with its `Suggested implementation`" (for example `/tdd`). Print an install recommendation for any item whose best-fit skill is not installed.

--- a/han-planning/skills/plan-work-items/references/deliverable-skill-catalog.md
+++ b/han-planning/skills/plan-work-items/references/deliverable-skill-catalog.md
@@ -1,0 +1,79 @@
+# Deliverable-skill catalog
+
+This map is used to choose each work item's **suggested implementation** and **suggested review** fields.
+
+## How to classify one work item
+
+Each work item consists of two parts: implementation and review. For each part, derive an appropriate skill, sub-agent, or action that can perform it. Additionally, classify part as `AFK` (can be completed without human input) or `HITL` (requires human participation). This will inform whether the part can run in a background sub-agent.
+
+1. **Classify the deliverable nature and pick the implementation and review skill** from Table 1.
+2. **Apply operator overrides** (see "Overrides").
+3. **Handle the non-han and not-installed cases** (see those sections).
+
+## Table 1: deliverable nature to implementation and review
+
+| Deliverable nature | Suggested implementation | Suggested review |
+|---|---|---|
+| New or changed testable code | `han-coding:tdd`, AFK | `han-coding:code-review`, AFK |
+| Behavior-preserving restructuring of already-tested code | `han-coding:refactor`, HITL | `han-coding:code-review`, AFK |
+| A new Claude Code skill | `han-plugin-builder:skill-builder`, HITL | none, HITL |
+| A new Claude Code agent | `han-plugin-builder:agent-builder`, HITL | none, HITL |
+| Editing an existing skill, agent, or plugin definition | `general-purpose` agent, AFK | none, HITL |
+| Other work related to Claude Code plugins | `general-purpose` agent, AFK | none, HITL |
+| Authoring feature or system documentation | `han-core:project-documentation`, AFK | `han-core:information-architect` agent, AFK |
+| Editing feature or system documentation | `han-core:project-documentation`, AFK | `han-core:content-auditor` agent, AFK |
+| An architectural decision record | `han-core:architectural-decision-record`, HITL | none, HITL |
+| A coding standard | `han-coding:coding-standard`, HITL | none, HITL |
+| A runbook | `han-core:runbook`, HITL | none, HITL |
+| An audit pass (checks, no new deliverable) | named checks, AFK if automatable else HITL | none, HITL |
+| A spike (an investigation that records a finding) | route by question (see "Spikes") | none, HITL |
+| No han skill fits | scan installed skills (see "Non-han skills"); if none fits, bare "none, HITL" |
+
+### `han-coding:tdd`
+
+Use `tdd` only for deliverables with tests to lead their development (code, or anything test-verifiable). Never default a non-testable deliverable (documentation, a vendoring step, an ADR) to `tdd`. When the nature is ambiguous, pick the best fit and flag it low-confidence in the breakdown rather than defaulting to `tdd`.
+
+### Dual-nature items
+
+A work item whose deliverable spans two natures (for example, code plus its runbook) is split into separate vertical-slice items, one per deliverable and skill. When it cannot be cleanly split, record the dominant skill and flag the uncovered nature in the breakdown rather than dropping it silently.
+
+### For more complex scenarios
+
+Table 1 lists common cases, but doesn't define strict pairings between implementation and review skills. If an item is best covered by a combination not listed in the table, you can use it, or add additional instructions for implementation and review stages.
+
+### Editing plugin definitions, and other plugin work
+
+An edit to an existing skill, agent, or plugin file, and the "Other work related to Claude Code plugins" catch-all, both build through a `general-purpose` agent that drafts the change, with the applicable authoring guidance linked in the item's `References` (the guidance is reference material, never the implementer). The review is a human read, because these are executable plugin artifacts, so a structurally-broken edit would ship green. `general-purpose` is a built-in agent, exempt from the never-auto-`AFK` guardrail below.
+
+### Audit passes
+
+An `audit` item runs checks and confirms a result. Its `Expected paths` name the report it writes, or `None` when it produces no artifact. A no-output audit must be **side-effect-free and safe to re-run**: the driver re-runs it from the first item on re-invocation, with no commit to skip it. Its review is a human result-confirmation.
+
+### Spikes
+
+A `spike` records a finding. Route its build by the question: `han-coding:investigate` for a named symptom with a codebase root cause, `han-core:research` for an open-ended question (the default), a `general-purpose` agent for a quick single-read probe. It names the finding file in `Expected paths` (never `None`). Its review is a human soundness read (recorded, non-empty, answers the question), independent of the build's `AFK`/`HITL`.
+
+### Non-han skills
+
+When no han skill in Table 1 fits an item's nature, scan the installed skills. If a non-han skill plausibly fits, surface it in the breakdown as a **low-confidence suggestion**, never an auto-assignment: the producer cannot reliably tell whether an arbitrary installed skill is code-producing or interactive.
+
+A non-han skill's `AFK`/`HITL` are **declared by the operator**, defaulting to `HITL` when undeclared. Never set an unconfirmed non-han skill to `AFK`.
+
+### Installed-skill detection
+
+User can be missing some skills or agents listed in table 1. Before committing to one, verify that it is installed. If not, fall back to an installed best-fit, and record uninstalled alternative next to it: none, HITL (or install and use `han-plugin-builder:skill-builder`, HITL).
+
+## Overrides
+
+The operator can override the implementation skill, the review, and a non-han skill's declared autonomy for a named item, two ways:
+
+- **Invocation instruction.** A natural-language instruction in the invocation (for example, "use `skill-builder` for the new-skill item", or "my `deploy-notes` skill has an autonomous build"). Interpret it and apply.
+- **Pre-written marker.** A recognizable single-line bracketed annotation left in the source plan near the relevant section, carrying a skill and an optional review and non-han autonomy declaration (for example, `[implementation: skill-builder; review: none]`). Read it read-only; never modify the source plan.
+
+On an override:
+
+- Re-derive the item's implementation and review classification: from Table 1 for a han skill, or from the operator's declaration for a non-han skill (defaulting to `HITL`). A required pre-work decision the item already needs is unaffected by a skill override.
+- **Flag a mismatch** when the override's skill does not match the item's nature (for example, `tdd` on a non-testable deliverable, or any skill on a deliverable of a different kind). Honor it, because the operator has the final say, but flag it in the breakdown.
+- **An override naming an uninstalled skill** is treated like a not-installed best-fit: the item becomes bare and the override is kept as a recommendation, a distinct outcome from an honored mismatch.
+- **Refuse an override that produces an invalid marker combination.** The driver refuses `Expected paths: None` on a non-`audit` item, an `AFK` review on an `audit` item or any item declaring `Expected paths: None`, and a `none`, AFK build. Do not write one: decline the offending field, restore the catalog-derived value, and name the declined override and the conflict in the breakdown, never transforming the item's `Type` to fit.
+- **Report how each override resolved** (applied to which item, unmatched, or ambiguous across items). Never drop an override silently.

--- a/han-planning/skills/plan-work-items/references/work-item-template.md
+++ b/han-planning/skills/plan-work-items/references/work-item-template.md
@@ -5,6 +5,8 @@ Each work item in `work-items.md` uses this template. Required fields appear in 
 ```
 ## <W-N> — <short descriptive name>
 
+**Type.** `deliverable` (default; builds and commits an artifact), `audit` (a checks-only pass), or `spike` (an investigation that records a finding). Required.
+
 **Summary.** One paragraph describing what this work item delivers. Include a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)` or `See plan: D-3, D-7, and Work Unit 2`). The plan reference replaces a standalone "Work items addressed" field — do not add one.
 
 **Description.**
@@ -26,12 +28,21 @@ Each work item in `work-items.md` uses this template. Required fields appear in 
 - **ADR / standard / repo doc** — link any architectural decision, coding standard, or feature doc the implementer must honor.
 - Omit any bullet that does not apply. Do not link iteration histories, decision logs, review findings, team findings, facilitation summaries, or any other process artifact.
 
-**Tests.**
-- Bullet list of tests required for the behavior above. Be concrete: name the test type (unit, integration, migration, visual, etc.) and the assertion.
+**Checks.**
+- How this item is checked: code test levels for code (name the test type and the assertion); read-the-file conformance and dry-run checks for docs and skills; for an `audit`, the checks it runs; for a `spike`, the finding's soundness. A no-output `audit` must be side-effect-free and safe to re-run.
 
 **Acceptance criteria.**
 - [ ] Criterion 1
 - [ ] Criterion 2
+
+**Requires pre-work decisions.** `yes` if a human judgment statable in a single sentence is required before work starts, otherwise `no`. A record-worthy decision instead becomes an ADR this item depends on; one needing investigation becomes a spike it depends on. Required. `yes` can be accompanied by one clarifying sentence.
+
+**Suggested implementation.** The skill or agent that should build this item, and whether it can run unattended. Required. Choose it with [deliverable-skill-catalog.md](./deliverable-skill-catalog.md). Example: `han-coding:tdd`, AFK.
+
+**Suggested review.** The skill or agent that should review this item, comes from deliverable-skill-catalog as well. Required. Example: `han-coding:code-review`, AFK.
+
+**Expected paths.**
+- `<repo-root-relative path this work item creates or modifies>`. One path per bullet, never absolute or a cross-repository URL. A rename lists both the old and the new path. Required. An `audit` that produces no files declares `**Expected paths.** None.`
 
 **Depends on.** `<W-N>` (within this file), comma-separated for multiple, or `None.`
 ```
@@ -41,4 +52,5 @@ Each work item in `work-items.md` uses this template. Required fields appear in 
 - Heading line begins with `## ` followed by `<W-N>` (the prefix letters, a dash, then digits), then ` — ` (em-dash with surrounding spaces), then the title.
 - A work item body ends at the next `## ` heading or end of file.
 - Design-reference paths are relative to the `work-items.md` file (e.g., `ui-designs/<file>.png` when the screenshots live in the plan folder). Never use an absolute path or a cross-repository URL.
-- The `**Depends on.**` line uses the literal bold marker, comma-separates dependencies, and ends with `.` (the trailing period is part of the format, not a sentence terminator).
+- The `**Type.**`, `**Requires pre-work decisions.**`, `**Suggested implementation.**`, and `**Suggested review.**` lines use the literal bold marker and end with `.` (the trailing period is part of the format, not a sentence terminator).
+- The `**Depends on.**` line uses the literal bold marker, comma-separates dependencies, and ends with `.`.


### PR DESCRIPTION
This is a draft MR with diff to `plan-work-items` cherry-picked from my #96 WIP branch.

The idea for the change: `plan-work-items` gains knowledge about which skill or agent can be used to implement and review a particular work item. It also knows whether that skill/agent can finish work unattended, or if it's explicitly interactive. Based on this, each item gains classification: build AFK/HITL, and review AFK/HITL. Additionally, it gains a separate classification on whether an item requires making HITL decisions before it can be implemented (i.e. deferred OIs or assumptions that require human intervention before build starts).

On top of it, it also adds work item types: deliverable is a regular "write code, then review"; audit is "verify something works and produce a report" (can be good for deferring OIs/assumptions into implementation, or adding verification that can't be done via tests); spike is for research or investigation items. Note that audit and spike are separate due to initial implementation constraints that I've eventually solved, so I'll merge them into one type before moving PR into ready state.

The change is not yet ready for deep review or merge, there are things to polish, edge cases to debug, and also I need to look at it with fresh eyes after working on something else for a bit. But you're welcome to comment on the general idea and approach. Or, well, you can review it, just know that this is not the final version.
