### PR TITLE
fix(CI): repair shellcheck findings and stale rules symlink

### DIFF
--- a/.claude/rules/plugin-entity-taxonomy.md
+++ b/.claude/rules/plugin-entity-taxonomy.md
@@ -1,1 +1,1 @@
-../../docs/guidance/plugin-entity-taxonomy.md
+../../han-plugin-builder/skills/guidance/references/plugin-entity-taxonomy.md

--- a/han-github/skills/work-items-to-issues/scripts/upload-screenshots.sh
+++ b/han-github/skills/work-items-to-issues/scripts/upload-screenshots.sh
@@ -132,8 +132,7 @@ put_file() {
 # authenticated viewers, so the issue body is correct.
 verify_on() {
   local branch="$1" api_path="$2"
-  local attempt
-  for attempt in 1 2 3 4 5; do
+  for _ in 1 2 3 4 5; do
     if gh api "$api_path?ref=$branch" --jq .sha >/dev/null 2>&1; then
       return 0
     fi

--- a/han-plugin-builder/skills/guidance/scripts/init-guidance.sh
+++ b/han-plugin-builder/skills/guidance/scripts/init-guidance.sh
@@ -51,6 +51,7 @@ RULE=".claude/rules/plugin-building-guidance.md"
 rewrite_skill() {
   file="$1"
   tmp="$(mktemp)"
+  # shellcheck disable=SC2016  # ${CLAUDE_PLUGIN_ROOT} is matched literally, not expanded.
   sed \
     -e 's|${CLAUDE_PLUGIN_ROOT}/skills/guidance/references/|.claude/skills/plugin-guidance/references/|g' \
     -e 's|^name: guidance$|name: plugin-guidance|' \


### PR DESCRIPTION
## Why

The `lint` job has failed on every branch, including `main`, since CI landed in #120. Two of its three failures are small and fixed here.

These fixes were originally pushed to the `fix/dependabot-multi-ecosystem-patterns` branch, but #123 merged at `408ff77` before they were picked up, so they never reached `main`. This re-lands them.

## What

- **`init-guidance.sh` (SC2016).** The `sed` expression matches the literal string `${CLAUDE_PLUGIN_ROOT}`, which must *not* expand, so the single quotes are correct. Silences the check rather than changing behavior.
- **`upload-screenshots.sh` (SC2034).** The retry loop's counter is never read. Binding it to `_` states that in the code instead of suppressing the warning.
- **`.claude/rules/plugin-entity-taxonomy.md`.** The symlink pointed at `docs/guidance/`, where the taxonomy no longer lives. Repointed at its real home under `han-plugin-builder/`.

## Verification

`shellcheck` and `check-symlinks` both pass; `npm test` passes.

## Still red: prettier

The lint job's third failure is prettier, and it is **not** fixed here. It is not a mechanical reformat — running it corrupts instructional content:

- It **renumbers ordered lists**. In `coding-standard/SKILL.md` step `4.` becomes `3.`, while that file's prose still refers to "Step 6" and "Step 7" — silently misdirecting instructions Claude executes.
- It **trims inline code spans**. The issue-heading spec `` ` — ` `` (em-dash *with surrounding spaces*) becomes `` `—` ``, while the prose beside it still reads "em-dash with surrounding spaces".

Neither is configurable away: both persist under `proseWrap: preserve` + `embeddedLanguageFormatting: off`. They are core CommonMark normalizations. Left for a separate decision.