### PR TITLE
fix(CI): add required patterns key to Dependabot ecosystem entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ version: 2
 # supply-chain risk from fresh or compromised releases. Cooldown does not apply
 # to security updates, so enabling Dependabot security updates in the repository
 # settings still lands those immediately.
+#
+# Every ecosystem below sets `patterns: ["*"]` to take in all of its
+# dependencies. Dependabot requires `patterns` on each entry that joins a
+# multi-ecosystem group, and rejects the whole file without it.
 multi-ecosystem-groups:
   dev-tooling:
     schedule:
@@ -15,6 +19,7 @@ updates:
   # npm devDependencies: prek, Prettier, Bats.
   - package-ecosystem: npm
     directory: "/"
+    patterns: ["*"]
     multi-ecosystem-group: dev-tooling
     cooldown:
       default-days: 30
@@ -22,6 +27,7 @@ updates:
   # GitHub Actions used by the CI workflows.
   - package-ecosystem: github-actions
     directory: "/"
+    patterns: ["*"]
     multi-ecosystem-group: dev-tooling
     cooldown:
       default-days: 30
@@ -30,6 +36,7 @@ updates:
   # pre-commit-hooks). prek reads the same config format Dependabot updates.
   - package-ecosystem: pre-commit
     directory: "/"
+    patterns: ["*"]
     multi-ecosystem-group: dev-tooling
     cooldown:
       default-days: 30


### PR DESCRIPTION
## What's broken

Dependabot rejects `.github/dependabot.yml` outright:

> The property `#/updates/0/patterns` is required when `multi-ecosystem-group` is set.

Because the config fails to parse, **no Dependabot update PRs can open at all** — the monthly `dev-tooling` bundle has never run. The failing check shows up on every open PR, including #114.

## Why

An `updates:` entry that joins a multi-ecosystem group has to declare which dependencies it takes in. All three entries (`npm`, `github-actions`, `pre-commit`) set `multi-ecosystem-group: dev-tooling` but omitted `patterns`, so none of them validated.

## The fix

Add `patterns: ["*"]` to each of the three entries, which is how GitHub documents "include every dependency in this ecosystem." The existing group and `cooldown` settings are unchanged.

Verified against [GitHub's multi-ecosystem updates docs](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-multi-ecosystem-updates), whose troubleshooting section states the `patterns` key is "required when using `multi-ecosystem-group`", and corroborated by [dependabot-core#12437](https://github.com/dependabot/dependabot-core/discussions/12437), where a user hits the identical error string.

## Note on the lint check

This branch is cut from `main`, which still carries pre-existing lint failures (Prettier was never run across the repo, plus two shellcheck findings and a broken symlink). Those are fixed in #114, so **the `lint` job on this PR will fail until #114 merges**. It is not caused by this change, which touches only `.github/dependabot.yml`.