### PR TITLE
docs(plugin-builder): add rule about token locality to skill-building references

### DIFF
--- a/han-plugin-builder/skills/guidance/references/skill-building-guidance/context-hygiene.md
+++ b/han-plugin-builder/skills/guidance/references/skill-building-guidance/context-hygiene.md
@@ -48,6 +48,16 @@ For each changed file:
 4. Record the file path and line number for each finding
 ```
 
+### Rule: Build a self-sufficient region at the point of use
+
+The previous rule cuts redundant tokens. This one keeps the tokens a step needs together. Both protect the model's limited attention.
+
+When a step acts, give it a region that already carries what the step needs — so the model isn't left reconstructing which reference applies where. A single instruction applied to the data in front of it is cheap; the model does that constantly and well. What's costly is a step that makes it hold several references at once and route each to a different, overlapping set of targets — "run the items from [A], but apply [B] to items 2 and 3 and [C] to items 1 and 4." Every extra binding the model has to track and route in one pass is another chance to mis-route. That routing is work you can do for it.
+
+A region is **self-sufficient** when the routing is already resolved: the step names what applies to what, with nothing left for the model to reconstruct. That is stronger than merely moving the references next to the step — it removes the bookkeeping rather than shortening the reach. A step that Reads one `references/checklist.md` and applies it is fine (a **loadable pointer**: one thing, in focus, applied uniformly). A step that hands the model three references and a mapping of which applies where is an **in-head reference** — collapse that mapping before the model sees it.
+
+This is the idea progressive disclosure already runs on: a `references/` file is a self-sufficient region, Read into focus only when a step needs it. Keep the source normalized, and build the region a step acts from at the point of use. See [Resolve variation at the point of use](./writing-effective-instructions.md) for the form this takes when a step drives many similar items.
+
 ### Rule: Position critical content at the edges, not the middle
 
 Front-load constraints, prerequisites, and context that shapes the entire skill execution. Back-load checklists, validation criteria, and summary structures. Avoid placing the skill's most important instructions in the middle steps, where they receive the least attention weight.
@@ -127,6 +137,7 @@ Stale tokens are worse than absent tokens. When a reference file describes a con
 |---|---|---|
 | Kitchen sink SKILL.md | Token competition dilutes attention on every instruction | [Progressive Disclosure](./progressive-disclosure.md) |
 | Restating toolchain rules | Wastes attention budget; drifts when config changes | [Progressive Disclosure](./progressive-disclosure.md) |
+| In-head join (matrix joined against a separate list) | Attention fragments across the blocks the model must join | [Writing Effective Instructions](./writing-effective-instructions.md) |
 | Stale references | Model faithfully follows outdated instructions | [Documentation Maintenance](./documentation-maintenance.md) |
 | Critical instruction buried in middle steps | Lost-in-the-middle reduces attention weight | [Workflow Patterns](./workflow-patterns.md) |
 | Verbose frontmatter descriptions | Token cost paid in every conversation | [Skill Description Frontmatter](./skill-description-frontmatter.md) |
@@ -139,10 +150,12 @@ Stale tokens are worse than absent tokens. When a reference file describes a con
 4. Treat stale documentation as a functional bug — audit when dependencies change
 5. Extract domain knowledge to `references/` to keep the SKILL.md body lean
 6. Place the most important instruction or example last within any list (recency bias)
+7. Give each step a self-sufficient region to act from — reachable when it runs, with nothing to join from elsewhere
 
 Cross-references:
 - [Progressive Disclosure](./progressive-disclosure.md) — The three-level architecture that controls context loading
 - [Workflow Patterns](./workflow-patterns.md) — Recency bias and lost-in-the-middle within step design
 - [Writing Effective Instructions](./writing-effective-instructions.md) — Conciseness and structure rules for SKILL.md body
+- [Multi-Agent Economics](../agent-building-guidelines/multi-agent-economics.md) — Self-contained briefs across the sub-agent boundary
 - [Skill Description Frontmatter](./skill-description-frontmatter.md) — Frontmatter token efficiency and trigger accuracy
 - [Documentation Maintenance](./documentation-maintenance.md) — Audit process for stale context

--- a/han-plugin-builder/skills/guidance/references/skill-building-guidance/writing-effective-instructions.md
+++ b/han-plugin-builder/skills/guidance/references/skill-building-guidance/writing-effective-instructions.md
@@ -276,6 +276,53 @@ Functions with network calls or file writes must name the side effect.
 ```
 Each convention is independently parseable: heading, rule, example.
 
+### Rule: Resolve variation at the point of use
+
+When a step drives several similar items that each take a slightly different set of inputs — dispatching sub-agents with different reference files, applying rules each scoped to different files — do not express the variation as a matrix the model must join against a separate list. Reading a table, extracting each item's cells, and binding them to a separate enumeration makes the model do an in-head join. That such a join trips the model is a reasoned bet — by analogy to documented weaknesses in large-table lookup and multi-hop binding, though no study tests it at this small a scale — so prefer to remove the join rather than rely on the model to get it right. Give each item its resolved, self-contained set instead.
+
+Keep the *source* normalized — author the shared parts once — but denormalize into the point of use, resolving the variation with a deterministic step (a script, or the driver that assembles each dispatch) where one exists. This does not contradict [Progressive Disclosure](./progressive-disclosure.md): a reference resolved by a Read co-locates its content at the point of use, so it is not an in-head join. See [Context Hygiene](./context-hygiene.md) for the loadable-pointer vs. in-head-reference distinction.
+
+**Before (variation as a matrix the model must join):**
+```markdown
+## Step 4: Dispatch Reviewers
+
+Files each reviewer receives:
+
+| Reviewer | api.ts | schema.sql | auth.ts |
+|---|---|---|---|
+| security | no | no | yes |
+| data | no | yes | no |
+| api | yes | no | no |
+
+Prompts:
+1. Review for injection and authz.
+2. Review schema normalization and indexes.
+3. Review endpoint contracts.
+```
+The model must read the matrix, extract each reviewer's "yes" columns, and bind them to the right numbered prompt before it can dispatch anything.
+
+**After (each item resolved and self-contained):**
+```markdown
+## Step 4: Dispatch Reviewers
+
+Dispatch one reviewer per block. Each block lists exactly what that reviewer gets:
+
+### security reviewer
+- Files: `auth.ts`
+- Prompt: Review for injection and authz.
+
+### data reviewer
+- Files: `schema.sql`
+- Prompt: Review schema normalization and indexes.
+
+### api reviewer
+- Files: `api.ts`
+- Prompt: Review endpoint contracts.
+```
+Nothing to join: each reviewer's files and prompt sit together.
+
+At small scale — two or three items, two or three inputs, no growth — a compact table you or a script reads once while assembling each item is fine; the join cost lands on an LLM only when the model itself must resolve the matrix at read time. Reach for resolved, self-contained items as the count of items and varying inputs grows.
+
 ### Rule: Include canonical examples for conventions the skill enforces
 
 When a skill teaches or enforces patterns, include 2-3 representative "do this / not this" examples. The model pattern-matches examples more reliably than it follows abstract rules — research shows 3 well-chosen examples match 9 in effectiveness. Place the most representative example last — the model weights it more heavily. Put examples in `references/` if they are substantial (following the progressive disclosure model), or inline in SKILL.md if they are brief (1-3 lines each).
@@ -349,6 +396,7 @@ If validation fails, the script prints which checks failed. Fix each issue befor
 8. Use scripts for deterministic validation instead of language instructions
 9. After Skill tool calls mid-workflow, explicitly instruct Claude to proceed immediately — never rely on implicit continuation
 10. Can an agent extract every convention from this SKILL.md without ambiguity? If a section requires inference about where one instruction ends and the next begins, restructure it
+11. When a step drives several varying items, give each its resolved, self-contained inputs — don't make the model join a matrix against a separate list
 
 Cross-references:
 - [Progressive Disclosure](./progressive-disclosure.md) — The three-level architecture that determines where content belongs


### PR DESCRIPTION
## What

Two companion rules for the skill-building guidance, both about keeping the inputs a step acts on resolved and co-located at the point of use:

- **`writing-effective-instructions.md` — "Resolve variation at the point of use."** When a step drives several similar items that each take a slightly different set of inputs (dispatching sub-agents with different reference files, applying rules each scoped to different files), give each item its resolved, self-contained inputs instead of a matrix the model must join against a separate list. Ships with a before/after example and a summary-checklist entry.
- **`context-hygiene.md` — "Build a self-sufficient region at the point of use."** The companion attention-budget framing: the loadable-pointer vs. in-head-reference distinction, an anti-pattern table row, a principle, and a cross-reference to Multi-Agent Economics.

## Why

The guidance already covers cutting redundant tokens (progressive disclosure, conciseness). It did not name the sibling failure mode: content the model needs but must join together across separated locations. These two rules close that gap and give skill authors a concrete, testable move: resolve the variation before the model sees it.

## Notes

- Scope is deliberately narrow: two guidance reference files, extracted onto their own branch so this can land independently.
- Both files are additions-only; no existing prose is edited.
- All internal cross-references resolve. Ran the CONTRIBUTING.md "Reviewing your own changes" checklist; the applicable items pass. Em-dashes follow the established house style of the `guidance/references/` register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4DaYQo9E6bCdFBAf3LwUm
