### PR TITLE
chore(CI): lint, Bats tests, CI, and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+
+# One monthly pull request bundles updates across all three ecosystems (npm,
+# GitHub Actions, pre-commit) via a multi-ecosystem group. Each ecosystem holds
+# a newly published version for 30 days before proposing it (cooldown), to lower
+# supply-chain risk from fresh or compromised releases. Cooldown does not apply
+# to security updates, so enabling Dependabot security updates in the repository
+# settings still lands those immediately.
+multi-ecosystem-groups:
+  dev-tooling:
+    schedule:
+      interval: monthly
+
+updates:
+  # npm devDependencies: prek, Prettier, Bats.
+  - package-ecosystem: npm
+    directory: "/"
+    multi-ecosystem-group: dev-tooling
+    cooldown:
+      default-days: 30
+
+  # GitHub Actions used by the CI workflows.
+  - package-ecosystem: github-actions
+    directory: "/"
+    multi-ecosystem-group: dev-tooling
+    cooldown:
+      default-days: 30
+
+  # pre-commit hook revisions in .pre-commit-config.yaml (shellcheck-py,
+  # pre-commit-hooks). prek reads the same config format Dependabot updates.
+  - package-ecosystem: pre-commit
+    directory: "/"
+    multi-ecosystem-group: dev-tooling
+    cooldown:
+      default-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+# Lint and test the repo with the same npm-pinned tools contributors run
+# locally (prek + Prettier + ShellCheck for lint, Bats for tests). Everything is
+# installed by `npm ci` from the committed package-lock.json, so CI and local
+# use identical versions.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+      - name: Cache prek hook environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/prek
+          key: prek-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            prek-${{ runner.os }}-
+      - run: npm ci
+      - run: npm run lint
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,5 @@
 # Pre-commit hooks for the han plugin suite, run with prek.
 #
-# prek is installed as an npm devDependency (@j178/prek); `npm install` fetches
-# it and installs the git hook automatically (the package.json "prepare" script).
 # Run every hook manually with `npm run lint` (prek run --all-files).
 
 # Files no hook ever touches: static archives and vendored assets.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,53 @@
+# Pre-commit hooks for the han plugin suite, run with prek.
+#
+# prek is installed as an npm devDependency (@j178/prek); `npm install` fetches
+# it and installs the git hook automatically (the package.json "prepare" script).
+# Run every hook manually with `npm run lint` (prek run --all-files).
+
+# Files no hook ever touches: static archives and vendored assets.
+exclude: "^(docs/plans/|docs/research/|han-reporting/skills/html-summary/assets/)"
+
+repos:
+  # Prettier owns formatting for Markdown, JSON, YAML, and JS: 120-column prose,
+  # ordered-list numbering, and unwrapped .github templates (.prettierrc.json),
+  # with ignore rules in .prettierignore. Running the local devDependency keeps
+  # Prettier's version in package.json only, not duplicated in a hook mirror.
+  # It runs first so the hygiene fixers below never fight it.
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        entry: npx prettier --write --ignore-unknown
+        language: system
+        types_or: [markdown, json, yaml, javascript]
+
+  # Lint shell scripts. prek builds the environment; no Docker, no global install.
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+
+  # Hygiene checks. The whitespace/EOL fixers exclude the file types Prettier
+  # already normalizes (Markdown, JSON, YAML, JS), so Prettier owns those and
+  # these cover the rest (shell scripts, dotfiles, LICENSE) with no overlap.
+  # check-yaml and check-json are intentionally omitted: Prettier parses and so
+  # validates those types already.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '\.(md|markdown|json|ya?ml|jsx?|mjs|cjs)$'
+      - id: end-of-file-fixer
+        exclude: '\.(md|markdown|json|ya?ml|jsx?|mjs|cjs)$'
+      - id: fix-byte-order-marker
+        exclude: '\.(md|markdown|json|ya?ml|jsx?|mjs|cjs)$'
+      - id: mixed-line-ending
+        args: [--fix=lf]
+        exclude: '\.(md|markdown|json|ya?ml|jsx?|mjs|cjs)$'
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-executables-have-shebangs
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      - id: check-vcs-permalinks

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+# Static historical artifacts: left as written.
+docs/plans/
+docs/research/
+
+# Vendored third-party assets: checked in verbatim, never reformat.
+han-reporting/skills/html-summary/assets/
+
+# Dependencies and generated files.
+node_modules/
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "printWidth": 120,
+  "proseWrap": "always",
+  "overrides": [
+    {
+      "files": ".github/**/*.md",
+      "options": {
+        "proseWrap": "never"
+      }
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,18 +24,19 @@ Read these once:
 
 ## Setting up your environment
 
-Han's dev tooling is managed as npm devDependencies, so a single `npm install` sets everything up at pinned versions with nothing installed globally. It installs [prek](https://github.com/j178/prek) (the git-hook runner), [Prettier](https://prettier.io) (formatting), and [Bats](https://github.com/bats-core/bats-core) (shell tests), and wires up the git pre-commit hook automatically.
+Han's dev tooling is managed as npm devDependencies, so a single `npm install` sets everything up at pinned versions with nothing installed globally. It installs [prek](https://github.com/j178/prek) (the git-hook runner), [Prettier](https://prettier.io) (formatting), and [Bats](https://github.com/bats-core/bats-core) (shell tests).
 
 One-time setup, from the repo root:
 
 1. Install [Node.js](https://nodejs.org/) (the current LTS is fine).
-2. Run `npm install`. It installs the pinned tools into `node_modules/` and runs `prek install` to add the git hook. Nothing lands on your global PATH, so tool versions never clash with your other projects.
+2. Run `npm install`. It installs the pinned tools into `node_modules/`. Nothing lands on your global PATH, so tool versions never clash with your other projects.
+3. If you want pre-commit hooks, run `npx prek install`.
 
 Everyday use:
 
-- Every commit runs the lint hooks (Prettier, ShellCheck, and file hygiene) on your staged files.
 - `npm run lint` runs every hook over the whole repo (`prek run --all-files`).
 - `npm test` runs the shell tests (`bats --recursive test/`).
+- If installed, every commit runs the lint hooks (Prettier, ShellCheck, and file hygiene) on your staged files.
 
 CI runs the same lint hooks and the tests on every pull request.
 
@@ -137,7 +138,8 @@ Before opening the PR, run through this checklist:
 - [ ] Internal links resolve.
 - [ ] No em-dashes anywhere in the doc.
 - [ ] No *"actually," "just," "leverage," "utilize," "showcase," "robust" (vague), "It's worth noting," "Importantly,"* or other voice violations.
-- [ ] `npm run lint` passes (Prettier, ShellCheck, and the hygiene hooks).
+- [ ] `npm run lint` passes.
+- [ ] `npm run test` passes.
 
 ## Related Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ This page is for contributors: anyone adding, editing, or restructuring skills, 
 - **Every skill and every agent gets a long-form doc.** No exceptions. See the [coverage rule](./docs/templates/coverage-rule.md).
 - Use the [long-form skill template](./docs/templates/skill-long-form-template.md) or the [agent template](./docs/templates/agent-long-form-template.md).
 - The root [CLAUDE.md](./CLAUDE.md) carries the at-a-glance project map for assistants and contributors.
+- Before your first commit, run `npm install`. It installs the pinned dev tools and wires up the git hook. See [Setting up your environment](#setting-up-your-environment).
 
 ## Before you start
 
@@ -20,6 +21,31 @@ Read these once:
 - **[`han-plugin-builder/skills/guidance/references/skill-building-guidance/`](./han-plugin-builder/skills/guidance/references/skill-building-guidance/).** The skill-authoring rules: description frontmatter, progressive disclosure, context hygiene, dynamic project discovery, bash permissions, script execution.
 - **[`han-plugin-builder/skills/guidance/references/agent-building-guidelines/`](./han-plugin-builder/skills/guidance/references/agent-building-guidelines/).** The agent-authoring rules: external files, model selection, domain focus, graceful degradation, multi-agent economics.
 - **[Root `CLAUDE.md`](./CLAUDE.md).** Repo conventions, doc map, and where each kind of file lives.
+
+## Setting up your environment
+
+Han's dev tooling is managed as npm devDependencies, so a single `npm install` sets everything up at pinned versions with nothing installed globally. It installs [prek](https://github.com/j178/prek) (the git-hook runner), [Prettier](https://prettier.io) (formatting), and [Bats](https://github.com/bats-core/bats-core) (shell tests), and wires up the git pre-commit hook automatically.
+
+One-time setup, from the repo root:
+
+1. Install [Node.js](https://nodejs.org/) (the current LTS is fine).
+2. Run `npm install`. It installs the pinned tools into `node_modules/` and runs `prek install` to add the git hook. Nothing lands on your global PATH, so tool versions never clash with your other projects.
+
+Everyday use:
+
+- Every commit runs the lint hooks (Prettier, ShellCheck, and file hygiene) on your staged files.
+- `npm run lint` runs every hook over the whole repo (`prek run --all-files`).
+- `npm test` runs the shell tests (`bats --recursive test/`).
+
+CI runs the same lint hooks and the tests on every pull request.
+
+How Prettier treats your files:
+
+- It formats Markdown, JSON, YAML, and JavaScript. Prose reflows to 120 columns and ordered lists keep their `1.`, `2.`, `3.` numbering (configured in `.prettierrc.json`).
+- PR and issue templates under `.github/` are unwrapped rather than wrapped, because GitHub renders every newline in a PR or issue body as a line break.
+- The static archives under `docs/plans/` and `docs/research/`, and the vendored assets under `han-reporting/skills/html-summary/assets/`, are left untouched (`.prettierignore`).
+
+Shell scripts are linted with ShellCheck. Tests live in `test/` as `*.bats` files and run in CI rather than on commit; run them locally with `npm test`.
 
 ## Which plugin does the change belong in?
 
@@ -111,6 +137,7 @@ Before opening the PR, run through this checklist:
 - [ ] Internal links resolve.
 - [ ] No em-dashes anywhere in the doc.
 - [ ] No *"actually," "just," "leverage," "utilize," "showcase," "robust" (vague), "It's worth noting," "Importantly,"* or other voice violations.
+- [ ] `npm run lint` passes (Prettier, ShellCheck, and the hygiene hooks).
 
 ## Related Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,364 @@
+{
+  "name": "han",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "han",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@j178/prek": "^0.4.9",
+        "bats": "^1.11.1",
+        "prettier": "^3.4.2"
+      }
+    },
+    "node_modules/@j178/prek": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek/-/prek-0.4.9.tgz",
+      "integrity": "sha512-9iWK3NgzworUjKLfOKR3vg36rQp2jZKEcxBhXkM1TrHYiO1q30KitehceEs1u+GTw1syNcb8Bye0Qe7NxlH/dw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prek": "bin/prek.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@j178/prek-android-arm64": "0.4.9",
+        "@j178/prek-darwin-arm64": "0.4.9",
+        "@j178/prek-darwin-x64": "0.4.9",
+        "@j178/prek-linux-arm-gnueabihf": "0.4.9",
+        "@j178/prek-linux-arm-musleabihf": "0.4.9",
+        "@j178/prek-linux-arm64-gnu": "0.4.9",
+        "@j178/prek-linux-arm64-musl": "0.4.9",
+        "@j178/prek-linux-armv7-musleabihf": "0.4.9",
+        "@j178/prek-linux-ia32-gnu": "0.4.9",
+        "@j178/prek-linux-ia32-musl": "0.4.9",
+        "@j178/prek-linux-riscv64-gnu": "0.4.9",
+        "@j178/prek-linux-s390x-gnu": "0.4.9",
+        "@j178/prek-linux-x64-gnu": "0.4.9",
+        "@j178/prek-linux-x64-musl": "0.4.9",
+        "@j178/prek-win32-arm64-msvc": "0.4.9",
+        "@j178/prek-win32-ia32-msvc": "0.4.9",
+        "@j178/prek-win32-x64-msvc": "0.4.9"
+      }
+    },
+    "node_modules/@j178/prek-android-arm64": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-android-arm64/-/prek-android-arm64-0.4.9.tgz",
+      "integrity": "sha512-mFJBMkUvvjCw/HY557lcKRit6f21cqCyIGSGG8+Q8ZnfIQYdWNcPpI7i1x/jbbzVH5MZ2M4FAkaW79hj+U3LCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-darwin-arm64": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-darwin-arm64/-/prek-darwin-arm64-0.4.9.tgz",
+      "integrity": "sha512-HQt1KhUMA/kzRr5o929JfmvMw7hJsvdAUW0XwMNL+bHWV0cS6sdMZwpRyrHFdkZXbB5sUIGZsvJoq+vl20RzSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-darwin-x64": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-darwin-x64/-/prek-darwin-x64-0.4.9.tgz",
+      "integrity": "sha512-3Fq6uMNXjCyR+5dkNnsibHhUwAfXrQ98RKDF0cAKlWiDGr7EBlzw8rwpahBY5On+roG8MHia3ZJjDpbdOYCrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm-gnueabihf": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm-gnueabihf/-/prek-linux-arm-gnueabihf-0.4.9.tgz",
+      "integrity": "sha512-ECpl6h54ZalcsNXKVFoEZCs077asYSOevLW7LEfKYtIv8wi1m7J/XNXhkTrBy6gBhCPGvnz6PGn4/Me1Y4m0Uw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm-musleabihf": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm-musleabihf/-/prek-linux-arm-musleabihf-0.4.9.tgz",
+      "integrity": "sha512-Nh8HgcjBKxHDil23GVrwSAd87bPC0VQIwRr1HzAQw4QF9GxCkd+M48h64EJBNTh5kHX5Br2qEXNXGVKYjRmsCg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm64-gnu": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm64-gnu/-/prek-linux-arm64-gnu-0.4.9.tgz",
+      "integrity": "sha512-vR8fsdbKIFi7jWVLkLzhZlmgQgBcDHe2uhnv3Nx/NefRBoBdSMJT7KUKMJlsNO7hUXKvBtvx+e/bB15ZasmgkA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm64-musl": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm64-musl/-/prek-linux-arm64-musl-0.4.9.tgz",
+      "integrity": "sha512-8wFjX0VbSmA0SGfs2PC8HPmq3PoAHmvntLGvqpaYUk+8NUblrUxn0S5OsifWSOQ8n02TZTVs2QGn+Sa5KhR9yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-armv7-musleabihf": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-armv7-musleabihf/-/prek-linux-armv7-musleabihf-0.4.9.tgz",
+      "integrity": "sha512-BDR8taqqH5aWtZ+6yT8lw59JadGUv0lEQwr4UCkrXg4u4bQzYu03ejdgrCNZo+eLt7uG9rpbOrB2fR+iDkO/hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-ia32-gnu": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-ia32-gnu/-/prek-linux-ia32-gnu-0.4.9.tgz",
+      "integrity": "sha512-3feciBV6RDUs7u8x05p4yA6ItcGqFT+71p7H2gFCLPBDHs7C9pOGpWDuPVmd+PMr/z5fzJtTA3ZQlv3tq1fncw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-ia32-musl": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-ia32-musl/-/prek-linux-ia32-musl-0.4.9.tgz",
+      "integrity": "sha512-d6rgJHWij7U1zuRa3CRkcecQW2Zq0TV/q1IW7pXvzQMk4FPL2uQkX2kR+37kPYLTpj7rIrkEW5SIs3PnH38UWQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-riscv64-gnu": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-riscv64-gnu/-/prek-linux-riscv64-gnu-0.4.9.tgz",
+      "integrity": "sha512-G0oXlm3WlN37i7in4tli93biu4G3zHmql4nq8cS+1wl/Dmi+Wk6OY51OWdMZO7J+O77SXQgoIPdAnO4jcONGUQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-s390x-gnu": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-s390x-gnu/-/prek-linux-s390x-gnu-0.4.9.tgz",
+      "integrity": "sha512-UjK2EwIKpI3B78kobJvwCv7rIZZ1oLGSfqs7AZR67fPZ1Xi6YJLAG5bMOixA8WjkhbRO0K3JSCFT4mXsXfV7pg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-x64-gnu": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-x64-gnu/-/prek-linux-x64-gnu-0.4.9.tgz",
+      "integrity": "sha512-O6bjPRkkTIeMJJl4SxxBGP5ifO1ILTPQkI5frwcvrWCprp28jNBw3v1pPdlenmEvjROn2R5YOVGrvlFlMzTg3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-x64-musl": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-x64-musl/-/prek-linux-x64-musl-0.4.9.tgz",
+      "integrity": "sha512-tqfvEy1rwWLsIVwuylmzk1lRaEj98X8FaXF1vR70FNhAjaqM7EuOQpDFdqUQpUyrkqm6iGwCmW6sz0azS6L6uA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-win32-arm64-msvc": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-win32-arm64-msvc/-/prek-win32-arm64-msvc-0.4.9.tgz",
+      "integrity": "sha512-oQnsQ+K+OTW9I0YwDJAG/rcD18dYCOgy5IV4tFEHMK9GdMsB7hiPz5bOcpuzYDMumStlh2KKTYHejnU86K1bUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-win32-ia32-msvc": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-win32-ia32-msvc/-/prek-win32-ia32-msvc-0.4.9.tgz",
+      "integrity": "sha512-jzzovfyzaPa8v0ckHTLiJqa4ZPfdnas/iNIBqGAGeEUZwO98szjOLlhP2pZt32E0VPNIpHxioR8dH9s2t26ePw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-win32-x64-msvc": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@j178/prek-win32-x64-msvc/-/prek-win32-x64-msvc-0.4.9.tgz",
+      "integrity": "sha512-tM9YVJuVffJIf/dEDIwQVC5EDdHmipXBqsjYfRwCWCPwzO11zr8edX6u3dAthqZywTIG/XveUso0kjJzPW3Dvg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/bats": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.13.0.tgz",
+      "integrity": "sha512-giSYKGTOcPZyJDbfbTtzAedLcNWdjCLbXYU3/MwPnjyvDXzu6Dgw8d2M+8jHhZXSmsCMSQqCp+YBsJ603UO4vQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bats": "bin/bats"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "description": "Dev tooling for the han plugin suite (lint, format, and shell tests).",
   "scripts": {
-    "prepare": "prek install",
     "lint": "prek run --all-files",
     "test": "bats --recursive test/"
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "han",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Dev tooling for the han plugin suite (lint, format, and shell tests).",
+  "scripts": {
+    "prepare": "prek install",
+    "lint": "prek run --all-files",
+    "test": "bats --recursive test/"
+  },
+  "devDependencies": {
+    "@j178/prek": "^0.4.9",
+    "bats": "^1.11.1",
+    "prettier": "^3.4.2"
+  }
+}

--- a/test/sanity.bats
+++ b/test/sanity.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+#
+# Sanity check: proves the Bats harness and the CI test job actually run.
+# Real script tests land as their own test/*.bats files.
+
+@test "sanity: arithmetic works (2 + 2 == 4)" {
+  result=$((2 + 2))
+  [ "$result" -eq 4 ]
+}


### PR DESCRIPTION
## Summary

Adds an npm-managed lint and test toolchain, CI, and Dependabot for the han repo. One `npm install` pins every tool
locally (no global installs, no cross-project version drift) and installs the git hook via the `prepare` script.

- **prek** (`@j178/prek`) runs the pre-commit hooks (drop-in for `pre-commit`).
- **Prettier** formats Markdown, JSON, YAML, and JS: 120-column prose wrap, ordered-list numbering preserved, `.github` PR/issue templates unwrapped (GitHub renders newlines as `<br>`), and `docs/plans`, `docs/research`, and the vendored assets excluded.
- **ShellCheck** (via `shellcheck-py`, no Docker) lints shell scripts.
- The `pre-commit-hooks` hygiene checks cover the rest; their whitespace/EOL fixers exclude md/json/yaml/js so Prettier owns those with no overlap, and `check-yaml`/`check-json` are dropped because Prettier already validates those types.
- **Bats** runs `test/*.bats` in CI (not on commit); a sanity test proves the harness.
- **CI**: a `lint` job (`npm run lint`) and a `test` job (`npm test`), both on the pinned lockfile.
- **Dependabot**: one monthly PR bundling npm + GitHub Actions + pre-commit updates via a multi-ecosystem group, with a 30-day cooldown on new releases to reduce supply-chain risk (security updates are exempt from the cooldown).

Mitigates #113 for this repo. Should be merged before #119.

## Note on the `lint` CI job

This PR adds the tooling only. Running `npm run lint` reflows the existing Markdown across the repo; that mechanical reflow is intentionally **not** included here, so the `lint` job will report changes until it is applied in a separate pass. The `test` job is green.

## Follow-ups for a maintainer

- Run `npm run lint` and commit the repo-wide Prettier reflow (and re-run so the `lint` job goes green).
- Resolve two ShellCheck findings, or add `# shellcheck disable` directives: `init-guidance.sh:55` (SC2016) and `upload-screenshots.sh:136` (SC2034). Both look benign.
- Fix the broken symlink `.claude/rules/plugin-entity-taxonomy.md` that `check-symlinks` flags.
- Enable *Settings → Code security → Dependabot security updates* so security patches bypass the 30-day cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFKuiUmQ9QinkSt9LbE7hc
