### PR TITLE
fix(dependabot): add required `patterns` to multi-ecosystem updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ version: 2
 # a newly published version for 30 days before proposing it (cooldown), to lower
 # supply-chain risk from fresh or compromised releases. Cooldown does not apply
 # to security updates, so enabling Dependabot security updates in the repository
-# settings still lands those immediately.
+# settings still lands those immediately. Dependabot requires `patterns` on every
+# update that joins a multi-ecosystem group; `["*"]` includes the whole ecosystem.
 multi-ecosystem-groups:
   dev-tooling:
     schedule:
@@ -15,6 +16,7 @@ updates:
   # npm devDependencies: prek, Prettier, Bats.
   - package-ecosystem: npm
     directory: "/"
+    patterns: ["*"]
     multi-ecosystem-group: dev-tooling
     cooldown:
       default-days: 30
@@ -22,6 +24,7 @@ updates:
   # GitHub Actions used by the CI workflows.
   - package-ecosystem: github-actions
     directory: "/"
+    patterns: ["*"]
     multi-ecosystem-group: dev-tooling
     cooldown:
       default-days: 30
@@ -30,6 +33,7 @@ updates:
   # pre-commit-hooks). prek reads the same config format Dependabot updates.
   - package-ecosystem: pre-commit
     directory: "/"
+    patterns: ["*"]
     multi-ecosystem-group: dev-tooling
     cooldown:
       default-days: 30


### PR DESCRIPTION
## Summary

Dependabot is failing to parse `.github/dependabot.yml` on `main` (the file landed in #120). The [check](https://github.com/testdouble/han/runs/87099717784) reports:

```
The property '#/updates/0/patterns' is required when 'multi-ecosystem-group' is set.
```

Any `updates` entry that joins a multi-ecosystem group must declare `patterns`. This adds `patterns: ["*"]` to the `npm`, `github-actions`, and `pre-commit` entries so each ecosystem's full package set participates in the `dev-tooling` group, and records the requirement in the header comment.

## Changes

- Add `patterns: ["*"]` to all three multi-ecosystem update entries.
- One clarifying sentence in the existing header comment.

No other lines were reformatted.

## Verification

- Parses as valid YAML.
- `["*"]` matches the wildcard example in the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) for multi-ecosystem groups, which shows `patterns` on every grouped entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED3rtS76H7m3njySarRrvM