### PR TITLE
chore(test): discover Bats tests repo-wide, not just test/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ One-time setup, from the repo root:
 Everyday use:
 
 - `npm run lint` runs every hook over the whole repo (`prek run --all-files`).
-- `npm test` runs the shell tests (`bats --recursive test/`).
+- `npm test` runs the shell tests (every `*.bats` file in the repo outside `node_modules`).
 - If installed, every commit runs the lint hooks (Prettier, ShellCheck, and file hygiene) on your staged files.
 
 CI runs the same lint hooks and the tests on every pull request.
@@ -79,8 +79,10 @@ How Prettier treats your files:
 - The static archives under `docs/plans/` and `docs/research/`, and the vendored assets under
   `han-reporting/skills/html-summary/assets/`, are left untouched (`.prettierignore`).
 
-Shell scripts are linted with ShellCheck. Tests live in `test/` as `*.bats` files and run in CI rather than on commit;
-run them locally with `npm test`.
+Shell scripts are linted with ShellCheck. A script's tests sit next to it as a `*.bats` file in the same directory
+(for example `scripts/detect-git-context.sh` is covered by `scripts/detect-git-context.bats`); harness-level checks
+that aren't tied to one script live in `test/`. `npm test` discovers every `*.bats` file in the repo outside
+`node_modules`. Tests run in CI rather than on commit; run them locally with `npm test`.
 
 ## Which plugin does the change belong in?
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Dev tooling for the han plugin suite (lint, format, and shell tests).",
   "scripts": {
     "lint": "prek run --all-files",
-    "test": "bats --recursive test/"
+    "test": "find . -name node_modules -prune -o -name '*.bats' -print0 | xargs -0 bats"
   },
   "devDependencies": {
     "@j178/prek": "^0.4.9",


### PR DESCRIPTION
## What

Change the `npm test` script so Bats discovers every `*.bats` file in the repo (outside `node_modules`) instead of only recursing `test/`:

```
find . -name node_modules -prune -o -name '*.bats' -print0 | xargs -0 bats
```

This lets a script's tests sit next to the script they cover (e.g. `scripts/foo.sh` covered by `scripts/foo.bats`), while `test/` stays home to harness-level checks like `sanity.bats`.

## Why `find`, not a Bats flag

Bats has no built-in path or directory exclusion. Its `--filter` / `--negative-filter` / `--filter-tags` flags all match test *names/tags*, not file paths — and a filtered-out file is still loaded and its file-level code executed anyway. There is no `.batsignore` and no `.gitignore` awareness; file discovery is driven purely by the positional path arguments. So shaping the list with `find` is what keeps `node_modules` (and any nested `node_modules`) out. `find` also still runs not-yet-committed tests, which a `git ls-files`-based list would skip.

## Sequencing

This is the config-only prerequisite. A follow-up MR relocates the existing `review-skill-or-agent` Bats tests next to their scripts and updates the `sanity.bats` comment. The CONTRIBUTING example it documents (`scripts/detect-git-context.bats`) only appears on `main` once that follow-up lands. Splitting them keeps this discovery change reviewable on its own.

## Verification

The new pipeline discovers and runs `test/sanity.bats` green on this branch. A failing test propagates correctly (`xargs` exits 123, so CI fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxmMsZfzA4d37Uh1rTfEDG
