### PR TITLE
Model specific guidance

### DIFF
--- a/docs/plans/per-model-authoring-guidance/artifacts/.discovery-notes.md
+++ b/docs/plans/per-model-authoring-guidance/artifacts/.discovery-notes.md
@@ -1,0 +1,42 @@
+# Discovery Notes: Per-Model Authoring Guidance Implementation
+
+Single source of truth for project context for this plan. Specialists read this first and do not re-grep what is here.
+
+## Tech stack / repo shape
+
+- Han is a documentation-and-markdown plugin suite. No application code; "implementation" here means authoring a markdown guidance reference and wiring it into two curated indexes. No build, test runner, or migration surface.
+- Writing voice is governed by `han-communication/references/writing-voice.md` (no em-dashes, direct second person, plainspoken; blocklist enforced). All prose-producing output follows it.
+
+## The deliverable and its touch points
+
+The feature is a new guidance reference in the `han-plugin-builder` guidance skill. Confirmed touch points:
+
+1. **The new reference file** — a markdown doc under `han-plugin-builder/skills/guidance/references/` (top-level, alongside `specialization-and-model-selection.md` and `iterative-plugin-development.md`). Format precedent: `iterative-plugin-development.md` (H1 title, prose, H2 sections, Cross-References section at the end) and `specialization-and-model-selection.md` (adds a Sources section).
+
+2. **The guidance skill routing map** — `han-plugin-builder/skills/guidance/SKILL.md`, Guidance Mode map (around lines 24-40). Today its only model-related line is "specialization-versus-model-tier reasoning → the top-level files." A per-model authoring entry needs its own bullet with task-distinguishing wording (spec D9).
+
+3. **The vendored rule index body** — `han-plugin-builder/skills/guidance/assets/rule-index-body.md`. IMPORTANT: this file hand-enumerates every guidance doc with a one-line description, grouped by section. It is the source of the path-scoped rule index that `init`/`update` writes to `.claude/rules/plugin-building-guidance.md`. A new reference that is not added here will be copied to disk but will NOT appear in the vendored rule index. This is a second index surface the spec's "one routing entry" (D4) did not name. The plan must update both the SKILL.md routing map AND rule-index-body.md.
+
+4. **The reverse cross-reference** — `han-plugin-builder/skills/guidance/references/specialization-and-model-selection.md` has a Cross-References section (lines 85-95) that must gain a link to the new doc plus a one-line scope disambiguator (spec D10). Ships in lockstep.
+
+## How vendoring actually works (confirms and refines the spec)
+
+- `scripts/init-guidance.sh` copies the references directory wholesale (`cp -R "$SRC_REFERENCES" .../plugin-guidance/references`, line ~74), so the new reference file is auto-vendored with no per-file wiring. This part of spec D4 holds.
+- BUT the same script regenerates the rule index from `assets/rule-index-body.md` (line ~32), which is curated. So "no separate wiring" is true for the reference file body and false for the two curated indexes (routing map + rule-index-body). Refinement, not contradiction: the spec's behavioral commitment ("the routing entry never points at a missing doc") still holds; the plan just has two index files to edit, not one.
+
+## Coverage / docs rules
+
+- CLAUDE.md coverage rule ("every skill and every agent gets a long-form doc in docs/skills or docs/agents") applies to skills and agents, NOT to guidance reference files. This new file is a guidance reference, so no `docs/skills/` or `docs/agents/` entry is required.
+- CLAUDE.md's repository-map does not enumerate individual guidance reference files (it describes the guidance folder as a whole), so no CLAUDE.md edit is required.
+- The authoring must follow han-plugin-builder's own guidance for reference files (`skill-building-guidance/skill-reference-files.md`) per the repo's standing rule that plugin assets use the plugin-building guidance.
+
+## Gaps explicitly checked and not found
+
+- No existing per-model authoring content anywhere in the guidance references (searched at spec stage).
+- No test harness or CI check specific to guidance references (Han runs prettier/shellcheck/whitespace hooks only; markdown prettier was disabled per recent commit a90cb09).
+- No ADRs or coding-standards directories under docs/ that govern guidance-doc content beyond the writing-voice profile.
+- No CHANGELOG entry is required at plan time; releasing is a separate `han-release` step and versions are not bumped unprompted.
+
+## Recent activity
+
+- The `han-plugin-builder` guidance references are actively maintained; `specialization-and-model-selection.md` is the adjacent doc and the closest format/scope precedent. The `model-specific-guidance` branch already carries the source research report and this feature spec.

--- a/docs/plans/per-model-authoring-guidance/artifacts/decision-log.md
+++ b/docs/plans/per-model-authoring-guidance/artifacts/decision-log.md
@@ -1,0 +1,90 @@
+# Decision Log: Per-Model Authoring Guidance
+
+This file records the decisions settled while specifying the per-model authoring guidance reference. Behavioral statements live in [../feature-specification.md](../feature-specification.md); this file holds the history, rationale, evidence, and rejected alternatives.
+
+The source research is [docs/research/model-specific-guidance-for-skills.md](../../../research/model-specific-guidance-for-skills.md), which recommended author-time guidance (its option O3) and is cited below as "the research."
+
+## Trivial decisions
+
+- D7: Models the guidance covers — Sonnet 5, Opus 4.8, and Fable 5, plus the model-agnostic default as the fallback for any other model. — Referenced in spec: Outcome, Alternate Flows and States.
+- D8: Writing voice — the document follows the Han writing-voice profile like every other guidance reference (considered a looser doc style; rejected because the repo holds one voice standard). — Referenced in spec: (whole document).
+
+## Full decisions
+
+### D1: A new authoring-guidance reference, distinct from tier selection
+
+- **Question:** Should per-model authoring guidance be a new reference, or an addition to the existing `specialization-and-model-selection.md`?
+- **Decision:** A new, separate guidance reference about how to write instructions for a given model.
+- **Rationale:** The existing document answers a different question, which model tier to run (opus, sonnet, haiku) based on how specialized the prompt is. This feature answers how to write instructions for a specific model generation at whatever tier. Mixing the two would blur both.
+- **Evidence:** `han-plugin-builder/skills/guidance/references/specialization-and-model-selection.md` is scoped to tier and effort selection (codebase). The research frames per-model prompting divergence as a separate concern from tier choice (the research).
+- **Rejected alternatives:**
+  - Extend `specialization-and-model-selection.md` — rejected because it would combine tier-choice reasoning with instruction-style reasoning in one document and make both harder to find and maintain.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** D5
+- **Referenced in spec:** Outcome
+
+### D2: Focus the content on the high-impact differences
+
+- **Question:** How much per-model detail should the document carry?
+- **Decision:** Lead with the two differences that change an authoring decision (the opposite-direction instruction style, and the Fable 5 reasoning-echo refusal trap), and cover thinking mode and effort and subagent eagerness as short supporting notes. Do not mirror every axis of Anthropic's per-model pages.
+- **Rationale:** The instruction-style split points an author in the wrong direction if they follow the wrong model's guidance, and the Fable 5 refusal trap is the one difference that can cause an outright failure rather than a style mismatch. The lighter axes were not shown to change an authoring decision, and a smaller document is cheaper to keep current against pages that get revised and archived.
+- **Evidence:** the research (instruction-following runs in opposite directions across Opus 4.8 / Sonnet 5 and Fable 5; the Fable 5 refusal category is the one functional-failure risk; model pages are pinned snapshots that get archived). User input on the content-depth question.
+- **Rejected alternatives:**
+  - Comprehensive per-model sections mirroring the full pages (verbosity, design defaults, tokenizer, and so on) — rejected because the extra axes were not shown to change authoring decisions and enlarge the maintenance surface. Deferred, not dropped (see the spec's Deferred section).
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow, Edge Cases and Failure Modes
+
+### D3: Author-time guidance that reaffirms the model-agnostic default
+
+- **Question:** Should the guidance encourage any run-time adaptation to the active model?
+- **Decision:** No. The guidance is author-time only. It states that shipped skills stay model-agnostic, that the model-agnostic form is the generalized fallback, and that run-time model detection and branching are out of scope and not reliable.
+- **Rationale:** The research found no reliable way for a skill to learn its own model at run time (no environment variable, the skill model field sets rather than reads the model, self-report is unreliable), and that run-time variants break cross-host portability and multiply maintenance. Acting on the real model differences at authoring time avoids all of that.
+- **Evidence:** the research (a skill cannot reliably learn which model is running it; the reject-run-time-branching conclusion is over-determined). Han's current skills already carry no model field and reference everything model-neutrally (`han-core/skills/*/SKILL.md`, codebase).
+- **Rejected alternatives:**
+  - Guidance that endorses inline "if running on model X" branches or per-model variants — rejected because the detection those depend on is unsound and the variants break portability.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Outcome, Primary Flow, Edge Cases and Failure Modes
+
+### D4: Surface through the guidance routing map, document only
+
+- **Question:** How is the document surfaced to authors, and does this feature also change the interactive builders?
+- **Decision:** Add one entry to the guidance skill's routing map pointing at the new reference, and place the reference alongside the other guidance references so the existing install and refresh carry it along. Do not change the skill-builder or agent-builder interviews.
+- **Rationale:** Authors already reach every guidance document through the routing map, and the install and refresh step vendors the references wholesale, so a new reference needs no separate wiring beyond the map entry. Prompting for a target model inside the builders is a larger change across two more skills with no evidence yet that it is needed.
+- **Evidence:** the guidance skill's Guidance Mode routing map lists reference groups and points authors to them (`han-plugin-builder/skills/guidance/SKILL.md`, codebase). The init and update modes vendor the `references/` directory wholesale (`han-plugin-builder/skills/guidance/SKILL.md`, codebase). User input on the scope-boundary question.
+- **Rejected alternatives:**
+  - Also add a target-model step to skill-builder and agent-builder — rejected as a larger surface with no evidence of need. Deferred, not dropped (see the spec's Deferred section).
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow, Coordinations, Out of Scope
+
+### D5: Cross-reference tier selection and cite the research as source
+
+- **Question:** How does the new document relate to the tier-selection guidance and to the research it comes from?
+- **Decision:** The document opens by stating its own scope, cross-references `specialization-and-model-selection.md` for the tier question, and cites the research report as the source of its per-model claims.
+- **Rationale:** The two documents answer adjacent questions that authors will confuse, so each should point at the other. Citing the research lets a reader trace a claim and judge its currency, and the research already recorded which per-model claims rest on single-vendor documentation.
+- **Evidence:** `specialization-and-model-selection.md` already uses a Cross-References section pointing at related guidance (codebase). The research labels the evidence status of each per-model claim (the research).
+- **Rejected alternatives:**
+  - Restate the tier-selection reasoning inline — rejected because it duplicates a maintained document and invites drift.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow, Edge Cases and Failure Modes
+
+### D6: Carry a currency marker
+
+- **Question:** How does the guidance stay trustworthy as Anthropic revises the model pages?
+- **Decision:** The document carries a visible marker of the date it was last checked and the models it was written against.
+- **Rationale:** The per-model claims rest largely on Anthropic's own pages, which are pinned snapshots that get revised and archived. A currency marker lets a reader judge whether the guidance is still current instead of trusting it blind.
+- **Evidence:** the research (model IDs are pinned snapshots, and legacy guidance is archived at each release; the per-model behavioral case leans on single-vendor documentation). Prior research reports in this repo carry a retrieval date convention (`docs/research/`, codebase).
+- **Rejected alternatives:**
+  - No currency marker — rejected because a reader could not tell whether the guidance had gone stale.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Edge Cases and Failure Modes

--- a/docs/plans/per-model-authoring-guidance/artifacts/decision-log.md
+++ b/docs/plans/per-model-authoring-guidance/artifacts/decision-log.md
@@ -27,15 +27,16 @@ The source research is [docs/research/model-specific-guidance-for-skills.md](../
 ### D2: Focus the content on the high-impact differences
 
 - **Question:** How much per-model detail should the document carry?
-- **Decision:** Lead with the two differences that change an authoring decision (the opposite-direction instruction style, and the Fable 5 reasoning-echo refusal trap), and cover thinking mode and effort and subagent eagerness as short supporting notes. Do not mirror every axis of Anthropic's per-model pages.
-- **Rationale:** The instruction-style split points an author in the wrong direction if they follow the wrong model's guidance, and the Fable 5 refusal trap is the one difference that can cause an outright failure rather than a style mismatch. The lighter axes were not shown to change an authoring decision, and a smaller document is cheaper to keep current against pages that get revised and archived.
-- **Evidence:** the research (instruction-following runs in opposite directions across Opus 4.8 / Sonnet 5 and Fable 5; the Fable 5 refusal category is the one functional-failure risk; model pages are pinned snapshots that get archived). User input on the content-depth question.
+- **Decision:** Lead with the two differences that change an authoring decision (the opposite-direction instruction style, and the Fable 5 reasoning-echo refusal trap). Cover thinking mode and effort and subagent eagerness as short supporting notes, and tie each note to the authoring decision it changes rather than listing it for completeness: the thinking-mode note tells an author not to write "think step by step" or thinking-toggle instructions for a model whose thinking is always on, and the effort note tells an author to rely on the effort setting rather than "think harder" prompt hacks. Do not mirror every axis of Anthropic's per-model pages.
+- **Rationale:** The instruction-style split points an author in the wrong direction if they follow the wrong model's guidance, and the Fable 5 refusal trap is the one difference that can cause an outright failure rather than a style mismatch. The supporting notes each change a concrete authoring choice, so they earn their place; the lighter axes (verbosity, design defaults, tokenizer) were not shown to change an authoring decision, and a smaller document is cheaper to keep current against pages that get revised and archived.
+- **Evidence:** the research (instruction-following runs in opposite directions across Opus 4.8 / Sonnet 5 and Fable 5; the Fable 5 refusal category is the one functional-failure risk; thinking-mode defaults differ across the three models; the effort setting is the reasoning-depth lever; model pages are pinned snapshots that get archived). User input on the content-depth question.
 - **Rejected alternatives:**
   - Comprehensive per-model sections mirroring the full pages (verbosity, design defaults, tokenizer, and so on) — rejected because the extra axes were not shown to change authoring decisions and enlarge the maintenance surface. Deferred, not dropped (see the spec's Deferred section).
+  - Listing the supporting notes for symmetry with no stated decision they change — rejected after review (F6) as a completeness anti-pattern; each note now names the decision it drives.
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F6
 - **Dependent decisions:** —
-- **Referenced in spec:** Primary Flow, Edge Cases and Failure Modes
+- **Referenced in spec:** Primary Flow
 
 ### D3: Author-time guidance that reaffirms the model-agnostic default
 
@@ -59,32 +60,86 @@ The source research is [docs/research/model-specific-guidance-for-skills.md](../
 - **Rejected alternatives:**
   - Also add a target-model step to skill-builder and agent-builder — rejected as a larger surface with no evidence of need. Deferred, not dropped (see the spec's Deferred section).
 - **Linked technical notes:** —
-- **Driven by findings:** —
-- **Dependent decisions:** —
+- **Driven by findings:** F1
+- **Dependent decisions:** D9
 - **Referenced in spec:** Primary Flow, Coordinations, Out of Scope
 
 ### D5: Cross-reference tier selection and cite the research as source
 
 - **Question:** How does the new document relate to the tier-selection guidance and to the research it comes from?
-- **Decision:** The document opens by stating its own scope, cross-references `specialization-and-model-selection.md` for the tier question, and cites the research report as the source of its per-model claims.
+- **Decision:** The document opens by stating its own scope, cross-references `specialization-and-model-selection.md` for the tier question, and cites the research report as the source of its per-model claims. The reverse link and a scope disambiguator on the tier doc are handled as a coordination (see D10).
 - **Rationale:** The two documents answer adjacent questions that authors will confuse, so each should point at the other. Citing the research lets a reader trace a claim and judge its currency, and the research already recorded which per-model claims rest on single-vendor documentation.
 - **Evidence:** `specialization-and-model-selection.md` already uses a Cross-References section pointing at related guidance (codebase). The research labels the evidence status of each per-model claim (the research).
 - **Rejected alternatives:**
   - Restate the tier-selection reasoning inline — rejected because it duplicates a maintained document and invites drift.
 - **Linked technical notes:** —
-- **Driven by findings:** —
-- **Dependent decisions:** —
+- **Driven by findings:** F2
+- **Dependent decisions:** D10
 - **Referenced in spec:** Primary Flow, Edge Cases and Failure Modes
 
 ### D6: Carry a currency marker
 
 - **Question:** How does the guidance stay trustworthy as Anthropic revises the model pages?
-- **Decision:** The document carries a visible marker of the date it was last checked and the models it was written against.
-- **Rationale:** The per-model claims rest largely on Anthropic's own pages, which are pinned snapshots that get revised and archived. A currency marker lets a reader judge whether the guidance is still current instead of trusting it blind.
-- **Evidence:** the research (model IDs are pinned snapshots, and legacy guidance is archived at each release; the per-model behavioral case leans on single-vendor documentation). Prior research reports in this repo carry a retrieval date convention (`docs/research/`, codebase).
+- **Decision:** The document carries a visible marker recording when it was written and against which model versions, and names its source (the research report and, through it, Anthropic's per-model pages) so a reader knows what to re-verify against. It also discloses that the Fable 5 refusal warning rests on single-vendor, single-source evidence. The marker records currency; it does not commit an owner to a re-check cadence, because the document is static and is refreshed when someone revisits it.
+- **Rationale:** The per-model claims rest largely on Anthropic's own pages, which are pinned snapshots that get revised and archived, and the refusal warning is the highest-stakes claim on the weakest evidence. A currency marker and an evidence-status disclosure let a reader judge how far to trust each claim instead of trusting it blind.
+- **Evidence:** the research (model IDs are pinned snapshots, and legacy guidance is archived at each release; the per-model behavioral case leans on single-vendor documentation; the refusal category is single-source, A3). Prior research reports in this repo carry a retrieval date convention (`docs/research/`, codebase).
 - **Rejected alternatives:**
   - No currency marker — rejected because a reader could not tell whether the guidance had gone stale.
+  - Presenting the refusal warning without its evidence status — rejected after review (F5) because the highest-stakes claim would read as the best-established one.
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F5, F10
 - **Dependent decisions:** —
 - **Referenced in spec:** Edge Cases and Failure Modes
+
+### D9: Give the routing entry its own bullet with task-distinguishing scent
+
+- **Question:** How does the guidance routing map surface the new document so an author looking for "how do I write for Fable 5" is routed here and not to the tier-selection doc?
+- **Decision:** The routing map gains its own bullet for per-model authoring, worded to distinguish the author task "how to write instructions for a target model" from the existing "which model tier to run." The new document is not folded into the location-based "top-level files" line.
+- **Rationale:** Findability is the whole feature for an on-demand document. The map's only model-related scent today points at the tier doc, so a per-model authoring entry needs task-distinguishing wording or authors are misrouted. A distinct bullet resolves the confusion at the routing layer, where prevention lives, rather than relying on the reader backtracking after landing on the wrong doc.
+- **Evidence:** the guidance routing map groups references and today routes "specialization-versus-model-tier reasoning" to the top-level files (`han-plugin-builder/skills/guidance/SKILL.md`, codebase). Review findings F1 (information-architect IA-001, junior-developer JD-006).
+- **Rejected alternatives:**
+  - Fold the new doc into the existing "top-level files" bucket line — rejected because that bucket is organized by file location and its only model scent points at the tier doc, so the author task would be misrouted.
+- **Linked technical notes:** —
+- **Driven by findings:** F1
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow, Coordinations
+
+### D10: The tier-selection doc is a coordinating artifact
+
+- **Question:** How is the bidirectional relationship with the tier-selection doc kept whole?
+- **Decision:** `specialization-and-model-selection.md` is a coordinating artifact that gains the reverse cross-reference to the new document and a one-line scope disambiguator, shipping in lockstep with the new document.
+- **Rationale:** The spec claims each document cross-references the other, but the reverse link was untracked, so an author who lands on the older, higher-scent tier doc would have no path onward to the authoring guidance. Naming the tier doc as a ship-together coordination keeps the cross-reference whole in both directions.
+- **Evidence:** `specialization-and-model-selection.md` has a Cross-References section that would carry the reverse link (`han-plugin-builder/skills/guidance/references/specialization-and-model-selection.md`, codebase). Review finding F2 (information-architect IA-003).
+- **Rejected alternatives:**
+  - Rely on the new doc's forward link alone — rejected because a reader entering through the tier doc would orphan.
+- **Linked technical notes:** —
+- **Driven by findings:** F2
+- **Dependent decisions:** —
+- **Referenced in spec:** Coordinations, Edge Cases and Failure Modes
+
+### D11: The concrete unknown-target default
+
+- **Question:** When the target model is unknown, what does "write model-agnostic" concretely tell an author to write, given that Opus 4.8 and Sonnet 5 want enumerated steps while Fable 5 degrades on checklists?
+- **Decision:** The default is to lead with the goal and the reasons behind it, state the load-bearing constraints and scope explicitly, and avoid exhaustive step-by-step micro-checklists. This pragmatic middle gives Fable 5 the goal and context it uses well without the checklist that degrades it, and gives Opus 4.8 and Sonnet 5 the explicit scope they need on the behaviors that matter.
+- **Rationale:** A bare "write model-agnostic" left the doc's central instruction undefined at the exact point the model families pull in opposite directions, which is the common unknown-target case. The middle path is synthesizable from the research: Fable 5 uses stated reasons to make good micro-decisions and is harmed by over-enumeration, while Opus 4.8 and Sonnet 5 read literally and need explicit scope. Stating the goal plus the load-bearing constraints satisfies both without the failure mode of either extreme.
+- **Evidence:** the research (Opus 4.8 / Sonnet 5 read instructions literally and need explicit scope; Fable 5 does better with a stated goal and reasons and degrades on step-by-step checklists). This is a synthesis across those findings, surfaced to the user as a settled decision they can revisit.
+- **Rejected alternatives:**
+  - Default to fully enumerated checklists — rejected because the research says this degrades Fable 5 output.
+  - Default to goal-only prompting — rejected because Opus 4.8 and Sonnet 5 read literally and would be under-specified on load-bearing behaviors.
+- **Linked technical notes:** —
+- **Driven by findings:** F3
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow, Alternate Flows and States
+
+### D12: A concrete test for the refusal pattern
+
+- **Question:** How does an author tell when the Fable 5 reasoning-echo warning applies to an instruction they are writing?
+- **Decision:** The warning carries a concrete test. The pattern is present when an instruction tells the model to reproduce or transcribe its own internal thinking into the visible deliverable. That is distinct from asking the model to write a normal explanation of a decision or a reasoned answer as ordinary content, which the warning does not cover.
+- **Rationale:** "Avoid it where it matters" offloaded a judgment without giving the author criteria, and the research calls the reasoning-echo pattern a common one in agentic skills, which raises the stakes. A recognition test makes the one failure-causing warning actionable.
+- **Evidence:** the research (the Fable 5 refusal category triggers on instructions that ask the model to echo its own reasoning into the response). Review finding F4 (junior-developer JD-002).
+- **Rejected alternatives:**
+  - Leave "where it matters" undefined — rejected because the author could not tell when the warning applies.
+- **Linked technical notes:** —
+- **Driven by findings:** F4
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow

--- a/docs/plans/per-model-authoring-guidance/artifacts/implementation-decision-log.md
+++ b/docs/plans/per-model-authoring-guidance/artifacts/implementation-decision-log.md
@@ -1,0 +1,104 @@
+# Implementation Decision Log: Per-Model Authoring Guidance
+
+This file records every implementation decision committed while planning the per-model authoring guidance reference. Behavioral and implementation statements live in [../feature-implementation-plan.md](../feature-implementation-plan.md); this file captures the question, rationale, evidence, and rejected alternatives for each decision. Round-by-round history lives in [implementation-iteration-history.md](implementation-iteration-history.md).
+
+The source specification is [../feature-specification.md](../feature-specification.md); its decision log is [decision-log.md](decision-log.md) and is cited below as "spec D#." The source research is [docs/research/model-specific-guidance-for-skills.md](../../../research/model-specific-guidance-for-skills.md), cited as "the research."
+
+## Trivial decisions
+
+_No trivial decisions. Every committed decision below carries at least one rejected alternative and rests on evidence beyond the source framing, so each is recorded in full._
+
+## Full decisions
+
+### D-1: Ship all five edits as one atomic commit
+
+- **Question:** How are the touch points sequenced so no navigation surface ever points at a document that is not yet present?
+- **Decision:** Land all five edits together in one atomic commit: (1) the new reference file under `han-plugin-builder/skills/guidance/references/`; (2) the routing bullet in `han-plugin-builder/skills/guidance/SKILL.md`; (3) the routing bullet in `han-plugin-builder/skills/guidance/assets/guidance-portable-SKILL.md`; (4) the entry in `han-plugin-builder/skills/guidance/assets/rule-index-body.md`; (5) the reverse cross-reference in `han-plugin-builder/skills/guidance/references/specialization-and-model-selection.md`. The forward link and source citation ship inside edit (1).
+- **Rationale:** Every navigation surface points at the reference and the reference points back, so shipping them together removes any ordering trap and satisfies the spec's Coordinations requirement that the routing entry never point at a missing document. A documentation feature has no build, migration, or deploy ordering, so atomicity is the only sequencing constraint that applies.
+- **Evidence:** spec Coordinations table (`../feature-specification.md` lines 51-55); spec D4, D9, D10; R1 claim C2 (junior-developer JD-002 + information-architect Q2); discovery notes touch-point list (`.discovery-notes.md`).
+- **Rejected alternatives:**
+  - Ship the reference file first and wire the indexes in a follow-up commit — rejected because a vendored refresh between the two commits would copy the reference to disk (`scripts/init-guidance.sh:74` copies `references/` wholesale) while the two curated indexes still carry no scent to it, orphaning it exactly as the spec Coordinations requirement forbids.
+- **Specialist owner:** junior-developer / authoring engineer.
+- **Revisit criterion:** if review-size constraints ever force the five edits across separate PRs (not expected for five small documentation edits).
+- **Dissent (if any):** none known.
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-2, D-3
+- **Referenced in plan:** Implementation Approach, Decomposition and Sequencing, Definition of Done
+
+### D-2: Add the routing bullet to both routing maps, plugin and portable copy
+
+- **Question:** Which routing map or maps receive the new task-distinguishing bullet?
+- **Decision:** Add an identically worded, task-distinguishing bullet to both the plugin's own `skills/guidance/SKILL.md` (inserted after the model bullet at lines 36-37 and before the Templates bullet at line 38) and the vendored `assets/guidance-portable-SKILL.md` (after the model bullet at lines 25-26 and before the Templates bullet at line 27).
+- **Rationale:** The plugin's own `SKILL.md` is never vendored into other repos; `scripts/init-guidance.sh` vendors the portable copy instead. A bullet placed only in the plugin copy would leave every vendored repo's routing map with no scent to the reference, even though the reference file itself is copied wholesale. Vendored repos are a primary audience per the spec's Actors, so both maps must carry the bullet. This is the load-bearing implementation decision beyond the spec, whose D4 and D9 named a single routing map.
+- **Evidence:** `scripts/init-guidance.sh:31` (`PORTABLE_SKILL` resolves to `assets/guidance-portable-SKILL.md`), `:73` (`cp "$PORTABLE_SKILL" .../plugin-guidance/SKILL.md`), `:74` (`cp -R "$SRC_REFERENCES" ...`); `SKILL.md` lines 36-38; `guidance-portable-SKILL.md` lines 25-27; R1 claim C1 (junior-developer JD-001); spec D4, D9.
+- **Rejected alternatives:**
+  - Update only the plugin's own `SKILL.md` — rejected because vendored repos (a primary audience per spec Actors) would receive the reference on disk with no routing scent, defeating the findability that is the whole feature.
+- **Specialist owner:** junior-developer / authoring engineer.
+- **Revisit criterion:** if `init-guidance.sh` ever begins vendoring the plugin's own `SKILL.md` rather than the portable copy, collapsing the two maps into one.
+- **Dissent (if any):** none known.
+- **Driven by rounds:** R1
+- **Dependent decisions:** —
+- **Referenced in plan:** Implementation Approach, Definition of Done
+
+### D-3: Add and task-distinguish the rule-index-body entry
+
+- **Question:** Does the vendored rule index need a curated entry for the new reference, and where does it go?
+- **Decision:** Add a third bullet under the `## Plugin development` section of `assets/rule-index-body.md` (after the Specialization and Model Selection entry at lines 161-164), matching the existing `[Title](path) — what it covers + when to read it` pattern and carrying an inline scope disambiguator that distinguishes writing-for-a-model from choosing-a-model-tier.
+- **Rationale:** `rule-index-body.md` is hand-enumerated and regenerates the vendored `.claude/rules/plugin-building-guidance.md` index. A reference not listed here is copied to disk but left orphaned in the vendored rule index. The spec's D4 named "one routing entry" and did not name this third surface. The entry sits beside Specialization and Model Selection and fires whenever an author edits a skill or agent file, so it needs the same task-distinguishing scent as the routing bullet.
+- **Evidence:** discovery notes item 3 (`.discovery-notes.md`); `rule-index-body.md` lines 154-164; `scripts/init-guidance.sh` rule-index regeneration step (`RULE_BODY` at `:32`); R1 claim C3 (information-architect Q2 flag + junior-developer JD-003); spec D4.
+- **Rejected alternatives:**
+  - Rely on the wholesale reference copy alone — rejected because copying the reference file does not touch the curated rule index, so omission leaves the doc orphaned in every vendored `.claude/rules` index.
+- **Specialist owner:** information-architect.
+- **Revisit criterion:** if rule-index generation ever switches from hand-enumeration to auto-enumerating the `references/` directory.
+- **Dissent (if any):** none known.
+- **Driven by rounds:** R1
+- **Dependent decisions:** —
+- **Referenced in plan:** Implementation Approach, Definition of Done
+
+### D-4: Top-level references/ placement and filename
+
+- **Question:** Where does the new reference file live, and what is it named?
+- **Decision:** Place it at top-level `han-plugin-builder/skills/guidance/references/`, alongside `specialization-and-model-selection.md` and `iterative-plugin-development.md`, named `per-model-authoring.md`.
+- **Rationale:** The document is cross-cutting to both skill authors and agent authors (spec Actors), like the adjacent tier doc, so top-level placement fits. The entity-scoped subdirectories (`skill-building-guidance/`, `agent-building-guidelines/`) would falsely signal single-entity scope and orphan half the audience, and a new two-file "model" folder is unearned structure that would break scent-adjacency with the tier doc. `per-model-authoring.md` carries clear task scent and matches the plan folder name.
+- **Evidence:** R1 claim C4 (information-architect Q3); discovery notes item 1, which names `iterative-plugin-development.md` and `specialization-and-model-selection.md` as the format precedents; spec Actors section (skill authors and agent authors).
+- **Rejected alternatives:**
+  - Place it under a per-entity subdirectory (`skill-building-guidance/` or `agent-building-guidelines/`) — rejected as Category Fiction that would orphan half the two-actor audience.
+  - Create a new `model/` folder — rejected as unearned structure that breaks scent-adjacency with the tier doc.
+  - Name it `writing-instructions-per-model.md` — rejected as longer with no added scent over `per-model-authoring.md`.
+- **Specialist owner:** information-architect.
+- **Revisit criterion:** if a second per-model authoring document is added, which would justify grouping them in a folder.
+- **Dissent (if any):** none known.
+- **Driven by rounds:** R1
+- **Dependent decisions:** —
+- **Referenced in plan:** Implementation Approach, Definition of Done
+
+### D-5: Source-citation form — external URLs plus named report, no fragile repo-relative path
+
+- **Question:** How does the new document cite its source, given that `references/` is copied wholesale into arbitrary repos?
+- **Decision:** Cite the Anthropic per-model page URLs directly and name the research report (`model-specific-guidance-for-skills.md`) without a repo-relative path, matching the tier doc's external-URL Sources convention. Resolves OQ-1 by evidence.
+- **Rationale:** `scripts/init-guidance.sh:74` copies `references/` into arbitrary repos, and `docs/research/` lives outside the guidance folder, so a repo-relative link to the research report would 404 in every vendored copy. The adjacent tier doc already cites external URLs only, so this matches an established convention rather than inventing one.
+- **Evidence:** R1 claim C5 (junior-developer JD-004, resolved); `scripts/init-guidance.sh:74`; `specialization-and-model-selection.md` Sources section (external URLs only, around lines 79-83); the research Sources table A1-A3 (the Anthropic per-model page URLs); spec D5, D6.
+- **Rejected alternatives:**
+  - A repo-relative link to `docs/research/model-specific-guidance-for-skills.md` — rejected because the path breaks in every vendored copy, where `references/` is transplanted into a repo that has no `docs/research/` at that location.
+- **Specialist owner:** information-architect.
+- **Revisit criterion:** if the guidance folder is ever vendored together with `docs/research/`, making a repo-relative link resolvable.
+- **Dissent (if any):** none known.
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-6
+- **Referenced in plan:** Implementation Approach, Definition of Done
+
+### D-6: The reference document's own structure and content commitments
+
+- **Question:** What must the new reference document contain for the routed author to get the promised outcome?
+- **Decision:** The document opens by stating its own scope (author-time only; shipped skills stay model-agnostic; run-time detection is out of scope and not reliable), then states the model-agnostic default and its concrete unknown-target form (lead with the goal and reasons, state load-bearing constraints and scope explicitly, avoid exhaustive micro-checklists), the opposite-direction instruction-style split (Opus 4.8 and Sonnet 5 read literally and want behaviors spelled out; Fable 5 does better with a stated goal than an enumerated checklist), the Fable 5 reasoning-echo refusal warning with its recognition test and single-source disclosure, the thinking-mode and effort supporting notes each tied to the authoring decision it changes, a forward cross-reference to the tier doc, a source citation in the D-5 form, and a visible currency marker naming the three models and the write date.
+- **Rationale:** These content commitments are inherited from the spec and are exactly what Definition of Done tests. Recording them here keeps the document's required content auditable at plan altitude without inlining the prose the author will write.
+- **Evidence:** spec Primary Flow and Edge Cases and Failure Modes; spec D2 (high-impact differences), D3 (author-time-only default), D5 (cross-reference and cite source), D6 (currency marker and single-source disclosure), D11 (concrete unknown-target default), D12 (refusal recognition test); the research A1-A3 (per-model behavioral claims), with the Fable 5 refusal category single-source on A3.
+- **Rejected alternatives:**
+  - Omit the currency marker or the single-source disclosure — rejected at spec stage (D6, finding F5) because the highest-stakes claim on the weakest evidence would otherwise read as the best-established one.
+  - State a bare "write model-agnostic" without the concrete unknown-target form — rejected at spec stage (D11, finding F3) because it leaves the document's central instruction undefined at the common unknown-target case.
+- **Specialist owner:** information-architect / authoring engineer.
+- **Revisit criterion:** if Anthropic revises or archives a named model's prompting page (the currency marker is the reader's signal to re-verify).
+- **Dissent (if any):** none known.
+- **Driven by rounds:** R1
+- **Dependent decisions:** —
+- **Referenced in plan:** Context, Implementation Approach, Definition of Done

--- a/docs/plans/per-model-authoring-guidance/artifacts/implementation-iteration-history.md
+++ b/docs/plans/per-model-authoring-guidance/artifacts/implementation-iteration-history.md
@@ -1,0 +1,21 @@
+# Implementation Iteration History: Per-Model Authoring Guidance
+
+This file records how the implementation plan evolved across discussion rounds. Committed decisions live in [implementation-decision-log.md](implementation-decision-log.md); the primary plan lives in [../feature-implementation-plan.md](../feature-implementation-plan.md).
+
+## R1: Parallel specialist review
+
+- **Specialists engaged:** `han-core:junior-developer`, `han-core:information-architect`. (Size: small; round cap 1. `han-core:project-manager` reserved for synthesis.)
+- **New input provided:** the feature specification, its decision log, and the discovery notes (`.discovery-notes.md`).
+- **Claim ledger:**
+  - **C1 (Evidenced, junior-developer JD-001):** the Guidance Mode routing map exists in two files, the plugin's `skills/guidance/SKILL.md` and the vendored `assets/guidance-portable-SKILL.md`; only the portable copy is vendored into other repos (`scripts/init-guidance.sh:73`, `:31`). Both need the new task-distinguishing bullet, or vendored-repo authors get the reference on disk with no scent to it. Extends spec D4/D9, which named one routing map.
+  - **C2 (Evidenced, junior-developer JD-002 + information-architect Q2):** the ship-together set is five edits in one atomic commit: the new reference file, the routing bullet in `SKILL.md`, the routing bullet in `guidance-portable-SKILL.md`, the entry in `assets/rule-index-body.md`, and the reverse link in `specialization-and-model-selection.md`.
+  - **C3 (Evidenced, information-architect Q2 flag + junior-developer JD-003):** `assets/rule-index-body.md` is a third curated navigation surface not named by spec D4/D9/D10. It hand-enumerates every guidance doc and regenerates the vendored `.claude/rules` index (`init-guidance.sh` regeneration step). Omitting it leaves the doc orphaned in the vendored rule index. The new entry belongs under the `## Plugin development` section and needs the same task-distinguishing wording as the routing bullet.
+  - **C4 (Evidenced, information-architect Q3):** top-level `references/` placement is correct. The doc is cross-cutting to both skill and agent authors (spec Actors), like the adjacent tier doc; a per-entity subfolder or a new two-file "model" folder would be Category Fiction and unearned structure.
+  - **C5 (Evidenced, junior-developer JD-004, resolved):** a repo-relative link to `docs/research/` would break in every vendored copy because `references/` is copied into arbitrary repos. The adjacent tier doc's Sources section cites external URLs only.
+- **Open Questions raised:**
+  - **OQ-1 (plan-level):** what citation form should the new doc use for its source, given the vendoring constraint (C5)? Resolved by evidence in this round.
+- **Spec-maturity tags:** plan-level: all findings (C1–C5, OQ-1). spec-level: 0. T#-contradiction: not applicable (no `feature-technical-notes.md` exists). Spec-maturity gate did not trip.
+- **Resolution source:** OQ-1 resolved by evidence: cite the Anthropic per-model page URLs directly and name the research report without a fragile repo-relative path, matching the adjacent tier doc's external-URL Sources convention. No question required user input or reframing.
+- **Decisions produced:** D-1, D-2, D-3, D-4, D-5, D-6
+- **Changed in plan:** Implementation Approach, Decomposition and Sequencing, Definition of Done
+- **Project-manager next-step recommendation:** Go to synthesis. No spec-maturity trip, no named handoff, the one Open Question resolved by evidence.

--- a/docs/plans/per-model-authoring-guidance/artifacts/team-findings.md
+++ b/docs/plans/per-model-authoring-guidance/artifacts/team-findings.md
@@ -1,0 +1,11 @@
+# Team Findings: Per-Model Authoring Guidance
+
+This file records the review-team findings for the per-model authoring guidance reference, and how each was resolved. Behavioral outcomes live in [../feature-specification.md](../feature-specification.md); decisions live in [decision-log.md](decision-log.md).
+
+## Major findings
+
+<!-- Populated after the review team returns. -->
+
+## Minor edits
+
+<!-- Populated after the review team returns. -->

--- a/docs/plans/per-model-authoring-guidance/artifacts/team-findings.md
+++ b/docs/plans/per-model-authoring-guidance/artifacts/team-findings.md
@@ -2,10 +2,61 @@
 
 This file records the review-team findings for the per-model authoring guidance reference, and how each was resolved. Behavioral outcomes live in [../feature-specification.md](../feature-specification.md); decisions live in [decision-log.md](decision-log.md).
 
+Reviewers: `han-core:junior-developer` (scope, assumptions, YAGNI) and `han-core:information-architect` (findability and the risk of confusion with the adjacent tier-selection doc).
+
 ## Major findings
 
-<!-- Populated after the review team returns. -->
+### F1: The routing-map entry that makes the document findable is unspecified
+
+- **Agent:** information-architect (IA-001), junior-developer (JD-006)
+- **Finding:** The spec's Primary Flow and Outcome promise the author "can find" the document, but the decision (D4) committed only to "add one entry" without committing its wording. The bucket it would join is organized by file location, and its only model-related scent today points at the tier-selection doc. Findability is the whole feature for an on-demand document, so an unspecified routing label is the gap between the promised flow and the committed flow.
+- **Resolution:** Added [D9](decision-log.md#d9-give-the-routing-entry-its-own-bullet-with-task-distinguishing-scent): the routing map gains its own bullet for per-model authoring, worded to distinguish "how to write instructions for a target model" from the existing "which model tier to run." Primary Flow step 2 and the Coordinations routing row now state the routing keys on that author intent.
+- **Resolved by:** evidence
+- **Affected decisions:** D9 (new), D4 (amended)
+- **Changed in spec:** Primary Flow, Coordinations
+
+### F2: The bidirectional cross-reference is claimed but not tracked as a coordination
+
+- **Agent:** information-architect (IA-003)
+- **Finding:** D5 and Edge Cases say each document cross-references the other, and imply the tier doc gains a scope disambiguator, but the Coordinations table (the spec's ledger of what ships together) lists only the routing map and the vendored copy. So the reverse link (tier doc to new doc) and the tier doc's disambiguating note are untracked, and an author who lands on the older, higher-scent tier doc has no path onward.
+- **Resolution:** Added [D10](decision-log.md#d10-the-tier-selection-doc-is-a-coordinating-artifact): the tier-selection doc is named as a coordinating artifact that gains the reverse cross-reference and a one-line scope disambiguator, shipping in lockstep. Added a Coordinations row for it.
+- **Resolved by:** evidence
+- **Affected decisions:** D10 (new), D5 (amended)
+- **Changed in spec:** Coordinations, Edge Cases and Failure Modes
+
+### F3: The "model-agnostic default" is undefined exactly where the model families want opposite things
+
+- **Agent:** junior-developer (JD-001, OQ2)
+- **Finding:** The headline difference is that Opus 4.8 and Sonnet 5 want each behavior enumerated while Fable 5 degrades on checklists and wants a stated goal. Yet the safe default the doc points authors to, "write model-agnostic," is left undefined at exactly that split, which is the common unknown-target case. The doc's central instruction would give an author nothing concrete to write.
+- **Resolution:** Added [D11](decision-log.md#d11-the-concrete-unknown-target-default): the concrete default is to lead with the goal and the reasons, state the load-bearing constraints and scope explicitly, and avoid exhaustive step-by-step micro-checklists. This pragmatic middle serves all three families from the research evidence. Primary Flow step 3 and the unknown-target flow now state it. Flagged to the user as a settled decision they can revisit.
+- **Resolved by:** evidence
+- **Affected decisions:** D11 (new)
+- **Changed in spec:** Primary Flow, Alternate Flows and States
+
+### F4: The refusal warning offers no test for when the pattern "matters"
+
+- **Agent:** junior-developer (JD-002)
+- **Finding:** Step 5 tells authors to avoid the reasoning-echo instruction "where it matters" but never says how to recognize when the pattern is present and consequential. The research calls it a common agentic pattern, which raises the stakes of the ambiguity.
+- **Resolution:** Added [D12](decision-log.md#d12-a-concrete-test-for-the-refusal-pattern): the warning carries a concrete test. The pattern is present when an instruction tells the model to reproduce its internal thinking into the visible deliverable, which is distinct from asking for a normally-written explanation of a decision. Primary Flow step 5 now states the test.
+- **Resolved by:** evidence
+- **Affected decisions:** D12 (new)
+- **Changed in spec:** Primary Flow
+
+### F5: The single-source status of the refusal warning does not reach the reader
+
+- **Agent:** junior-developer (JD-005)
+- **Finding:** The refusal-trap claim is the doc's one functional-failure warning and also its weakest evidence (research A3, single-source, single-vendor). The doc should let a reader weigh the warning knowing that.
+- **Resolution:** Amended [D6](decision-log.md#d6-carry-a-currency-marker): the document discloses that the refusal warning rests on single-vendor, single-source evidence, alongside the currency marker. Edge Cases updated.
+- **Resolved by:** evidence
+- **Affected decisions:** D6 (amended)
+- **Changed in spec:** Edge Cases and Failure Modes
 
 ## Minor edits
 
-<!-- Populated after the review team returns. -->
+- F6: Supporting notes (thinking mode, effort, subagent eagerness) read as included-for-completeness; reframed to name the authoring decision each one changes rather than listing them for symmetry — junior-developer (JD-003) — Primary Flow; D2 amended.
+- F7: The out-of-scope note on the `readability-guidance` per-model note claimed it is "planned on its own" with no pointer; reworded to state it is a separate research item (item 3) not yet planned, tracked out of scope here — junior-developer (JD-004) — Out of Scope.
+- F8: No stated acceptance test; added a one-line definition of done to Outcome — junior-developer (JD-008) — Outcome.
+- F9: The unknown-target flow conflated two reasons (operator picks the model at run time vs. a skill cannot self-detect its model); separated them — junior-developer (JD-009) — Alternate Flows and States.
+- F10: The currency marker implied an unnamed re-check owner and an ambiguous verification source; clarified that it records when the doc was written and against which model pages, and that a reader verifies against those pages and the cited research — junior-developer (JD-010); D6 amended — Edge Cases and Failure Modes.
+- F11: Coordinations row 2 leaked install/placement mechanics ("lives with the other references, no separate wiring"); restated behaviorally as "repos that vendor the guidance receive the new reference through the normal refresh, and the routing entry never points at a missing document" — junior-developer (JD-007) — Coordinations.
+- F12: Confirmed no existing Han skill or agent uses the reasoning-echo instruction pattern the guidance warns against (grep across all prose-producing plugins, zero hits), so the suite will not contradict its own new guidance; recorded as a resolved open item — junior-developer (OQ3) — Open Items.

--- a/docs/plans/per-model-authoring-guidance/feature-implementation-plan.md
+++ b/docs/plans/per-model-authoring-guidance/feature-implementation-plan.md
@@ -1,0 +1,109 @@
+# Feature Implementation Plan: Per-Model Authoring Guidance
+
+A new markdown guidance reference in the `han-plugin-builder` guidance skill that teaches skill and agent authors how Sonnet 5, Opus 4.8, and Fable 5 differ in how you write instructions for them, anchored to a model-agnostic default. It ships as one atomic commit of five documentation edits, wires into the two curated navigation surfaces plus the reverse cross-reference, and changes no run-time behavior.
+
+## Source Specification
+
+- **Feature specification:** [feature-specification.md](feature-specification.md)
+- **Specification decision log:** [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Specification team findings:** [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Specification decisions this plan inherits:** D1, D2, D3, D4, D5, D6, D7, D8, D9, D10, D11, D12
+- **Specification open items this plan must respect or resolve:** OI-1 (resolved at spec stage; see Open Items)
+
+## Outcome
+
+When this plan is executed, a new reference file `per-model-authoring.md` exists in `han-plugin-builder/skills/guidance/references/`, and an author consulting the plugin-building guidance while writing or hardening a skill or agent can be routed to it by the "how do I write instructions for this model" question. Both routing maps (the plugin's own `SKILL.md` and the vendored portable copy) and the vendored rule index carry a task-distinguishing entry, and the tier-selection doc carries the reverse cross-reference, so neither door orphans a reader. No shipped skill or agent behaves differently at run time.
+
+## Context
+
+- **Driving constraint:** The source research ([docs/research/model-specific-guidance-for-skills.md](../../research/model-specific-guidance-for-skills.md), recommendation O3) found that the three models genuinely diverge in how they follow instructions, that a skill cannot reliably detect its own model at run time, and that the sound place to act on the differences is when an author writes a skill. This feature is the author-time half of that recommendation.
+- **Stakeholders:** skill authors and agent authors (who need to find and apply the guidance), and maintainers of the vendored guidance in downstream repos (who need the reference to arrive wired into every navigation surface, not orphaned).
+- **Future-state concern:** the per-model behavioral claims rest largely on Anthropic's own prompting pages, which are pinned snapshots that get revised and archived, and the Fable 5 refusal warning is single-vendor, single-source. The document carries a currency marker and a single-source disclosure so a reader can judge staleness; there is no automated re-check and none is warranted for a static document ([D-6](artifacts/implementation-decision-log.md#d-6-the-reference-documents-own-structure-and-content-commitments)).
+- **Out-of-scope boundary:** no run-time model detection or branching, no per-model skill or agent variants, no edits to existing skills or agents to tune them per model, no changes to the skill-builder or agent-builder interviews, and no `readability-guidance` per-model note. These are carried out of scope by the spec (Out of Scope and Deferred (YAGNI) sections) and are not reopened here.
+
+## Team Composition and Participation
+
+| Specialist               | Status      | Key Input                                                                                                                                                       |
+| ------------------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project-manager`        | Coordinator | Facilitated R1 and synthesized this plan.                                                                                                                        |
+| `junior-developer`       | Active      | Found the second (portable) routing map and the third (rule-index) navigation surface the spec did not name; confirmed the citation-path vendoring trap (C1, C2, C3, C5). |
+| `information-architect`  | Active      | Fixed the routing-bullet placement and task-distinguishing wording, the rule-index entry, top-level placement, and the filename scent (Q1-Q3, C3, C4).           |
+
+## Implementation Approach
+
+This is a documentation feature. "Implementation" means authoring one markdown reference and wiring it into the guidance skill's navigation surfaces. There is no build, test runner, migration, or run-time surface (discovery notes: Han runs prettier/shellcheck/whitespace hooks only, and markdown prettier was disabled in commit a90cb09).
+
+The work is a single atomic commit of five edits ([D-1](artifacts/implementation-decision-log.md#d-1-ship-all-five-edits-as-one-atomic-commit)). Shipping them together is the only sequencing constraint, because a vendored refresh between commits would copy the reference to disk (`scripts/init-guidance.sh:74`) while the curated indexes still had no scent to it.
+
+### Architecture and Integration Points
+
+The feature touches five files, all under `han-plugin-builder/skills/guidance/`:
+
+1. **New reference file — `references/per-model-authoring.md`.** Top-level `references/`, alongside `specialization-and-model-selection.md` and `iterative-plugin-development.md`, named for task scent ([D-4](artifacts/implementation-decision-log.md#d-4-top-level-references-placement-and-filename)). It follows the format precedent of those two docs (H1 title, prose, H2 sections, a Cross-References section, and a Sources section) and the `han-plugin-builder` reference-file guidance (`skill-building-guidance/skill-reference-files.md`). Its content commitments are in [D-6](artifacts/implementation-decision-log.md#d-6-the-reference-documents-own-structure-and-content-commitments); its source-citation form (external Anthropic URLs plus the named research report, no repo-relative path) is in [D-5](artifacts/implementation-decision-log.md#d-5-source-citation-form--external-urls-plus-named-report-no-fragile-repo-relative-path).
+
+2. **Plugin routing map — `SKILL.md`.** A new standalone bullet inserted after the model bullet at lines 36-37 and before the Templates bullet at line 38, so the two model-reasoning entries sit adjacent. The existing "specialization-versus-model-tier reasoning" bullet is not reworded ([D-2](artifacts/implementation-decision-log.md#d-2-add-the-routing-bullet-to-both-routing-maps-plugin-and-portable-copy)). Proposed bullet wording (label wording is a decision, so the text is inlined; the target path is not further prescribed here):
+
+   > Writing the instructions for a target model (how Sonnet 5, Opus 4.8, and Fable 5 differ in following instructions, and how that changes what you write) → `${CLAUDE_SKILL_DIR}/references/per-model-authoring.md`.
+
+3. **Portable routing map — `assets/guidance-portable-SKILL.md`.** The same bullet, inserted after the mirroring model bullet at lines 25-26 and before the Templates bullet at line 27. This is the copy `scripts/init-guidance.sh` actually vendors into other repos (`:31`, `:73`); the plugin's own `SKILL.md` is never vendored, so both maps must carry the bullet or vendored repos get the reference with no scent ([D-2](artifacts/implementation-decision-log.md#d-2-add-the-routing-bullet-to-both-routing-maps-plugin-and-portable-copy)).
+
+4. **Vendored rule index body — `assets/rule-index-body.md`.** A third bullet under the `## Plugin development` section (after the Specialization and Model Selection entry at lines 161-164), matching the `[Title](path) — what it covers + when to read it` pattern with an inline scope disambiguator against the tier doc. This curated file regenerates the vendored `.claude/rules` index; a reference not listed here is copied to disk but orphaned in that index ([D-3](artifacts/implementation-decision-log.md#d-3-add-and-task-distinguish-the-rule-index-body-entry)).
+
+5. **Reverse cross-reference — `references/specialization-and-model-selection.md`.** A link to the new doc plus a one-line scope disambiguator added to its Cross-References section (lines 85-95), so a reader entering through the higher-scent tier doc has a path onward ([D-1](artifacts/implementation-decision-log.md#d-1-ship-all-five-edits-as-one-atomic-commit); spec D10).
+
+The reference file body is auto-vendored by the wholesale `references/` copy (`scripts/init-guidance.sh:74`), so it needs no per-file wiring beyond existing in the directory; the two curated index files and the reverse link are the hand-edited surfaces.
+
+## Decomposition and Sequencing
+
+All five edits ship in one atomic commit ([D-1](artifacts/implementation-decision-log.md#d-1-ship-all-five-edits-as-one-atomic-commit)). They are listed separately for verification, not for separate delivery.
+
+| #   | Work Unit                                                             | Delivers                                                              | Depends On | Verification                                                                                 |
+| --- | -------------------------------------------------------------------- | -------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------- |
+| 1   | Author `references/per-model-authoring.md`                           | The reference with all D-6 content and the D-5 citation form         | —          | Doc states the default, its unknown-target form, the instruction split, and the refusal warning with recognition test + single-source disclosure; forward link and currency marker present |
+| 2   | Add task-distinguishing bullet to `SKILL.md`                         | Plugin routing map resolves the "write for this model" question       | 1          | Bullet sits between lines 37 and 38; points at `per-model-authoring.md`                       |
+| 3   | Add the same bullet to `assets/guidance-portable-SKILL.md`           | Vendored routing map carries the same scent                           | 1          | Bullet sits between lines 26 and 27; matches unit 2 wording                                   |
+| 4   | Add entry to `assets/rule-index-body.md` `## Plugin development`     | Vendored rule index lists the doc with a scope disambiguator          | 1          | Entry sits after the Specialization and Model Selection bullet; disambiguator present         |
+| 5   | Add reverse link to `specialization-and-model-selection.md`          | Bidirectional cross-reference; neither door orphans a reader          | 1          | Cross-References section links `per-model-authoring.md` with a one-line scope note            |
+
+## Testing Strategy
+
+No automated test harness or CI check exists for guidance reference files (discovery notes: Han runs prettier/shellcheck/whitespace hooks only, and markdown prettier is disabled). Verification is structural and is the Definition of Done checklist below.
+
+- **Observable behaviors to verify:** all five edits present in one commit; both routing maps and the rule index carry a task-distinguishing entry; the forward and reverse cross-references resolve in both directions.
+- **Optional confirmation:** run `init-guidance.sh` (or `update` mode) in a scratch checkout and confirm the regenerated `.claude/rules/plugin-building-guidance.md` lists `per-model-authoring.md` under Plugin development and that `references/per-model-authoring.md` is present in the vendored copy.
+- **Test levels:** structural review only; no unit, integration, or end-to-end layers apply to a documentation reference.
+
+## Definition of Done
+
+- [ ] `references/per-model-authoring.md` exists at top-level `references/` and states its own author-time-only scope ([D-4](artifacts/implementation-decision-log.md#d-4-top-level-references-placement-and-filename), [D-6](artifacts/implementation-decision-log.md#d-6-the-reference-documents-own-structure-and-content-commitments)).
+- [ ] The document states the model-agnostic default and its concrete unknown-target form (goal and reasons first, load-bearing constraints and scope explicit, no exhaustive micro-checklists) ([D-6](artifacts/implementation-decision-log.md#d-6-the-reference-documents-own-structure-and-content-commitments)).
+- [ ] The document states the opposite-direction instruction-style split across Opus 4.8 / Sonnet 5 and Fable 5 ([D-6](artifacts/implementation-decision-log.md#d-6-the-reference-documents-own-structure-and-content-commitments)).
+- [ ] The document carries the Fable 5 reasoning-echo refusal warning, its recognition test (reproducing internal thinking into the deliverable, distinct from a normal explanation), and its single-source disclosure ([D-6](artifacts/implementation-decision-log.md#d-6-the-reference-documents-own-structure-and-content-commitments)).
+- [ ] The document carries a visible currency marker naming the three models and the write date, and cites its source as external Anthropic URLs plus the named research report with no repo-relative path ([D-5](artifacts/implementation-decision-log.md#d-5-source-citation-form--external-urls-plus-named-report-no-fragile-repo-relative-path), [D-6](artifacts/implementation-decision-log.md#d-6-the-reference-documents-own-structure-and-content-commitments)).
+- [ ] Both `SKILL.md` and `assets/guidance-portable-SKILL.md` carry an identically worded task-distinguishing routing bullet pointing at the new doc ([D-2](artifacts/implementation-decision-log.md#d-2-add-the-routing-bullet-to-both-routing-maps-plugin-and-portable-copy)).
+- [ ] `assets/rule-index-body.md` carries a task-distinguishing entry under `## Plugin development` ([D-3](artifacts/implementation-decision-log.md#d-3-add-and-task-distinguish-the-rule-index-body-entry)).
+- [ ] `specialization-and-model-selection.md` carries the reverse cross-reference and a one-line scope disambiguator ([D-1](artifacts/implementation-decision-log.md#d-1-ship-all-five-edits-as-one-atomic-commit)).
+- [ ] All five edits land in one atomic commit ([D-1](artifacts/implementation-decision-log.md#d-1-ship-all-five-edits-as-one-atomic-commit)).
+
+## Specialist Handoffs for Implementation
+
+- **`han-communication:readability-editor`** — dispatch after the reference draft is complete and before commit; needs the drafted `per-model-authoring.md` and the routing/rule-index/reverse-link edits. The document follows the Han writing-voice profile like every other guidance reference (spec D8), and the author applies `han-plugin-builder` reference-file guidance (`skill-building-guidance/skill-reference-files.md`) while drafting.
+
+## Open Items
+
+- **OI-1:** Whether any existing Han skill or agent already uses the reasoning-echo instruction pattern the new guidance warns against.
+  - **Resolves when:** resolved at spec stage. A grep across all prose-producing plugins returned zero matches (team findings F12), so the suite will not contradict its own new guidance.
+  - **Blocks implementation:** No.
+
+## Summary
+
+- **Outcome delivered:** a new, findable, on-demand guidance reference teaching authors how the three named models differ in how you write instructions for them, wired into every navigation surface with no run-time change.
+- **Team size:** 2 specialists (plus `project-manager` coordinator) — see [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md)
+- **Rounds of facilitation:** 1 — see [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md)
+- **Decisions committed:** 6 — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Decisions settled by evidence:** 6 — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Decisions settled by junior-developer reframing:** 0 — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Decisions settled by user input:** 0 — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Rejected alternatives recorded:** 9 — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Open items remaining:** 0
+- **Recommendation:** Ship as planned.

--- a/docs/plans/per-model-authoring-guidance/feature-specification.md
+++ b/docs/plans/per-model-authoring-guidance/feature-specification.md
@@ -1,0 +1,88 @@
+# Feature Specification: Per-Model Authoring Guidance
+
+A new plugin-building guidance reference that teaches skill and agent authors how Sonnet 5, Opus 4.8, and Fable 5 differ in how they follow instructions, and how those differences should shape the instructions an author writes. It surfaces on demand through the existing guidance skill, and it commits authors to a model-agnostic default so the guidance improves how skills are written without making any skill behave differently at run time.
+
+## Outcome
+
+An author writing or hardening a skill or agent can find guidance that answers "does the model I am targeting change how I should write these instructions, and if so, how?" The guidance gives a clear default (write model-agnostic, which is the fallback for any model), names the few differences big enough to change an authoring decision, and warns about the one difference that can cause an outright failure rather than a stylistic mismatch. An author who applies it writes instructions that suit their target model, or knowingly writes to the safe default when the target is unknown ([D1](artifacts/decision-log.md#d1-a-new-authoring-guidance-reference-distinct-from-tier-selection), [D3](artifacts/decision-log.md#d3-author-time-guidance-that-reaffirms-the-model-agnostic-default)).
+
+## Actors and Triggers
+
+- **Actors** — skill authors and agent authors working in a repository that has the plugin-building guidance available, whether through the installed plugin or a vendored copy. The guidance skill is the intermediary that routes an author to the document.
+- **Triggers** — an author consults the plugin-building guidance while designing, writing, reviewing, or hardening a skill or agent, and the question of model-specific behavior is in play.
+- **Preconditions** — the plugin-building guidance is present, either through the installed `han-plugin-builder` plugin or a vendored in-repo copy.
+
+## Primary Flow
+
+1. An author consults the plugin-building guidance while working on a skill or agent.
+2. The guidance skill matches the author's need to its routing map and points to the per-model authoring reference ([D4](artifacts/decision-log.md#d4-surface-through-the-guidance-routing-map-document-only)).
+3. The author reads the reference and meets the default first: write model-agnostic instructions unless there is a specific reason to tune for a known model ([D3](artifacts/decision-log.md#d3-author-time-guidance-that-reaffirms-the-model-agnostic-default)).
+4. The author reads the instruction-style difference that most changes authoring: Opus 4.8 and Sonnet 5 follow instructions literally and want each behavior spelled out, while Fable 5 does better with a stated goal than with an enumerated checklist ([D2](artifacts/decision-log.md#d2-focus-the-content-on-the-high-impact-differences)).
+5. The author reads the one failure-causing warning: on Fable 5, an instruction telling the model to echo or transcribe its own reasoning into its visible answer can be refused, so authors avoid that instruction pattern where it matters ([D2](artifacts/decision-log.md#d2-focus-the-content-on-the-high-impact-differences)).
+6. The author reads the short supporting notes on thinking mode and on effort and subagent eagerness, kept brief because they rarely change an authoring decision on their own ([D2](artifacts/decision-log.md#d2-focus-the-content-on-the-high-impact-differences)).
+7. The author applies the guidance to the instructions they are writing, and follows the cross-reference to the tier-selection guidance when the question is which model tier to run rather than how to write for a model ([D5](artifacts/decision-log.md#d5-cross-reference-tier-selection-and-cite-the-research-as-source)).
+
+## Alternate Flows and States
+
+### The author has no known target model
+
+- **Entry condition:** the author does not know which model will run the skill or agent, which is the common case because a skill cannot reliably detect its own model at run time.
+- **Sequence:** the guidance directs the author to the model-agnostic default and treats that default as the generalized fallback for any model outside the three named ones.
+- **Exit:** the author writes to the default and reads no further per-model tuning.
+
+### The target is a model the guidance does not name
+
+- **Entry condition:** the author is targeting a model other than Sonnet 5, Opus 4.8, or Fable 5.
+- **Sequence:** the guidance states that the model-agnostic default is the fallback, and that per-model tuning applies only to the three named models.
+- **Exit:** the author writes to the default.
+
+## Edge Cases and Failure Modes
+
+| Condition | Required Behavior |
+| --------- | ----------------- |
+| An author reads the guidance as license to branch skill content on the running model | The guidance states plainly that it is author-time only, that shipped skills stay model-agnostic, and that run-time model detection is out of scope and not reliable ([D3](artifacts/decision-log.md#d3-author-time-guidance-that-reaffirms-the-model-agnostic-default)). |
+| Anthropic revises or archives a named model's prompting page after the guidance is written | The guidance carries a visible currency marker (the date it was last checked and the models it was written against) so a reader can judge whether it is still current, and names the source it was drawn from ([D6](artifacts/decision-log.md#d6-carry-a-currency-marker)). |
+| An author confuses this guidance with the tier-selection guidance | Each document states its own scope in its opening and cross-references the other, so an author lands on the right one ([D5](artifacts/decision-log.md#d5-cross-reference-tier-selection-and-cite-the-research-as-source)). |
+
+## Coordinations
+
+| Coordinating System | Direction | Interaction | Ordering / Consistency Requirement |
+| ------------------- | --------- | ----------- | ---------------------------------- |
+| The guidance skill's routing map | inbound | The routing map gains an entry that points authors to the new reference | The routing entry and the document ship together, so the map never points at a missing document ([D4](artifacts/decision-log.md#d4-surface-through-the-guidance-routing-map-document-only)) |
+| The in-repo vendored copy of the guidance | outbound | Repositories that vendor the guidance pick up the new reference the next time they install or refresh it | The document lives with the other guidance references so it is carried along by the existing install and refresh, with no separate wiring ([D4](artifacts/decision-log.md#d4-surface-through-the-guidance-routing-map-document-only)) |
+
+## Out of Scope
+
+- Run-time model detection or branching of any kind, and per-model skill or agent variants. The research found no reliable way for a skill to learn its own model at run time, and this feature does not attempt one.
+- Editing the content of existing skills or agents to tune them per model.
+- The opt-in per-model note for the `readability-guidance` skill. That is a separate item from the research and is planned on its own.
+- Prompting the author for a target model inside the skill-builder or agent-builder interviews. Authors reach this guidance the same way they reach every other guidance document ([D4](artifacts/decision-log.md#d4-surface-through-the-guidance-routing-map-document-only)). See Deferred (YAGNI).
+- Changing how the `model` frontmatter field or model tiers are chosen. That is the tier-selection guidance's job, and this document cross-references it rather than restating it.
+
+## Deferred (YAGNI)
+
+### Prompting for a target model inside the skill-builder and agent-builder interviews
+
+- **Why deferred:** no evidence yet that authors ship model-mismatched instructions often enough to justify adding an interview decision to two more skills. The simpler version, a guidance document surfaced on demand, satisfies the stated need (an author can find and apply per-model guidance).
+- **Reopen when:** authors are observed repeatedly shipping instructions that fight their target model, or a decision is made to make the builders model-aware for another reason.
+- **Source:** user choice during the interview (scope-boundary question).
+
+### Comprehensive per-model sections mirroring Anthropic's full pages
+
+- **Why deferred:** the lighter axes (verbosity defaults, design and frontend defaults, tokenizer notes) were not shown to change an authoring decision, and mirroring them enlarges the surface to keep current against pages that get revised and archived.
+- **Reopen when:** a documented divergence on one of those lighter axes starts causing real authoring mistakes.
+- **Source:** user choice during the interview (content-depth question).
+
+## Open Items
+
+- None at draft time. The review team populates this section if it surfaces anything.
+
+## Summary
+
+- **Outcome delivered:** authors get a short, on-demand guidance reference on how the three named models differ in how you should write instructions for them, anchored to a model-agnostic default.
+- **Primary actors:** skill authors and agent authors, routed by the plugin-building guidance skill.
+- **Decisions settled by evidence:** 4 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Decisions settled by user input:** 2 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Sub-agents consulted:** pending review — see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Key adjustments from review:** pending review — see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Remaining open items:** 0

--- a/docs/plans/per-model-authoring-guidance/feature-specification.md
+++ b/docs/plans/per-model-authoring-guidance/feature-specification.md
@@ -6,6 +6,8 @@ A new plugin-building guidance reference that teaches skill and agent authors ho
 
 An author writing or hardening a skill or agent can find guidance that answers "does the model I am targeting change how I should write these instructions, and if so, how?" The guidance gives a clear default (write model-agnostic, which is the fallback for any model), names the few differences big enough to change an authoring decision, and warns about the one difference that can cause an outright failure rather than a stylistic mismatch. An author who applies it writes instructions that suit their target model, or knowingly writes to the safe default when the target is unknown ([D1](artifacts/decision-log.md#d1-a-new-authoring-guidance-reference-distinct-from-tier-selection), [D3](artifacts/decision-log.md#d3-author-time-guidance-that-reaffirms-the-model-agnostic-default)).
 
+The work is done when the reference exists and states the model-agnostic default and its concrete unknown-target form, the opposite-direction instruction-style difference, and the Fable 5 refusal warning with its recognition test; the guidance routing map resolves an author's "how do I write for this model" question to it; and the tier-selection doc carries the reverse cross-reference so neither door orphans a reader.
+
 ## Actors and Triggers
 
 - **Actors** — skill authors and agent authors working in a repository that has the plugin-building guidance available, whether through the installed plugin or a vendored copy. The guidance skill is the intermediary that routes an author to the document.
@@ -15,19 +17,19 @@ An author writing or hardening a skill or agent can find guidance that answers "
 ## Primary Flow
 
 1. An author consults the plugin-building guidance while working on a skill or agent.
-2. The guidance skill matches the author's need to its routing map and points to the per-model authoring reference ([D4](artifacts/decision-log.md#d4-surface-through-the-guidance-routing-map-document-only)).
-3. The author reads the reference and meets the default first: write model-agnostic instructions unless there is a specific reason to tune for a known model ([D3](artifacts/decision-log.md#d3-author-time-guidance-that-reaffirms-the-model-agnostic-default)).
+2. The guidance skill routes the author's question "how should I write instructions for this model" to the per-model authoring reference through a routing-map entry worded to distinguish that task from "which model tier to run" ([D4](artifacts/decision-log.md#d4-surface-through-the-guidance-routing-map-document-only), [D9](artifacts/decision-log.md#d9-give-the-routing-entry-its-own-bullet-with-task-distinguishing-scent)).
+3. The author reads the reference and meets the default first: write model-agnostic instructions unless there is a specific reason to tune for a known model. The document states what that default concretely means when the target is unknown, which is the common case: lead with the goal and the reasons behind it, state the load-bearing constraints and scope explicitly, and avoid exhaustive step-by-step micro-checklists ([D3](artifacts/decision-log.md#d3-author-time-guidance-that-reaffirms-the-model-agnostic-default), [D11](artifacts/decision-log.md#d11-the-concrete-unknown-target-default)).
 4. The author reads the instruction-style difference that most changes authoring: Opus 4.8 and Sonnet 5 follow instructions literally and want each behavior spelled out, while Fable 5 does better with a stated goal than with an enumerated checklist ([D2](artifacts/decision-log.md#d2-focus-the-content-on-the-high-impact-differences)).
-5. The author reads the one failure-causing warning: on Fable 5, an instruction telling the model to echo or transcribe its own reasoning into its visible answer can be refused, so authors avoid that instruction pattern where it matters ([D2](artifacts/decision-log.md#d2-focus-the-content-on-the-high-impact-differences)).
-6. The author reads the short supporting notes on thinking mode and on effort and subagent eagerness, kept brief because they rarely change an authoring decision on their own ([D2](artifacts/decision-log.md#d2-focus-the-content-on-the-high-impact-differences)).
+5. The author reads the one failure-causing warning: on Fable 5, an instruction telling the model to reproduce or transcribe its own internal thinking into its visible deliverable can be refused. The warning carries a recognition test that separates this pattern from asking for a normally-written explanation of a decision, so the author can tell when it applies ([D2](artifacts/decision-log.md#d2-focus-the-content-on-the-high-impact-differences), [D12](artifacts/decision-log.md#d12-a-concrete-test-for-the-refusal-pattern)).
+6. The author reads the short supporting notes, each tied to the authoring choice it changes: the thinking-mode note says not to write "think step by step" or thinking-toggle instructions for a model whose thinking is always on, and the effort note says to rely on the effort setting rather than "think harder" prompt hacks ([D2](artifacts/decision-log.md#d2-focus-the-content-on-the-high-impact-differences)).
 7. The author applies the guidance to the instructions they are writing, and follows the cross-reference to the tier-selection guidance when the question is which model tier to run rather than how to write for a model ([D5](artifacts/decision-log.md#d5-cross-reference-tier-selection-and-cite-the-research-as-source)).
 
 ## Alternate Flows and States
 
 ### The author has no known target model
 
-- **Entry condition:** the author does not know which model will run the skill or agent, which is the common case because a skill cannot reliably detect its own model at run time.
-- **Sequence:** the guidance directs the author to the model-agnostic default and treats that default as the generalized fallback for any model outside the three named ones.
+- **Entry condition:** the author does not know which model will run the skill or agent. This is the common case because the operator chooses the model when they run it, and can switch it mid-session, so the author cannot count on a specific target at writing time ([D11](artifacts/decision-log.md#d11-the-concrete-unknown-target-default)).
+- **Sequence:** the guidance directs the author to the concrete model-agnostic default (lead with the goal and reasons, state load-bearing constraints and scope explicitly, avoid exhaustive micro-checklists) and treats that default as the generalized fallback for any model outside the three named ones.
 - **Exit:** the author writes to the default and reads no further per-model tuning.
 
 ### The target is a model the guidance does not name
@@ -41,21 +43,22 @@ An author writing or hardening a skill or agent can find guidance that answers "
 | Condition | Required Behavior |
 | --------- | ----------------- |
 | An author reads the guidance as license to branch skill content on the running model | The guidance states plainly that it is author-time only, that shipped skills stay model-agnostic, and that run-time model detection is out of scope and not reliable ([D3](artifacts/decision-log.md#d3-author-time-guidance-that-reaffirms-the-model-agnostic-default)). |
-| Anthropic revises or archives a named model's prompting page after the guidance is written | The guidance carries a visible currency marker (the date it was last checked and the models it was written against) so a reader can judge whether it is still current, and names the source it was drawn from ([D6](artifacts/decision-log.md#d6-carry-a-currency-marker)). |
-| An author confuses this guidance with the tier-selection guidance | Each document states its own scope in its opening and cross-references the other, so an author lands on the right one ([D5](artifacts/decision-log.md#d5-cross-reference-tier-selection-and-cite-the-research-as-source)). |
+| Anthropic revises or archives a named model's prompting page after the guidance is written | The guidance carries a visible currency marker (when it was written and the model versions it was written against) so a reader can judge whether it is still current, names the source it was drawn from so a reader knows what to re-verify against, and discloses that the Fable 5 refusal warning rests on single-vendor, single-source evidence ([D6](artifacts/decision-log.md#d6-carry-a-currency-marker)). |
+| An author confuses this guidance with the tier-selection guidance | Each document states its own scope in its opening and cross-references the other in both directions, so an author who lands on either one is pointed to the right one ([D5](artifacts/decision-log.md#d5-cross-reference-tier-selection-and-cite-the-research-as-source), [D10](artifacts/decision-log.md#d10-the-tier-selection-doc-is-a-coordinating-artifact)). |
 
 ## Coordinations
 
 | Coordinating System | Direction | Interaction | Ordering / Consistency Requirement |
 | ------------------- | --------- | ----------- | ---------------------------------- |
-| The guidance skill's routing map | inbound | The routing map gains an entry that points authors to the new reference | The routing entry and the document ship together, so the map never points at a missing document ([D4](artifacts/decision-log.md#d4-surface-through-the-guidance-routing-map-document-only)) |
-| The in-repo vendored copy of the guidance | outbound | Repositories that vendor the guidance pick up the new reference the next time they install or refresh it | The document lives with the other guidance references so it is carried along by the existing install and refresh, with no separate wiring ([D4](artifacts/decision-log.md#d4-surface-through-the-guidance-routing-map-document-only)) |
+| The guidance skill's routing map | inbound | The routing map gains its own entry that routes the "how do I write for this model" author question to the new reference, worded to distinguish it from the tier question | The routing entry and the document ship together, so the map never points at a missing document ([D4](artifacts/decision-log.md#d4-surface-through-the-guidance-routing-map-document-only), [D9](artifacts/decision-log.md#d9-give-the-routing-entry-its-own-bullet-with-task-distinguishing-scent)) |
+| The tier-selection guidance | inbound | It gains a reverse cross-reference to the new document and a one-line scope disambiguator | It ships in lockstep with the new document so a reader who enters through the tier doc has a path onward and neither door orphans a reader ([D10](artifacts/decision-log.md#d10-the-tier-selection-doc-is-a-coordinating-artifact)) |
+| Repositories that vendor the guidance | outbound | They receive the new reference through the normal refresh of the vendored guidance | The new reference is a guidance reference like the others, so the existing refresh carries it; a repo's routing entry never points at a document it did not receive ([D4](artifacts/decision-log.md#d4-surface-through-the-guidance-routing-map-document-only)) |
 
 ## Out of Scope
 
 - Run-time model detection or branching of any kind, and per-model skill or agent variants. The research found no reliable way for a skill to learn its own model at run time, and this feature does not attempt one.
 - Editing the content of existing skills or agents to tune them per model.
-- The opt-in per-model note for the `readability-guidance` skill. That is a separate item from the research and is planned on its own.
+- The opt-in per-model note for the `readability-guidance` skill. The research lists it as a separate item (its item 3), and this planning was scoped to the author-guidance item only, so it is not planned yet and is tracked out of scope here rather than dropped.
 - Prompting the author for a target model inside the skill-builder or agent-builder interviews. Authors reach this guidance the same way they reach every other guidance document ([D4](artifacts/decision-log.md#d4-surface-through-the-guidance-routing-map-document-only)). See Deferred (YAGNI).
 - Changing how the `model` frontmatter field or model tiers are chosen. That is the tier-selection guidance's job, and this document cross-references it rather than restating it.
 
@@ -75,14 +78,16 @@ An author writing or hardening a skill or agent can find guidance that answers "
 
 ## Open Items
 
-- None at draft time. The review team populates this section if it surfaces anything.
+- **OI-1:** Whether any existing Han skill or agent already uses the reasoning-echo instruction pattern the new guidance warns against. Checked during review across all prose-producing plugins and found zero matches, so the suite will not contradict its own new guidance.
+  - **Resolves when:** resolved. A grep across the plugins returned no hits ([F12](artifacts/team-findings.md)).
+  - **Blocks implementation:** No.
 
 ## Summary
 
-- **Outcome delivered:** authors get a short, on-demand guidance reference on how the three named models differ in how you should write instructions for them, anchored to a model-agnostic default.
+- **Outcome delivered:** authors get a short, on-demand guidance reference on how the three named models differ in how you should write instructions for them, anchored to a concrete model-agnostic default.
 - **Primary actors:** skill authors and agent authors, routed by the plugin-building guidance skill.
-- **Decisions settled by evidence:** 4 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Decisions settled by evidence:** 10 — see [artifacts/decision-log.md](artifacts/decision-log.md)
 - **Decisions settled by user input:** 2 — see [artifacts/decision-log.md](artifacts/decision-log.md)
-- **Sub-agents consulted:** pending review — see [artifacts/team-findings.md](artifacts/team-findings.md)
-- **Key adjustments from review:** pending review — see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Sub-agents consulted:** `han-core:junior-developer`, `han-core:information-architect` — see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Key adjustments from review:** committed the routing-map entry to task-distinguishing wording, tracked the tier doc's reverse cross-reference as a ship-together coordination, defined the concrete unknown-target default, and added a recognition test and single-source disclosure to the refusal warning — see [artifacts/team-findings.md](artifacts/team-findings.md)
 - **Remaining open items:** 0

--- a/docs/research/model-specific-guidance-for-skills.md
+++ b/docs/research/model-specific-guidance-for-skills.md
@@ -1,0 +1,263 @@
+# Research: Should Han skills carry model-specific guidance for Sonnet 5, Opus 4.8, and Fable 5?
+
+**The recommendation is to keep Han's shipped skills model-agnostic, exactly as they are today, and add per-model guidance for skill authors in the plugin-building layer instead.** The models genuinely differ, but a skill cannot reliably detect which one is running it, so the right place to act on the differences is when an author writes a skill, not when the skill runs.
+
+The open-ended question this report answers: should Han's authoring skills carry model-specific instructions that change with the model running them (Sonnet 5, Opus 4.8, Fable 5, or a generalized fallback), and is per-model tailoring feasible and worth the cost?
+
+Evidence mode: **strict** (default; no opt-out was requested).
+
+## Summary
+
+The differences between these models are real and documented, but the right place to act on them is when an author writes a skill, not when the skill runs. Anthropic publishes a separate prompting page for each of the three models, and the guidance genuinely diverges. Opus 4.8 and Sonnet 5 follow instructions literally and want every behavior spelled out. Fable 5 wants goals instead of step-by-step checklists, and can even refuse a request that tells it to echo its own reasoning into its answer. So yes, there is enough difference to matter.
+
+The problem is that a skill cannot reliably find out which model is running it. Claude Code does not hand the active model to a skill through any documented, stable channel, and asking a model to name itself is unreliable. Building skills that branch on the current model would rest on a foundation that is not there. It would also double or triple the number of files to maintain, and would break when the suite runs on a non-Claude host.
+
+That recommendation keeps the shipped skills model-agnostic exactly as they are today, which is already the "generalized fallback," and adds per-model guidance for skill authors in the plugin-building layer instead. The one skill with a documented, model-sensitive risk today (`readability-guidance`) is the first concrete candidate for an opt-in per-model note. The core of this recommendation is strongly supported; the case for how much the models differ leans on Anthropic's own documentation more than on independent testing.
+
+- **Confidence:** Medium
+
+## Research Results
+
+**Anthropic documents genuine, sometimes opposite, prompting differences across the three models.** Each model has its own prompting page (A1, A2, A3) on top of a shared page of techniques that apply to every current model (A4). The differences are not cosmetic. The sharpest ones a skill author would care about:
+
+- **Thinking mode differs by model.** Opus 4.8 has thinking off unless you turn it on; Sonnet 5 has it on by default; Fable 5 always has it on and cannot turn it off (A1, A2, A3, A4, A5 all agree).
+- **Instruction-following runs in opposite directions.** Opus 4.8 and Sonnet 5 read instructions literally and do not generalize on their own, so they need explicit scope (A1, A2). Fable 5's own page says the opposite is now the risk. Spelling out every step with a checklist degrades its output; a short, goal-based instruction works better (A3, corroborated independently by A8). A skill written to one model's guidance points the other in the wrong direction.
+- **Fable 5 can refuse a "show your reasoning" instruction.** Fable 5 carries safety classifiers that can return a refusal for a prompt telling the model to echo or transcribe its own thinking into the visible response (A3) [single-source]. This is the one difference that could cause a functional failure rather than a style mismatch, because "explain your reasoning in the output" is a common instruction pattern in agentic skills.
+- **Effort and subagent eagerness differ in degree.** The `effort` knob exists on all three but the same label does not mean the same thing across them, and the three models reach for subagents with different eagerness (A1, A2, A3).
+
+Guidance is not sparse for any of the three named models; each page runs to several detailed sections (A1, A2, A3). The honest gap is the generalized fallback. Anthropic publishes nothing specific for an unnamed or future model beyond the shared "techniques for all current models" section (A4). That section is the best available baseline, but by definition it cannot reflect a specific new model's defaults.
+
+**A skill cannot reliably learn which model is running it.** This is the finding that decides the question. Claude Code exposes no `$CLAUDE_MODEL` environment variable (A10). A skill's `model` frontmatter field sets the model for the turn; it does not report the current one (A11, confirmed in-repo by A28). No skill string-substitution carries model identity the way session id and effort do (A11). The one place Claude Code surfaces a live model id is the statusline feed, which is a one-way channel to the terminal with no path back into the model's context (A12). The active model is not even a stable fact for a session, because `/model` can switch it mid-session (A13).
+
+There is one narrow, deterministic path: a `SessionStart` hook can read an optional `model` field and inject it into context (A15). It comes with three limits, all sourced. The field is not guaranteed present (A10). It goes stale the moment the user switches models (A13). And hooks are a Claude Code extension outside the portable Agent Skills standard, so this path does not carry to Codex or other runtimes (A11, A14).
+
+There is also a channel this research initially missed, which the validation pass surfaced (V1): Claude Code's own system prompt states the model's name in context. That makes reading the current model more reliable on Claude Code than the blind self-identification the research literature measures, because the model is reading an asserted string rather than guessing. It is still the wrong foundation for shipped skills. It is undocumented as a stable contract, harness-specific, and absent on other hosts, which is the same class of weakness as the `SessionStart` field.
+
+**Asking a model to name itself is unreliable.** Two independent studies converge. About 26% of 27 tested models misidentified themselves when asked directly (A16). Only 4 of 10 models could recognize their own output, near chance (A17). These measure blind self-identification, not branching when the model's name is already asserted in context (V1), so they bound the weakest form of self-report rather than every form. Even so, any mechanism that depends on the model correctly reporting itself is standing on a documented failure mode.
+
+**Full per-model skills would be a large, drift-prone maintenance surface that also breaks portability.** Han has 48 skill files and roughly 100 reference files across ten plugins (A27; the exact reference count is 103 to 107 depending on what you include, per V7). Duplicating skills per model multiplies that surface, and keeping variants in sync is the classic place drift creeps in.
+
+Portability is a harder constraint. Prior research on issue #78 (A23) found that Claude Code and Codex have separate model namespaces, and that Claude model names break on Codex. The fix was to remove skill-level model overrides rather than translate them. Codex does not even register Han's agents (A24), and Han's current skills carry no model field at all; they reference everything model-neutrally (A19, A20, A22). Nothing in the plugin-building guidance addresses model-conditional skills today (A25, A26).
+
+**A model-sensitivity risk already exists in the suite.** The project's own spike testing of the foundational `readability-guidance` skill flagged that its results came from Opus 4.8 subagents and might not hold on smaller or faster models (A29). This is not a hypothetical: it is a concrete, already-recorded case where a skill's behavior may depend on the model, which is exactly what an opt-in per-model note is for.
+
+## Options to Consider
+
+### O1: Keep skills model-agnostic (the current state, which is also the fallback)
+
+- **What it is:** Change nothing in how skills are written. Every skill stays one model-neutral definition, authored against Anthropic's shared cross-model techniques (A4). This state already serves as the generalized fallback for any model.
+- **Trade-offs:** Simplest to author and maintain, fully portable across Claude Code and Codex (A19, A20, A22, A23, A24), and immune to the self-identification failure mode because it never asks (A16, A17). It forgoes any model-tailored guidance, including the Fable 5 refusal-trap warning (A3), which a purely generic instruction set has no way to surface to an author.
+- **Rests on:** (A4, A19, A20, A22, A23, A24); avoided failure mode (A16, A17).
+- **Evidence status:** corroborated (codebase + web).
+
+### O2: Runtime model-conditional skills (branch on the active model)
+
+- **What it is:** Make skills adapt at runtime through inline "if running on model X" sections, per-model reference files the skill chooses among, separate per-model skill variants, or a `SessionStart` hook that injects the model name (A15).
+- **Trade-offs:** Every shape except the hook needs the skill to know the current model, and no reliable, documented way to know it exists (A10, A11, A12, A13, A18). The shapes that skip the hook fall back to self-report, which fails often (A16, A17). The hook path is the only one on a real signal, but it is not guaranteed present, goes stale on a model switch, and breaks on non-Claude hosts (A10, A13, A11, A14). All variant shapes multiply the maintenance surface (A27) and invite drift, and Anthropic's own skills ship no such pattern (A18).
+- **Rests on:** (A10, A11, A12, A13, A14, A15, A16, A17, A18, A27).
+- **Evidence status:** corroborated (web + codebase).
+
+### O3: Author-time model guidance, model-agnostic runtime
+
+- **What it is:** Keep shipped skills model-agnostic (O1) as the runtime default and fallback. Add per-model guidance to the plugin-building layer (`han-plugin-builder`) that tells a skill author how each model's documented behavior should shape the instructions they write. Flag the Fable 5 reasoning-echo refusal trap so authors avoid the "show your reasoning in the output" pattern where it matters (A3). Allow a skill to opt into a per-model reference note only where a documented functional divergence justifies it; `readability-guidance` is the first concrete candidate, given its recorded model-sensitivity flag (A29).
+- **Trade-offs:** Captures the real, high-impact differences (A1, A2, A3) at the one point where the model is known: the author chooses the target when they write. It adds no runtime detection, no portability risk, and no per-skill duplication, because the guidance lives in the authoring layer that already exists (A25, A26). Its cost is upkeep of one guidance document against Anthropic's release cadence, since the model pages are pinned snapshots that get revised and archived (A5). It does not make a single skill behave differently per model on its own; it improves how skills are written.
+- **Rests on:** (A1, A2, A3, A4, A5, A25, A26, A29); model-agnostic default inherits O1's basis.
+- **Evidence status:** corroborated (web + codebase), with the per-model behavioral characterization leaning on single-vendor documentation (see Validation V5).
+
+### O4: Force a known-good model per step (control, not detection)
+
+- **What it is:** Use the skill `model` frontmatter as a control (A11, A28) to force a specific model for a step that a weaker model handles badly. This sidesteps detection, because the skill sets the model rather than reading it.
+- **Trade-offs:** Available today and needs no detection. But it sends a Claude-specific model name across the host boundary, which is the exact failure issue #78 removed from the planning skills (A23). The plugin-building guidance already tells skills not to override the model at dispatch (A22). It also overrides the user's chosen session model, which contradicts the `inherit` default the suite settled on.
+- **Rests on:** (A11, A22, A23, A28).
+- **Evidence status:** corroborated (codebase).
+
+## Recommendation
+
+- **Recommendation:** Adopt **O3**. Keep the shipped skills model-agnostic (the O1 state) as the runtime default and the generalized fallback. Add per-model guidance for skill authors in `han-plugin-builder`, starting with the Fable 5 reasoning-echo refusal warning and an opt-in per-model note for `readability-guidance`. Reject **O2** as the suite default. Record the `SessionStart` hook (A15) as the only sound runtime-detection path, reserved for a future Claude-Code-only skill that proves a hard need. Reject **O4** as a general pattern for the same portability reason issue #78 already settled.
+- **Evidence basis:** The load-bearing half of this recommendation, that runtime branching is the wrong default, rests on corroborated evidence. Claude Code exposes no reliable model signal to a skill (A10, A11, A12, A13, confirmed in-repo by A28). Self-report is unreliable (A16, A17, two independent studies). And runtime variants break portability and multiply maintenance (A23, A24, A27). A sensitivity check (V8) found this conclusion holds even if any single one of those artifacts is discounted. The other half, that the models differ enough to be worth author-time guidance, rests mainly on Anthropic's own prompting pages (A1, A2, A3). That evidence is corroborated for the goals-versus-checklist difference by one independent source (A8), but is otherwise single-vendor; the Fable 5 refusal category is single-source (A3) [single-source]. That is why the improvement is scoped to author guidance rather than automated behavior, and why overall confidence is Medium rather than High.
+
+## Validation
+
+### V1: The research missed the system-prompt model-identity channel
+
+- **Strategy:** Challenge the Evidence
+- **Investigation:** The validator observed that Claude Code's system prompt states the running model's name in context, a channel the mechanism angle never considered.
+- **Result:** Partially Refuted (the "only path is the SessionStart hook" claim was overstated).
+- **Impact:** The Research Results now name this channel and reject it on the same grounds as the hook: undocumented as a stable contract, harness-specific, and absent on other hosts. It does not change the recommendation, and it narrows how far the self-identification studies (A16, A17) can be stretched.
+
+### V2: The agent model-tier count was wrong
+
+- **Strategy:** Challenge the Evidence-Gathering Integrity
+- **Investigation:** Direct enumeration of every agent file's `model:` field.
+- **Result:** Refuted. The correct distribution is 10 opus, 10 sonnet, 3 haiku across the 23 han-core agents, not the "9 / ~13 / 3" the codebase angle first reported. This matches the count in the prior issue-78 research (A21, A23).
+- **Impact:** Corrected in A21. It does not bear on the options, but it prompted a recount of the file-surface claim (V7).
+
+### V3: `readability-guidance` is a concrete per-model candidate, not a hypothetical one
+
+- **Strategy:** Challenge the Options Framing
+- **Investigation:** The validator found the project's own spike report flagging that `readability-guidance` was tested only on Opus 4.8 and might behave differently on smaller or faster models (A29).
+- **Result:** Confirmed.
+- **Impact:** O3's scope was rewritten to name `readability-guidance` as the first opt-in candidate, so the option no longer reads as purely speculative future work.
+
+### V4: The core mechanism claims are independently confirmed in-repo
+
+- **Strategy:** Challenge the Recommendation
+- **Investigation:** The validator read `skill-frontmatter-fields.md` (A28) and grepped every SKILL.md for a `model:` line and for the old "run on sonnet" planning-skill language.
+- **Result:** Confirmed. The skill `model` field is documented in-repo as a setter, no SKILL.md carries a model field, and the issue-78 fix has landed.
+- **Impact:** Strengthens the recommendation's central pillar with a source independent of the cited web docs.
+
+### V5: The behavioral-divergence case is largely single-vendor
+
+- **Strategy:** Challenge the Evidence-Gathering Integrity
+- **Investigation:** The validator traced the per-model behavioral claims to their origins.
+- **Result:** Partially Refuted as a fabrication risk (Fable 5 and Opus 4.8 appear in this repo's records predating this research). But it is confirmed as a single-source concern: the behavioral claims trace to Anthropic's own docs. A7 amplifies rather than independently confirms them, and A8 is the one loosely independent corroboration.
+- **Impact:** The recommendation scopes the model-difference case to author guidance rather than automated behavior, and confidence is held at Medium for this reason.
+
+### V6: The options set missed the "force a model" mechanism
+
+- **Strategy:** Challenge the Options Framing
+- **Investigation:** The validator noted a skill could force a known-good model with the `model` frontmatter control rather than detect the active one.
+- **Result:** Confirmed as a gap in the option set.
+- **Impact:** Added as O4 and rejected on the issue-78 portability grounds (A22, A23).
+
+### V7: The file-count framing was imprecise
+
+- **Strategy:** Challenge the Evidence-Gathering Integrity
+- **Investigation:** Direct counts of reference files across the ten plugins.
+- **Result:** Partially Refuted. The real reference-file count is 103 to 107 depending on inclusion rules, not exactly 99, and much of `han-plugin-builder`'s 41 files are authoring guidance that would not need per-model duplication.
+- **Impact:** The maintenance-burden claim is softened accordingly (A27). The burden is still real and large; the precise multiplier was dropped.
+
+### V8: Sensitivity test on the reject-O2 conclusion
+
+- **Strategy:** Challenge the Recommendation
+- **Investigation:** The validator discounted each load-bearing artifact in turn and re-ran the reject-O2 logic.
+- **Result:** Confirmed. The conclusion survives discounting any single one of A15, A16/A17, A23/A24, or A27, because it is over-determined by independent in-repo facts (V4).
+- **Impact:** Raises confidence in the core call. It also exposed one condition the recommendation should watch, folded in below.
+
+### Adjustments Made
+
+- Corrected the agent tier count to 10 opus / 10 sonnet / 3 haiku (V2, A21).
+- Named and rejected the system-prompt model-identity channel rather than implying the hook is the only path (V1).
+- Rewrote O3's scope to name `readability-guidance` as the first concrete opt-in candidate (V3, A29).
+- Added O4 (force a model) and rejected it (V6).
+- Softened the file-count and maintenance framing (V7, A27).
+- Added a revisit condition to the confidence assessment: if a future release makes the active model a documented, stable context field, O2 becomes newly feasible and this recommendation should be revisited (V8).
+
+### Confidence Assessment
+
+- **Confidence:** Medium
+- **Remaining Risks:** The reject-O2 half of the recommendation is high-confidence and over-determined (V4, V8). The model-difference half rests mainly on single-vendor documentation (A1, A2, A3), with the Fable 5 refusal category carried single-source (A3, V5). If that page is revised or was mischaracterized, the specifics of the author guidance would need updating, though not the structural recommendation. The model pages are pinned snapshots that Anthropic revises and archives (A5), so O3's guidance document carries ongoing upkeep. The recommendation should be revisited if the active model ever becomes a documented, stable context field a skill can read (V8).
+
+## Sources
+
+| ID  | Source | Link / location | Retrieved | Trust class | Summary (one line) | Evidence status |
+| --- | --- | --- | --- | --- | --- | --- |
+| A1  | Prompting Claude Opus 4.8 | https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-4-8 | 2026-07-20 | web | Opus 4.8 reads prompts literally, needs explicit scope, favors reasoning over tool calls | corroborated in part by A7 |
+| A2  | Prompting Claude Sonnet 5 | https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-sonnet-5 | 2026-07-20 | web | Sonnet 5 has thinking on by default, more agentic than 4.6, literal instruction following | single source (caveated) |
+| A3  | Prompting Claude Fable 5 | https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5 | 2026-07-20 | web | Fable 5 wants goals not checklists; can refuse "echo your reasoning" prompts | corroborated by A8 on goals-vs-checklists; single source on refusal category |
+| A4  | Claude prompting best practices | https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices | 2026-07-20 | web | Shared cross-model techniques; confirms the three-way thinking-mode split | corroborated by A1, A2, A3 |
+| A5  | Models overview table | https://platform.claude.com/docs/en/about-claude/models/overview | 2026-07-20 | web | Spec table; model IDs are pinned snapshots; legacy models archived at each release | corroborated by A1, A2, A3 |
+| A6  | Fable 5 / Mythos 5 announcement | https://www.anthropic.com/news/claude-fable-5-mythos-5 | 2026-07-20 | web | Fable 5 and Mythos 5 share one model; Mythos 5 limited availability | corroborated by A3, A5 (via search summary, precision caveat) |
+| A7  | GitHub discussion: tuning for Opus 4.8 | https://github.com/danielmiessler/LifeOS/discussions/1312 | 2026-07-20 | web | Restates A1 near-verbatim | amplifies A1, not independent |
+| A8  | Ken Huang: how to stop prompting Fable 5 like Opus | https://kenhuangus.substack.com/p/claude-fable-5-what-changed-and-how | 2026-07-20 | web | Independent-ish: checklists hurt Fable 5, give the reason instead | corroborates A3 |
+| A9  | Simon Willison: initial impressions of Fable 5 | https://simonwillison.net/2026/Jun/9/claude-fable-5/ | 2026-07-20 | web | Fable 5 beats Opus 4.8 on recall; does not discuss prompting technique | single source (tangential) |
+| A10 | Claude Code Hooks reference | https://code.claude.com/docs/en/hooks | 2026-07-20 | web | No $CLAUDE_MODEL env var; only SessionStart gets an optional model field | corroborated by A11, A12 |
+| A11 | Claude Code Skills reference | https://code.claude.com/docs/en/skills | 2026-07-20 | web | Skill model frontmatter sets the model; no read/conditional-load mechanism | corroborated by A10, A28 |
+| A12 | Claude Code Statusline reference | https://code.claude.com/docs/en/statusline | 2026-07-20 | web | Statusline gets model.id but it is a one-way UI sink | single source (caveated) |
+| A13 | Claude Code Model config reference | https://code.claude.com/docs/en/model-config | 2026-07-20 | web | /model can switch the active model mid-session | corroborated by A10 |
+| A14 | Agent Skills open-standard commentary | https://codex.danielvaughan.com/2026/05/05/agent-skills-open-standard-portable-skills-codex-cli-cross-agent/ | 2026-07-20 | web | Hooks and model selection are Claude Code extensions outside the portable spec | corroborated by A11 |
+| A15 | SessionStart additionalContext injection | https://github.com/anthropics/claude-code/issues/16538 | 2026-07-20 | web | A SessionStart hook can inject model identity into context | corroborated by A10, A13 |
+| A16 | LLM identity confusion study | https://arxiv.org/abs/2411.10683 | 2026-07-20 | web | ~26% of 27 LLMs misidentify themselves when asked directly | corroborated by A17 |
+| A17 | AI self-recognition study | https://arxiv.org/html/2510.03399 | 2026-07-20 | web | Only 4/10 models self-recognize their output, near chance | corroborated by A16 |
+| A18 | anthropics/skills official repo | https://github.com/anthropics/skills | 2026-07-20 | web | Negative: no model-conditional pattern in Anthropic's own skills | single source (authoritative negative) |
+| A19 | No model field in SKILL.md files | han-core/skills/*/SKILL.md and 47 others | n/a | codebase | None of 48 skills carry a model field; skills are model-neutral process instructions | corroborated by A28 |
+| A20 | Model-neutral reference mechanism | han-core/skills/research/SKILL.md:68 | n/a | codebase | Cross-plugin and local references are name-only, no model qualifier | single source (codebase anchor) |
+| A21 | Agent model-tier distribution | han-core/agents/*.md | n/a | codebase | 10 opus / 10 sonnet / 3 haiku across 23 han-core agents; 1 sonnet in han-communication | corroborated by A23 |
+| A22 | No model override at skill dispatch | han-plugin-builder/skills/guidance/references/agent-building-guidelines/agent-model-selection.md:49 | n/a | codebase | Skills pass no model override; "always set model" scoped to agent files only | corroborated by A23 |
+| A23 | Issue #78 model-specifier research | docs/research/issue-78-model-specifier-portability.md | n/a | codebase | Claude model names break on Codex; fix removed skill-level overrides | corroborated (codebase + provided + web in the source) |
+| A24 | Codex plugin manifest is skills-only | han-core/.codex-plugin/plugin.json:13 | n/a | codebase | Codex manifest exposes only skills capability; no agents path | single source (codebase anchor) |
+| A25 | Plugin-builder guidance has no model-conditional language | han-plugin-builder/skills/guidance/references/agent-building-guidelines/agent-model-selection.md | n/a | codebase | Guidance covers per-agent model choice, not per-model skill variants | corroborated by A26 |
+| A26 | Specialization-and-model-selection rationale | han-plugin-builder/skills/guidance/references/specialization-and-model-selection.md | n/a | codebase | Assumes one skill definition; no model-conditional variant concept | corroborated by A25 |
+| A27 | Maintenance surface counts | repo-wide (find over skills and references) | n/a | codebase | 48 SKILL.md and ~103 to 107 reference files across 10 plugins | corrected by V7 |
+| A28 | Skill frontmatter fields reference | han-plugin-builder/skills/guidance/references/skill-building-guidance/skill-frontmatter-fields.md:45 | n/a | codebase | Confirms the skill model field overrides for the turn only, a setter not a reader | corroborates A11 |
+| A29 | Readability-guidance spike model-sensitivity flag | docs/plans/han-communication-plugin/artifacts/oi-3-spike/OI-3-spike-report.md:59 | n/a | codebase | Spike tested only Opus 4.8 subagents; flagged possible different behavior on smaller/faster models | single source (codebase anchor) |
+
+### A1: Prompting Claude Opus 4.8 (recommendation-bearing)
+
+- **Link / location:** https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-4-8
+- **Retrieved:** 2026-07-20
+- **Trust class:** web (outside the trust boundary; first-party vendor documentation)
+- **Summary:** Opus 4.8's prompting page states the model interprets prompts literally and does not silently generalize instructions, so an author must state scope explicitly. It favors reasoning over tool calls, spawns fewer subagents by default, defaults effort to high (xhigh for coding), and keeps adaptive thinking off unless enabled. These are the behaviors that make Opus 4.8's authoring guidance point the opposite way from Fable 5's.
+- **Evidence status:** corroborated in part by A7, which restates it; the underlying behavioral claims are single-vendor beyond that.
+
+### A3: Prompting Claude Fable 5 (recommendation-bearing)
+
+- **Link / location:** https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5
+- **Retrieved:** 2026-07-20
+- **Trust class:** web (outside the trust boundary; first-party vendor documentation)
+- **Summary:** Fable 5's page, framed throughout as differences from Opus 4.8, says instruction-following is good enough that a brief goal-based instruction beats an enumerated checklist, and that over-specifying degrades output. It documents safety classifiers that can return a refusal for prompts telling the model to echo its own reasoning into the response, with configurable fallback to Opus 4.8. This is the source of both the highest-value author guidance and the one functional-failure warning in the report.
+- **Evidence status:** corroborated by A8 on the goals-versus-checklist claim; single source on the refusal-category claim.
+
+### A16: LLM identity confusion study (recommendation-bearing)
+
+- **Link / location:** https://arxiv.org/abs/2411.10683
+- **Retrieved:** 2026-07-20
+- **Trust class:** web (outside the trust boundary; academic preprint)
+- **Summary:** Across 27 tested models, 25.93% exhibited self-identification confusion when asked their own identity, often claiming to be a different, more famous model. This bounds how much a skill can trust a model to name itself, which is the fallback any non-hook runtime-branching mechanism would rely on.
+- **Evidence status:** corroborated by A17, an independent study reaching the same conclusion.
+
+### A17: AI self-recognition study (recommendation-bearing)
+
+- **Link / location:** https://arxiv.org/html/2510.03399
+- **Retrieved:** 2026-07-20
+- **Trust class:** web (outside the trust boundary; academic preprint)
+- **Summary:** Only 4 of 10 tested models could correctly recognize their own output, near chance, with a systematic bias toward attributing output to established families like GPT and Claude. Reinforces A16 that self-report is not a sound branching signal.
+- **Evidence status:** corroborated by A16.
+
+### A19: No model field in SKILL.md files (recommendation-bearing)
+
+- **Link / location:** han-core/skills/research/SKILL.md and the other 47 SKILL.md files
+- **Retrieved:** n/a
+- **Trust class:** codebase (trusted current-state anchor)
+- **Summary:** None of Han's 48 skill files carry a model field, and skills reference agents and other skills by name with no model qualifier. The current suite is already fully model-agnostic, which is what makes O1 the existing fallback and O3 an authoring-layer change rather than a rewrite of every skill.
+- **Evidence status:** corroborated by A28, which documents the frontmatter field set.
+
+### A22: No model override at skill dispatch (recommendation-bearing)
+
+- **Link / location:** han-plugin-builder/skills/guidance/references/agent-building-guidelines/agent-model-selection.md:49
+- **Retrieved:** n/a
+- **Trust class:** codebase (trusted current-state anchor)
+- **Summary:** The guidance scopes "always set the model explicitly" to agent definition files only. It tells skills to pass no model override at dispatch, because a hard-coded tier name sends a Claude-specific identifier across the host boundary and supersedes each agent's own tier. This is the rule O4 would violate and the reason to reject it.
+- **Evidence status:** corroborated by A23.
+
+### A23: Issue #78 model-specifier research (recommendation-bearing)
+
+- **Link / location:** docs/research/issue-78-model-specifier-portability.md
+- **Retrieved:** n/a
+- **Trust class:** codebase (trusted current-state anchor; a prior research report in this repo)
+- **Summary:** Prior research found that Claude Code and Codex have separate model namespaces, and that Claude model names fail on Codex. The fix was to remove skill-level model overrides rather than translate them per host. It establishes portability as a hard constraint on any skill-level model handling, which is the backbone of the reject-O2 and reject-O4 calls.
+- **Evidence status:** corroborated within its own source across codebase, provided, and web evidence.
+
+### A24: Codex plugin manifest is skills-only (recommendation-bearing)
+
+- **Link / location:** han-core/.codex-plugin/plugin.json:13
+- **Retrieved:** n/a
+- **Trust class:** codebase (trusted current-state anchor)
+- **Summary:** The Codex plugin manifest exposes only a skills capability and no agents path, so Codex does not register Han's agents at all. This confirms that any skill-level model handling has to work without the agent layer on a non-Claude host, reinforcing the portability constraint.
+- **Evidence status:** single source (codebase anchor).
+
+### A28: Skill frontmatter fields reference (recommendation-bearing)
+
+- **Link / location:** han-plugin-builder/skills/guidance/references/skill-building-guidance/skill-frontmatter-fields.md:45
+- **Retrieved:** n/a
+- **Trust class:** codebase (trusted current-state anchor)
+- **Summary:** The in-repo frontmatter reference states the skill model field overrides the model for the skill's turn only and is not saved to session settings. This is an independent in-repo confirmation that the field is a control, not a way to read the active model, which is the mechanism pillar of the recommendation.
+- **Evidence status:** corroborates A11.
+
+### A29: Readability-guidance spike model-sensitivity flag (recommendation-bearing)
+
+- **Link / location:** docs/plans/han-communication-plugin/artifacts/oi-3-spike/OI-3-spike-report.md:59
+- **Retrieved:** n/a
+- **Trust class:** codebase (trusted current-state anchor)
+- **Summary:** The project's own spike testing of `readability-guidance` recorded that its results came from Opus 4.8 subagents and might not transfer to smaller or faster models an operator might run. This is the concrete, already-recorded model-sensitivity case that makes `readability-guidance` the first opt-in candidate under O3.
+- **Evidence status:** single source (codebase anchor).

--- a/han-plugin-builder/skills/guidance/SKILL.md
+++ b/han-plugin-builder/skills/guidance/SKILL.md
@@ -35,6 +35,8 @@ specific file(s) you need:
   under `${CLAUDE_SKILL_DIR}/references/claude-marketplace-and-plugin-configuration/`.
 - Versioning, README structure, local development, the iterative development process, and
   specialization-versus-model-tier reasoning → the top-level files in `${CLAUDE_SKILL_DIR}/references/`.
+- Writing the instructions for a target model (how Sonnet 5, Opus 4.8, and Fable 5 differ in following instructions,
+  and how that changes what you write) → `${CLAUDE_SKILL_DIR}/references/per-model-authoring.md`.
 - Copyable starter files → `${CLAUDE_SKILL_DIR}/references/templates/`.
 
 Steps:

--- a/han-plugin-builder/skills/guidance/assets/guidance-portable-SKILL.md
+++ b/han-plugin-builder/skills/guidance/assets/guidance-portable-SKILL.md
@@ -24,6 +24,8 @@ specific file(s) you need:
   under `${CLAUDE_SKILL_DIR}/references/claude-marketplace-and-plugin-configuration/`.
 - Versioning, README structure, local development, the iterative development process, and
   specialization-versus-model-tier reasoning → the top-level files in `${CLAUDE_SKILL_DIR}/references/`.
+- Writing the instructions for a target model (how Sonnet 5, Opus 4.8, and Fable 5 differ in following instructions,
+  and how that changes what you write) → `${CLAUDE_SKILL_DIR}/references/per-model-authoring.md`.
 - Copyable starter files → `${CLAUDE_SKILL_DIR}/references/templates/`.
 
 Steps:

--- a/han-plugin-builder/skills/guidance/assets/rule-index-body.md
+++ b/han-plugin-builder/skills/guidance/assets/rule-index-body.md
@@ -162,6 +162,11 @@ Process guidance for building and evolving a plugin over its lifetime.
   — The research-backed rationale for why tighter specialization lets a smaller model at lower effort match a larger one
   on narrow tasks, without raising the capability ceiling. Read when reasoning about the
   specialization-versus-model-tier trade-off across skills and agents.
+- [Per-Model Authoring Guidance](.claude/skills/plugin-guidance/references/per-model-authoring.md) — How Sonnet 5,
+  Opus 4.8, and Fable 5 differ in how they follow instructions, and how those differences change what you write: the
+  model-agnostic default for an unknown target, the opposite-direction instruction-style split, and the Fable 5
+  reasoning-echo refusal to avoid. Read when writing or hardening a skill or agent and tuning the instructions to a
+  target model, not when choosing which model tier to run (see Specialization and Model Selection).
 
 ## Templates and examples
 

--- a/han-plugin-builder/skills/guidance/references/per-model-authoring.md
+++ b/han-plugin-builder/skills/guidance/references/per-model-authoring.md
@@ -1,0 +1,68 @@
+# Per-Model Authoring Guidance
+
+Write your skill and agent instructions to be model-agnostic by default. When you know the model that will run them, three of Anthropic's models differ enough in how they follow instructions that you should adjust how you write. This document tells you when that adjustment is worth making and what it is.
+
+_Last checked against Anthropic's published guidance on 2026-07-20, for Sonnet 5, Opus 4.8, and Fable 5. The per-model behavior below comes from Anthropic's own prompting pages (see Sources). Treat it as current only as of that date: those pages are pinned snapshots that get revised and archived as new models ship._
+
+This is author-time guidance. It shapes how you write instructions, not how a skill behaves while it runs.
+
+A skill cannot reliably detect which model is running it, so do not try to branch skill content on the active model. Claude Code exposes no reliable model signal to a skill, and asking a model to name itself is unreliable. The source research covers the reasons in more detail. Keep your shipped skills model-agnostic, and act on the differences below as you write them.
+
+## Default to model-agnostic instructions
+
+Most of the time you do not know which model will run your skill. The operator picks the model when they run it, and can switch it mid-session, so you cannot count on a specific target. Write for the general case first. The model-agnostic form is also the right fallback for any model this document does not name, including future ones.
+
+Reach for per-model tuning only when you have a specific reason: you know the target model, and one of the differences below applies to what you are writing. When in doubt, the model-agnostic default is the safe choice.
+
+## What "model-agnostic" means when you do not know the target
+
+The three models pull in opposite directions on how much to spell out (see the next section), so "write model-agnostic" needs a concrete meaning. Here it is: lead with the goal and the reasons behind it, state the load-bearing constraints and scope explicitly, and skip the exhaustive step-by-step micro-checklist.
+
+This middle path serves all three models. Stating the goal and the reasons gives Fable 5 the context it uses well, without the checklist that degrades its output. Stating the load-bearing constraints explicitly gives Opus 4.8 and Sonnet 5 the scope they need on the behaviors that matter. You are not writing to the lowest common denominator; you are giving each model what it needs and withholding what hurts one of them.
+
+## The difference that changes how you write: instruction style
+
+This is the one difference worth acting on. Opus 4.8 and Sonnet 5 follow instructions literally and do not generalize on their own, so they want each behavior spelled out and the scope stated.
+
+Fable 5 runs the other way. A short, goal-based instruction works better for it, and spelling out every step with a checklist actively degrades its output.
+
+Because the two directions are opposite, a skill written to one model's guidance points the other the wrong way. If you tune a skill for Fable 5 with terse goals and then it runs on Opus 4.8, the Opus run may under-specify. If you tune for Opus 4.8 with an exhaustive checklist and then it runs on Fable 5, the Fable run may degrade.
+
+When you know the target, match its style. When you do not, use the model-agnostic middle above.
+
+## The difference that can cause a failure: Fable 5 and reasoning echo
+
+On Fable 5, an instruction that tells the model to reproduce or transcribe its own internal thinking into its visible answer can be refused outright. This is the one difference here that causes a functional failure rather than a stylistic mismatch, so it is worth recognizing on sight.
+
+Use this test to tell when the pattern is present. It applies when an instruction tells the model to copy its own internal reasoning or thinking into the deliverable it returns. It does not apply when you ask the model to write a normal explanation of a decision, or to produce a reasoned answer as ordinary content. Asking for an explanation written for the reader is fine; asking the model to echo its private thinking verbatim is the pattern to avoid.
+
+This warning rests on a single Anthropic source and is not independently corroborated (see Sources). It is a documented product behavior, not a subjective style claim, so it is worth heeding. Weigh it knowing the evidence is single-source and single-vendor.
+
+## Other settings the model differences affect: thinking mode, effort, and subagent eagerness
+
+These three differences rarely decide how you write on their own, but each changes a specific choice:
+
+- **Thinking mode.** The three models default differently. Opus 4.8 has thinking off unless you turn it on. Sonnet 5 has it on by default. Fable 5 always has it on and cannot turn it off. So do not write "think step by step" prompt hacks or instructions that assume you can toggle thinking. Set the behavior you want through the model's own controls, not through prose that fights the default.
+- **Effort.** The reasoning-depth lever is the effort setting, not "think harder" phrasing in your instructions. The same effort label does not mean the same depth across the three models, so do not hardcode an assumption that a given level produces a fixed amount of reasoning.
+- **Subagent eagerness.** The three models reach for subagents with different eagerness. If your skill dispatches subagents, state the delegation you want rather than relying on the model's default tendency, which varies by model.
+
+## What this guidance does not cover
+
+This document is about how to write instructions for a model. It is not about which model tier to run. For the tier question (opus, sonnet, or haiku, and at what effort), read [Specialization and Model Selection](./specialization-and-model-selection.md).
+
+It also does not cover run-time model detection or per-model skill variants. Those are out of scope by design, because a skill cannot reliably detect its own model at run time.
+
+## Cross-References
+
+- [Specialization and Model Selection](./specialization-and-model-selection.md). The counterpart to this document. It covers which model _tier_ to run and at what effort; this one covers how to _write the instructions_ for a given model.
+- [Writing Effective Instructions](./skill-building-guidance/writing-effective-instructions.md). How to write clear skill instructions in general, independent of the target model.
+
+## Sources
+
+The per-model behavior above comes from Anthropic's own prompting pages, plus this suite's own research report, `model-specific-guidance-for-skills.md`, which gathered and adversarially validated these claims. The Fable 5 reasoning-echo refusal is single-source on the Fable 5 page.
+
+- [Prompting Claude Opus 4.8 (Anthropic)](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-4-8)
+- [Prompting Claude Sonnet 5 (Anthropic)](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-sonnet-5)
+- [Prompting Claude Fable 5 (Anthropic)](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5)
+- [Claude prompting best practices (Anthropic)](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices)
+- [Claude models overview (Anthropic)](https://platform.claude.com/docs/en/about-claude/models/overview)

--- a/han-plugin-builder/skills/guidance/references/specialization-and-model-selection.md
+++ b/han-plugin-builder/skills/guidance/references/specialization-and-model-selection.md
@@ -84,6 +84,9 @@ The pattern that falls out, by agent archetype:
 
 ## Cross-References
 
+- [Per-Model Authoring Guidance](./per-model-authoring.md). This document is about which model _tier_ to run (opus,
+  sonnet, haiku) and at what effort. Its counterpart is about how to _write the instructions_ for a given model. Read
+  that one when the question is how to phrase instructions for Sonnet 5, Opus 4.8, or Fable 5, not which tier to run.
 - [Agent Model Selection](./agent-building-guidelines/agent-model-selection.md). Decision criteria for the `model`
   frontmatter field on agents.
 - [Agent Domain Focus](./agent-building-guidelines/agent-domain-focus.md). How vocabulary routing, persona length, and


### PR DESCRIPTION
## Summary

**This PR adds an author-time guidance doc that tells a skill or agent author how to phrase instructions when they know which Anthropic model (Sonnet 5, Opus 4.8, or Fable 5) will run them, so authoring choices match how each model actually reads instructions.**

The new reference, `per-model-authoring.md`, lives in the `han-plugin-builder` guidance skill (the plugin that holds the how-to-build-plugins guidance). It leads with the default: when the target model is unknown, write model-agnostic. The one difference worth acting on is instruction style, and the models pull in opposite directions. Opus 4.8 and Sonnet 5 read instructions literally and want each behavior spelled out. Fable 5 does better with a short goal-based instruction, and degrades when handed an exhaustive checklist.

The doc also flags one failure trap. On Fable 5, an instruction telling the model to echo its own internal reasoning verbatim into visible output can be refused outright. That claim rests on a single vendor source, and the doc says so. Shorter notes cover thinking-mode, effort, and subagent-eagerness defaults. The doc scopes itself to how you write instructions, not to which model tier to run; that second question belongs to the sibling doc, `specialization-and-model-selection.md`.

An author reaches the doc through the guidance skill's routing list. Wiring it in adds a routing entry in the skill (`SKILL.md` and its portable copy), a line in the vendored rule index, and a cross-link back from the tier-selection doc. The rest of the branch holds the supporting research report and the plan artifacts (the spec, implementation plan, and decision logs) that produced the guidance.
