### PR TITLE
chore(CI): stop running Prettier over Markdown

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,11 @@
 exclude: "^(docs/plans/|docs/research/|han-reporting/skills/html-summary/assets/)"
 
 repos:
-  # Prettier owns formatting for Markdown, JSON, YAML, and JS: 120-column prose,
-  # ordered-list numbering, and unwrapped .github templates (.prettierrc.json),
-  # with ignore rules in .prettierignore. Running the local devDependency keeps
-  # Prettier's version in package.json only, not duplicated in a hook mirror.
+  # Prettier owns formatting for JSON, YAML, and JS at 120 columns. Markdown is
+  # deliberately excluded in .prettierignore: agents read skills and reference
+  # files as raw source, and Prettier's list renumbering and code-span trimming
+  # change what those files say. Running the local devDependency keeps Prettier's
+  # version in package.json only, not duplicated in a hook mirror.
   # It runs first so the hygiene fixers below never fight it.
   - repo: local
     hooks:
@@ -25,11 +26,12 @@ repos:
     hooks:
       - id: shellcheck
 
-  # Hygiene checks. The whitespace/EOL fixers exclude the file types Prettier
-  # already normalizes (Markdown, JSON, YAML, JS), so Prettier owns those and
-  # these cover the rest (shell scripts, dotfiles, LICENSE) with no overlap.
-  # check-yaml and check-json are intentionally omitted: Prettier parses and so
-  # validates those types already.
+  # Hygiene checks. The whitespace/EOL fixers exclude JSON, YAML, and JS because
+  # Prettier owns those, and they exclude Markdown for its own reason: a trailing
+  # double-space is a meaningful hard line break, so a whitespace fixer would
+  # change how the file reads. That leaves these covering the rest (shell scripts,
+  # dotfiles, LICENSE) with no overlap. check-yaml and check-json are intentionally
+  # omitted: Prettier parses and so validates those types already.
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,15 @@
+# Markdown is the product, not just prose about it: skills, agents, and reference
+# files are read as raw source by agents, so a transform that renders the same can
+# still change what an agent is told to do. Prettier has two such transforms that
+# cannot be turned off, because they are core CommonMark normalizations:
+#   * It renumbers ordered lists, while the prose cross-references to those steps
+#     ("see Step 6") stay put and end up pointing at the wrong ones.
+#   * It strips the spaces inside inline code spans, so a heading spec written as
+#     ` — ` becomes `—` next to prose that still says "with surrounding spaces".
+# Both survive proseWrap: preserve and embeddedLanguageFormatting: off, so there is
+# no configuration that formats this repo's Markdown without corrupting it.
+*.md
+
 # Static historical artifacts: left as written.
 docs/plans/
 docs/research/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,12 +1,3 @@
 {
-  "printWidth": 120,
-  "proseWrap": "always",
-  "overrides": [
-    {
-      "files": ".github/**/*.md",
-      "options": {
-        "proseWrap": "never"
-      }
-    }
-  ]
+  "printWidth": 120
 }

--- a/han-atlassian/.claude-plugin/plugin.json
+++ b/han-atlassian/.claude-plugin/plugin.json
@@ -2,9 +2,5 @@
   "name": "han-atlassian",
   "description": "Atlassian-facing extensions to the Han suite. Adds markdown-to-confluence, which publishes a local Markdown file to a user-specified Confluence page; project-documentation-to-confluence, which runs the core project-documentation skill and then publishes the result there; investigate-to-confluence, which runs the core investigate skill and publishes the resulting investigation report there; code-overview-to-confluence, which runs the core code-overview skill and publishes the resulting overview there; plan-a-feature-to-confluence, which runs the plan-a-feature planning skill and publishes the spec and its companion artifacts there as a page tree; and work-items-to-jira, which creates one Jira ticket per slice from a work-items file. All work through the Atlassian MCP server. Depends on han-core, han-planning, and han-coding (its wrapper skills run skills from each) and requires a configured Atlassian MCP server. Opt-in: installed on its own, not pulled in by the han meta-plugin.",
   "version": "2.2.0",
-  "dependencies": [
-    "han-core",
-    "han-planning",
-    "han-coding"
-  ]
+  "dependencies": ["han-core", "han-planning", "han-coding"]
 }

--- a/han-coding/.claude-plugin/plugin.json
+++ b/han-coding/.claude-plugin/plugin.json
@@ -2,7 +2,5 @@
   "name": "han-coding",
   "description": "Coding-facing skills for the Han suite: writing, reviewing, testing, investigating, and standardizing code. Home of the tdd skill, which drives a feature or behavior through a BDD-framed red-green-refactor loop with an enforced observed-failure gate, and the refactor skill, which restructures existing code without changing its behavior through a test-gated refactoring loop, plus code-review (comprehensive review of local changes), code-overview (a progressive-disclosure, understand-now overview of unfamiliar code or a PR's changes), architectural-analysis (module-level coupling, data flow, concurrency, risk, and SOLID assessment), test-planning (coverage-gap and edge-case test plans), investigate (evidence-based root-cause debugging), and coding-standard (creating and updating coding standards). Depends on han-core; bundled by the han meta-plugin.",
   "version": "2.6.0",
-  "dependencies": [
-    "han-core"
-  ]
+  "dependencies": ["han-core"]
 }

--- a/han-feedback/.claude-plugin/plugin.json
+++ b/han-feedback/.claude-plugin/plugin.json
@@ -2,7 +2,5 @@
   "name": "han-feedback",
   "description": "Post-session feedback skill for the Han suite. Captures structured observations, ratings, and improvement ideas on the Han skills you ran in a session and optionally posts them as a GitHub issue to testdouble/han. Opt-in: installed on its own, not pulled in by the han meta-plugin.",
   "version": "2.0.0",
-  "dependencies": [
-    "han-core"
-  ]
+  "dependencies": ["han-core"]
 }

--- a/han-github/.claude-plugin/plugin.json
+++ b/han-github/.claude-plugin/plugin.json
@@ -2,7 +2,5 @@
   "name": "han-github",
   "description": "Github specific extensions to the Han plugin for agentic planning and coding. Provides skills to post code reviews as PR comments, update a PR description with a consistent format, etc.",
   "version": "2.2.2",
-  "dependencies": [
-    "han-core"
-  ]
+  "dependencies": ["han-core"]
 }

--- a/han-linear/.claude-plugin/plugin.json
+++ b/han-linear/.claude-plugin/plugin.json
@@ -2,7 +2,5 @@
   "name": "han-linear",
   "description": "Linear-facing extensions to the Han suite. Adds work-items-to-linear, which creates one Linear issue per slice from a work-items file. Works through the Linear MCP server. Depends on han-core and requires a configured Linear MCP server. Opt-in: installed on its own, not pulled in by the han meta-plugin.",
   "version": "1.0.2",
-  "dependencies": [
-    "han-core"
-  ]
+  "dependencies": ["han-core"]
 }

--- a/han-planning/.claude-plugin/plugin.json
+++ b/han-planning/.claude-plugin/plugin.json
@@ -2,7 +2,5 @@
   "name": "han-planning",
   "description": "Planning-facing skills for the Han suite: specifying, planning, sequencing, breaking down, and stress-testing work before implementation. Home of plan-a-feature (build a feature specification from scratch through a relentless, evidence-based interview that walks the design tree), plan-implementation (turn a feature specification into an implementation plan through a project-manager-led team conversation), plan-a-phased-build (split a body of context into a sequence of independently demoable vertical-slice phases), plan-work-items (break a trusted implementation plan into independently-grabbable, atomic work items), and iterative-plan-review (stress-test an existing plan through multiple codebase-grounded review passes). Depends on han-core; bundled by the han meta-plugin.",
   "version": "2.0.4",
-  "dependencies": [
-    "han-core"
-  ]
+  "dependencies": ["han-core"]
 }

--- a/han-plugin-builder/skills/guidance/references/templates/marketplace-example.json
+++ b/han-plugin-builder/skills/guidance/references/templates/marketplace-example.json
@@ -11,10 +11,7 @@
     "description": "Alternate description location (merged with root description)",
     "version": "1.0.0"
   },
-  "allowCrossMarketplaceDependenciesOn": [
-    "other-internal-marketplace",
-    "partner-tools-marketplace"
-  ],
+  "allowCrossMarketplaceDependenciesOn": ["other-internal-marketplace", "partner-tools-marketplace"],
   "plugins": [
     {
       "name": "relative-path-plugin",

--- a/han-plugin-builder/skills/guidance/references/templates/plugin-example.json
+++ b/han-plugin-builder/skills/guidance/references/templates/plugin-example.json
@@ -91,8 +91,5 @@
       }
     }
   ],
-  "dependencies": [
-    "helper-lib",
-    { "name": "secrets-vault", "version": "~2.1.0" }
-  ]
+  "dependencies": ["helper-lib", { "name": "secrets-vault", "version": "~2.1.0" }]
 }

--- a/han-reporting/.claude-plugin/plugin.json
+++ b/han-reporting/.claude-plugin/plugin.json
@@ -2,7 +2,5 @@
   "name": "han-reporting",
   "description": "Reporting and summary skills for the Han suite. Turns feature specifications into plain-language stakeholder summaries (also called executive or business summaries) with diagrams, for sharing with non-technical stakeholders before implementation kicks off.",
   "version": "2.1.1",
-  "dependencies": [
-    "han-core"
-  ]
+  "dependencies": ["han-core"]
 }

--- a/han/.claude-plugin/plugin.json
+++ b/han/.claude-plugin/plugin.json
@@ -2,11 +2,5 @@
   "name": "han",
   "description": "Evidence-based planning, investigation, documentation, and review for solo and small-team product engineers. Installs the full Han suite by pulling in han-core, its planning skills (han-planning), its code-writing skills (han-coding), its GitHub extensions (han-github), and its reporting skills (han-reporting).",
   "version": "4.6.0",
-  "dependencies": [
-    "han-core",
-    "han-planning",
-    "han-coding",
-    "han-github",
-    "han-reporting"
-  ]
+  "dependencies": ["han-core", "han-planning", "han-coding", "han-github", "han-reporting"]
 }


### PR DESCRIPTION
# Prettier reformat: failure modes

Han's `lint` job has failed on every branch, including `main`, since CI landed in #120. The prettier config
(`proseWrap: "always"`, printWidth 120) was added but never actually run against the repo. Applying it touches 281
files (+28,218 / -12,660).

This report categorizes what that reformat actually does, based on the diffs verified against the working tree.

The thing to hold onto: prettier keeps the _rendered_ page the same, but han's markdown is read as raw text by agents.
Three of these categories change the raw text in ways that matter.

| #   | Category                    | Files | Harmful?            | Fixable by config? |
| --- | --------------------------- | ----- | ------------------- | ------------------ |
| 1   | Harmless reformatting       | ~271  | No                  | n/a                |
| 2   | Frontmatter re-quoting      | 103   | No (verified)       | n/a                |
| 3   | Renumbered steps            | 1     | **Yes**             | **No**             |
| 4   | Mangled code snippets       | 9     | **Yes**             | **No**             |
| 5   | Rewritten code examples     | 3     | Yes                 | Yes                |
| 6   | A file prettier can't read  | 1     | Not in CI           | n/a                |

## 1. Harmless reformatting

Rewraps paragraphs at 120 characters, swaps `*word*` for `_word_`, pads out tables, tidies blockquotes. This is most of
the 28k-line diff. The words don't change, so nothing breaks. It just makes every future doc diff noisy.

## 2. Frontmatter re-quoting

Rewrites the `description:` field at the top of each skill file from double quotes to single quotes. This one warranted
checking, since that field is what Claude reads to decide when to run a skill. All 103 frontmatter blocks were parsed
before and after with a YAML parser: the values come out identical. Safe.

## 3. Renumbered steps

Prettier renumbers ordered lists. In `han-coding/skills/coding-standard/SKILL.md`, step 4 becomes step 3 — but the
sentences around it still say "Step 6" and "Step 7". Those now point at the wrong steps, in a file Claude follows as
instructions. Nothing errors; the skill just quietly does the wrong step. This is the worst one.

Note that `.pre-commit-config.yaml` lists "ordered-list numbering" as something prettier is meant to own, which is the
direct conflict.

## 4. Mangled code snippets

Prettier strips the spaces inside `` ` — ` ``, turning it into `` `—` ``. In two work-item templates that snippet _is_
the heading format, and the sentence next to it still says "em-dash with surrounding spaces." The source now shows the
opposite of what the text says.

It also garbles backticks in docs that explain markdown itself, including `readability-editor.md` — the doc whose job is
to say "leave code fences byte-for-byte unchanged."

Affected: `work-items-to-issues/references/issue-template.md`, `plan-work-items/references/work-item-template.md`,
`markdown-to-confluence/SKILL.md`, `code-overview/references/overview-template.md`, `han-core/agents/readability-editor.md`,
`project-documentation/SKILL.md`, and three guidance references under `han-plugin-builder/`.

## 5. Rewritten code examples

Prettier reaches inside fenced code blocks and restyles the code: collapsing JSON arrays, flipping `'base'` to `"base"`,
shifting HTML spacing. Those examples are specs, so restyling them is wrong — but this one turns off with
`embeddedLanguageFormatting: "off"`.

Affected: `plugin-json-options.md`, `html-summary/SKILL.md`, `html-summary/references/report-style.md`.

## 6. A file prettier can't read

`han-reporting/skills/html-summary/references/html-template.html` is a schematic sketch, not real HTML, and prettier
hard-errors on it (exit 2). Not a CI problem today, because the prek hook only hands prettier markdown, JSON, YAML, and
JS. It would break if anyone widens that list.

## Bottom line

Categories 1 and 2 are just noise. Category 5 has a config switch. **Categories 3 and 4 are the blockers, and neither
can be turned off** — both still happen under the safest config available (`proseWrap: preserve` plus
`embeddedLanguageFormatting: off`), because they are core CommonMark normalizations.

No prettier setting formats this repo's markdown without breaking it. Recommendation: take markdown out of prettier's
scope and keep it on JSON, YAML, and JS — a clean 10-file diff that turns lint green.

## Related

- [PR #126](https://github.com/testdouble/han/pull/126) — fixes the other two lint failures (shellcheck, broken symlink).
  Its `lint` job is still red on prettier alone, pending this decision.
