### PR TITLE
Integrate readability planning coding

### DIFF
--- a/docs/plans/readability-in-planning-coding/artifacts/.discovery-notes.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/.discovery-notes.md
@@ -1,0 +1,76 @@
+# Implementation Discovery Notes
+
+Single source of project context for the implementation team. Read this first; do not re-grep what is already here.
+
+## Tech stack / repo type
+
+Han is a Claude Code plugin suite. "Code" here is Markdown skill/agent definitions and JSON plugin manifests, not a
+compiled language. No test runner, build, or CI for behavior; the "tests" are consistency/verification checks over
+Markdown. Authoring of any skill/agent/plugin asset MUST follow the han-plugin-builder guidance
+(`han-plugin-builder/skills/guidance/references/`) per the repo CLAUDE.md.
+
+## The canonical integration pattern (reference implementations)
+
+The pattern to replicate, sourced from already-integrated skills:
+
+- **Source guidance (all 7):** an instruction-text line "invoke `han-communication:readability-guidance` to source the
+  standard, apply it as you draft" — no `Skill` tool grant needed (integrated skills don't grant it). Example:
+  `han-core/skills/issue-triage/SKILL.md:30`, `han-github/skills/update-pr-description/SKILL.md:96`.
+- **Editor pass (5 full only):** dispatch one `han-communication:readability-editor` agent after the final draft/synthesis
+  exists, pass the named reader and NO rule path (the editor reads its own canonical rule), apply the returned rewrite,
+  operate on prose regions only. Reference: `han-coding/skills/investigate/SKILL.md` Step 5;
+  `han-github/skills/update-pr-description/SKILL.md:205`.
+- **Standardized self-check (all 7):** the 6-point check over prose regions only, "confirm each criterion and fix any
+  failure before presenting." Reference: `han-coding/skills/investigate/SKILL.md` Step 5 tail; the 6 criteria are in
+  `han-communication/references/readability-rule.md` ("The standardized self-check").
+- The editor agent definition: `han-communication/agents/readability-editor.md` (leaves code fences, diagram bodies,
+  citation identifiers unchanged).
+
+## Insertion points per target skill (spec D2 split)
+
+FULL pattern (guidance early + editor after final content + self-check before present):
+
+- **plan-a-feature** — guidance at Step 5 (Draft) start; final content = Step 8 PM synthesis; editor + self-check as a new
+  pass before Step 9 (Present). Reader: stakeholder/reviewer of the spec. Note: prose regions exclude D#/T#/F# citation
+  identifiers, tables, code fences.
+- **plan-implementation** — guidance early (Step 2 or before Step 8); final content = Step 8 PM synthesis; editor +
+  self-check before Step 9 (Present). Reader: the engineer who will build. Exclude D-N citation identifiers.
+- **plan-a-phased-build** — guidance at Step 6 (Draft); final content = Step 8 (Apply IA Findings); editor + self-check
+  after Step 8, before Step 9 (Present). Reader: the per-run audience collected in Step 3 (engineering / mixed /
+  customer-facing).
+- **coding-standard** — guidance at Step 6 (Write); final content after Step 9 (Adversarial Review); editor + self-check
+  at/after Step 10 (Verification), before presenting. Scope to newly authored/converted content; update mode (Step 1
+  mode) scopes to the edited region. Reader: the engineer who must follow the standard. Preserve frontmatter untouched.
+- **test-planning** — guidance at Step 4 (Generate Output); final content = Step 4; editor + self-check at Step 5 (Review
+  the Output), before presenting. Reader: the engineer who will implement the tests. Exclude TP-NNN IDs.
+
+LIGHTWEIGHT pattern (guidance + self-check only, no editor):
+
+- **plan-work-items** — guidance at Process step 5 (Draft the work items); self-check before step 7 (Print) / step 8
+  (Write file), over work-item prose regions only (exclude W-N IDs and structured fields). Reader: the engineer who grabs
+  a work item.
+- **iterative-plan-review** — guidance early; self-check at Step 6/Step 7 over the regions this run authored or changed on
+  the converged plan (not pre-existing untouched prose). Reader: the reader of the plan it refines.
+
+## Non-skill edits
+
+- **`han-planning/.claude-plugin/plugin.json`** — dependencies currently `["han-core"]`; add `"han-communication"` (D4).
+  `han-coding` already declares `["han-communication", "han-core"]` — no change. Confirm the `han` meta-plugin and
+  marketplace need no change (han-planning already bundled).
+- **`han-communication/references/readability-rule.md`** — clarify the "who reads reader-facing output" scope text (lines
+  20-23) so a human-read plan-of-record is distinguished from a pure pipeline artifact (D9).
+- **`han-communication/skills/readability-guidance/SKILL.md`** — add a brief restatement of the clarified reader-facing
+  scope test (it carries none today; has an audience frame at Step 2 but no scope summary) (D9, F13).
+
+## Out of scope (from spec)
+
+- Long-form docs under `docs/skills/*` — handled later by the repo's `han-update-documentation` skill.
+- No version bumps (user memory: never bump version unprompted). No CHANGELOG edit in this plan.
+- The publishing wrappers / work-items publishers (inherited gaps close upstream).
+
+## Gaps / not found
+
+- No automated test harness for skill behavior exists; verification is manual/grep-based consistency checking — a
+  Definition-of-Done concern for the team (the spec's review flagged "no per-skill acceptance test").
+- No existing implementation-plan precedent in `docs/plans/` for a pure-Markdown meta-change; format follows the
+  plan-implementation template.

--- a/docs/plans/readability-in-planning-coding/artifacts/decision-log.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/decision-log.md
@@ -178,8 +178,10 @@ rationale, evidence, and the alternatives a reasonable engineer would have weigh
 
 - **Decision:** Keep all seven skills in scope, and add a narrow clarification to `readability-rule.md`'s "who reads
   reader-facing output" section so it distinguishes a plan-of-record or standard a human reads end to end (reader-facing,
-  applies the rule) from a pure pipeline artifact consumed only by downstream skills (not reader-facing). The rules the
-  standard enforces do not change; only the scope text is clarified.
+  applies the rule) from a pure pipeline artifact consumed only by downstream skills (not reader-facing). Echo the same
+  clarification in the `readability-guidance` skill's in-context summary of who is reader-facing, so the canonical rule
+  and the in-context surface a caller sees agree. The rules the standard enforces do not change; only the scope text is
+  clarified, in both places.
 - **Rationale:** As written, the scope text excludes "a structured specification / plan / work-item / standard consumed
   mainly by downstream skills," and all seven targets produce those artifact types. Left unreconciled, the standard's own
   text would read as excluding the very skills this feature integrates, inviting a future contributor to remove the
@@ -188,14 +190,17 @@ rationale, evidence, and the alternatives a reasonable engineer would have weigh
   a spec is read for approval), and already-integrated skills such as `issue-triage`, `gap-analysis`, and
   `project-documentation` set the precedent that Han treats structured documents as reader-facing. Clarifying the text
   keeps the standard internally consistent with that intent.
-- **Evidence:** (codebase) `readability-rule.md` lines 20-23 define the carve-out. (provided/user) The user chose to keep
-  all seven and clarify the rule rather than narrow scope or leave the text unchanged.
+- **Evidence:** (codebase) `readability-rule.md` lines 20-23 define the carve-out. (user) The user chose to keep all
+  seven and clarify the rule rather than narrow scope or leave the text unchanged, and directed that the clarification be
+  echoed in `readability-guidance` as well as the canonical rule.
 - **Rejected alternatives:** Keep seven but leave the rule text unchanged — rejected because the text still reads as
   excluding these skills and would drift. Narrow scope to only the clearly human-read outputs — rejected because the
-  user judges all seven reader-facing in Han's use.
-- **Driven by findings:** F1
+  user judges all seven reader-facing in Han's use. Clarify only the canonical rule and leave `readability-guidance`'s
+  in-context summary unchanged — rejected by user direction, because a caller sees the guidance summary in context and
+  the two surfaces must not disagree.
+- **Driven by findings:** F1; user direction (echo in `readability-guidance`)
 - **Linked technical notes:** —
-- **Referenced in spec:** Outcome, Coordinations
+- **Referenced in spec:** Outcome, Coordinations, Open Items
 - **Dependent decisions:** —
 
 ## Trivial decisions

--- a/docs/plans/readability-in-planning-coding/artifacts/decision-log.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/decision-log.md
@@ -178,10 +178,11 @@ rationale, evidence, and the alternatives a reasonable engineer would have weigh
 
 - **Decision:** Keep all seven skills in scope, and add a narrow clarification to `readability-rule.md`'s "who reads
   reader-facing output" section so it distinguishes a plan-of-record or standard a human reads end to end (reader-facing,
-  applies the rule) from a pure pipeline artifact consumed only by downstream skills (not reader-facing). Echo the same
-  clarification in the `readability-guidance` skill's in-context summary of who is reader-facing, so the canonical rule
-  and the in-context surface a caller sees agree. The rules the standard enforces do not change; only the scope text is
-  clarified, in both places.
+  applies the rule) from a pure pipeline artifact consumed only by downstream skills (not reader-facing). Add the same
+  clarified scope test to the `readability-guidance` skill's own instructions: today that skill surfaces the reader-facing
+  scope only by having the caller read the canonical rule and carries no restatement of its own, so this work adds a brief
+  restatement, giving a caller the clarified test in context. The rules the standard enforces do not change; only the
+  scope text is clarified, in both places.
 - **Rationale:** As written, the scope text excludes "a structured specification / plan / work-item / standard consumed
   mainly by downstream skills," and all seven targets produce those artifact types. Left unreconciled, the standard's own
   text would read as excluding the very skills this feature integrates, inviting a future contributor to remove the
@@ -190,15 +191,18 @@ rationale, evidence, and the alternatives a reasonable engineer would have weigh
   a spec is read for approval), and already-integrated skills such as `issue-triage`, `gap-analysis`, and
   `project-documentation` set the precedent that Han treats structured documents as reader-facing. Clarifying the text
   keeps the standard internally consistent with that intent.
-- **Evidence:** (codebase) `readability-rule.md` lines 20-23 define the carve-out. (user) The user chose to keep all
-  seven and clarify the rule rather than narrow scope or leave the text unchanged, and directed that the clarification be
-  echoed in `readability-guidance` as well as the canonical rule.
+- **Evidence:** (codebase) `readability-rule.md` lines 20-23 define the carve-out. (codebase)
+  `readability-guidance/SKILL.md` carries an audience frame but no restatement of the reader-facing scope test — it
+  surfaces that test only by having the caller read the canonical rule (confirmed in review, F13). (user) The user chose
+  to keep all seven and clarify the rule rather than narrow scope or leave the text unchanged, and directed that the
+  clarification also appear in `readability-guidance`, not only the canonical rule.
 - **Rejected alternatives:** Keep seven but leave the rule text unchanged — rejected because the text still reads as
   excluding these skills and would drift. Narrow scope to only the clearly human-read outputs — rejected because the
   user judges all seven reader-facing in Han's use. Clarify only the canonical rule and leave `readability-guidance`'s
   in-context summary unchanged — rejected by user direction, because a caller sees the guidance summary in context and
   the two surfaces must not disagree.
-- **Driven by findings:** F1; user direction (echo in `readability-guidance`)
+- **Driven by findings:** F1; F13 (wording accuracy for the guidance-skill edit); user direction (also clarify in
+  `readability-guidance`)
 - **Linked technical notes:** —
 - **Referenced in spec:** Outcome, Coordinations, Open Items
 - **Dependent decisions:** —

--- a/docs/plans/readability-in-planning-coding/artifacts/decision-log.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/decision-log.md
@@ -7,9 +7,9 @@ rationale, evidence, and the alternatives a reasonable engineer would have weigh
 
 ### D1: Canonical integration pattern
 
-- **Decision:** Each target skill sources `han-communication:readability-guidance` from instruction text, drafts in
-  voice, and runs the standardized six-point self-check before presenting. This is the same pattern the already-integrated
-  skills use.
+- **Decision:** Each target skill sources `han-communication:readability-guidance` from instruction text, drafts its own
+  prose in voice, and runs the standardized six-point self-check before presenting. This is the same pattern the
+  already-integrated skills use.
 - **Rationale:** The pattern is established and canonical, so copying it keeps all integrated skills consistent and lets
   the standard evolve in one place. Inventing a new pattern would fragment the suite.
 - **Evidence:** (codebase) The integrated skills `investigate`, `issue-triage`, `update-pr-description`,
@@ -22,24 +22,28 @@ rationale, evidence, and the alternatives a reasonable engineer would have weigh
 - **Referenced in spec:** Outcome, Primary Flow
 - **Dependent decisions:** D2, D3, D7
 
-### D2: Synthesis-rule split for the editor pass
+### D2: Prose-document vs structured-artifact split for the editor pass
 
 - **Decision:** Five skills (`plan-a-feature`, `plan-implementation`, `plan-a-phased-build`, `coding-standard`,
   `test-planning`) get the full pattern, which adds a `han-communication:readability-editor` agent pass. Two skills
   (`plan-work-items`, `iterative-plan-review`) get the lightweight pattern: guidance plus self-check, no editor pass.
-- **Rationale:** The canonical rule reserves the adversarial rewrite pass for synthesis output. The five full-pattern
-  skills each synthesize a substantial authored deliverable from an agent-team or project-manager pass; the two
-  lightweight skills transform or iterate on already-structured content, where a per-item or per-iteration editor
-  dispatch would be heavy for little gain. The self-check still runs everywhere as the mandatory fidelity floor.
-- **Evidence:** (codebase) `readability-guidance/SKILL.md` line 52: "If your workflow is a synthesis skill, dispatch
-  `han-communication:readability-editor` for the adversarial rewrite after your full draft exists, as the standard
-  reserves that pass for synthesis output." Integrated synthesis skills (`research`, `project-documentation`,
-  `investigate`) dispatch the editor; templated or structured skills (`issue-triage`, `runbook`, `html-summary`) run
-  self-check only.
-- **Rejected alternatives:** Full pattern for all seven — rejected because it dispatches a heavy agent pass on
-  structured and iterative skills against the standard's own guidance. Lightweight for all seven — rejected because the
-  five synthesizers would lose the rewrite the standard reserves for them.
-- **Driven by findings:** —
+- **Rationale:** The split is by deliverable type, not by whether the skill runs an agent pass. The five full-pattern
+  skills produce a prose-heavy document a reader works through end to end, where an adversarial rewrite earns its cost.
+  The two lightweight skills produce an itemized or in-place-edited artifact (`plan-work-items` emits a structured list
+  of atomic items; `iterative-plan-review` edits an existing plan across iterations), where a whole-document editor pass
+  would churn structured content or re-edit already-approved prose for little gain. The self-check still runs everywhere
+  as the mandatory fidelity floor. This framing is chosen deliberately because the alternative test — "does the skill
+  run a project-manager or agent pass?" — misclassifies: `plan-work-items` runs a project-manager synthesis yet stays
+  lightweight, and three of the five full-pattern skills self-author their draft and dispatch only a review agent.
+- **Evidence:** (codebase) `readability-guidance/SKILL.md` line 52 reserves the rewrite pass for "synthesis output";
+  integrated prose-document skills (`research`, `project-documentation`, `investigate`) dispatch the editor, while
+  itemized or templated skills (`issue-triage`, `html-summary`) run self-check only. `plan-work-items/SKILL.md` Step 5
+  dispatches `han-core:project-manager` yet its deliverable is a structured work-items list.
+- **Rejected alternatives:** Classify by "runs an agent/PM synthesis pass" — rejected because it misclassifies
+  `plan-work-items` (F3). Full pattern for all seven — rejected because it dispatches a heavy agent pass on structured
+  and in-place skills. Lightweight for all seven — rejected because the five prose-document skills would lose the
+  rewrite the standard reserves for reader-facing documents.
+- **Driven by findings:** F3
 - **Linked technical notes:** —
 - **Referenced in spec:** Outcome, Primary Flow, Alternate Flows and States
 - **Dependent decisions:** D5, D6
@@ -47,62 +51,96 @@ rationale, evidence, and the alternatives a reasonable engineer would have weigh
 ### D3: Prose-regions-only scope and fact fidelity
 
 - **Decision:** The readability work (both the editor pass and the self-check) operates on prose regions only and never
-  inside code fences, tables, diagram bodies, function signatures, or citation identifiers. Every fact, quantity, named
-  entity, stated qualifier, and cross-reference identifier survives unchanged.
+  inside code fences, tables, diagram bodies, frontmatter, or citation identifiers. Every fact, quantity, named entity,
+  stated qualifier, and cross-reference identifier survives unchanged.
 - **Rationale:** These skills produce deliverables dense with load-bearing identifiers (file:line citations, D#/T#/F#
-  cross-references, work-item IDs). Rewriting inside them would break references or corrupt facts. Fidelity is the
-  point of the deliverable; readability governs only how the prose is said.
+  cross-references, work-item IDs, YAML frontmatter). Rewriting inside them would break references or corrupt facts.
+  Fidelity is the point of the deliverable; readability governs only how the prose is said.
 - **Evidence:** (codebase) Every integrated skill scopes its readability pass to "prose regions only," and the
   `readability-editor` agent definition (`han-communication/agents/readability-editor.md`) already leaves code fences,
-  diagram bodies, and citation identifiers byte-for-byte unchanged.
+  diagram bodies, and citation identifiers unchanged.
 - **Rejected alternatives:** Let the editor rewrite the whole document — rejected because it would rewrite citation
-  identifiers and structured tables.
-- **Driven by findings:** —
+  identifiers, structured tables, and frontmatter.
+- **Driven by findings:** F8
 - **Linked technical notes:** —
 - **Referenced in spec:** Outcome, Edge Cases and Failure Modes
 - **Dependent decisions:** D5
 
-### D5: Per-skill scope and named audience
+### D4: han-planning gains a direct han-communication dependency
 
-- **Decision:** Each skill's readability step names the specific prose regions it covers and the specific audience it
-  holds while applying the standard. The audience per skill: `plan-a-feature` and `plan-a-phased-build` hold the
-  stakeholder or reviewer reading the plan; `plan-implementation`, `plan-work-items`, and `test-planning` hold the
-  engineer who will build or test; `coding-standard` holds the engineer who must follow the standard;
-  `iterative-plan-review` holds the reader of the plan it refines.
-- **Rationale:** The integrated skills all pass a named audience to the editor and self-check so the standard is applied
-  for a concrete reader rather than in the abstract. Naming the covered regions keeps structured companion files out of
-  scope.
-- **Evidence:** (codebase) `investigate` names "the engineer who will implement the fix and may be paged on the bug";
-  `update-pr-description` names "the reviewer evaluating the pull request." Each target skill's own description states
-  its deliverable and reader.
-- **Rejected alternatives:** A single generic audience for all seven — rejected because the standard is audience-scoped
-  and the seven deliverables have different readers.
-- **Driven by findings:** —
+- **Decision:** Add `han-communication` to `han-planning`'s plugin dependencies. `han-coding` already declares it. No
+  tool grants change, because every target skill already grants the `Agent` tool the editor pass uses, and the
+  integrated skills invoke `readability-guidance` from instruction text with no `Skill` tool grant.
+- **Rationale:** `han-planning` currently declares only `han-core`, reaching `han-communication` transitively. Every
+  plugin whose skills successfully invoke `readability-guidance` today (`han-core`, `han-coding`, `han-github`,
+  `han-reporting`) declares `han-communication` directly. Han's own convention requires every prose-producing plugin to
+  depend on `han-communication` directly, and `han-planning` was absent from that list. Adding the direct dependency
+  both follows the convention and removes the risk that a transitive-only chain fails to resolve the sibling skill and
+  agent at runtime.
+- **Evidence:** (codebase) `han-planning/.claude-plugin/plugin.json` declares `"dependencies": ["han-core"]`;
+  `han-coding/.claude-plugin/plugin.json` declares `["han-communication", "han-core"]`;
+  `han-core/.claude-plugin/plugin.json` declares `["han-communication"]`. CLAUDE.md names `han-core`, `han-coding`,
+  `han-github`, `han-reporting`, and `han-atlassian` as direct `han-communication` dependents and omits `han-planning`.
+- **Rejected alternatives:** Rely on the transitive chain and change nothing — rejected because it contradicts the
+  stated convention and leaves the runtime resolution untested for the five planning skills.
+- **Driven by findings:** F2
 - **Linked technical notes:** —
-- **Referenced in spec:** Alternate Flows and States, Edge Cases and Failure Modes
+- **Referenced in spec:** Actors and Triggers
 - **Dependent decisions:** —
 
-### D6: Readability pass runs after the final synthesis step
+### D5: Per-skill scope and named audience
 
-- **Decision:** In skills that end with a synthesis step owning final content (notably `plan-a-feature`'s
-  project-manager synthesis), the readability pass runs after that step produces the final content and before the
-  deliverable is presented.
-- **Rationale:** The readability pass governs how final content reads. Running it before an authoritative later step
-  would let that step reintroduce voice violations. Ordering it last, before presentation, matches how `investigate`
-  places its editor pass after adversarial validation.
-- **Evidence:** (codebase) `investigate/SKILL.md` Step 5 runs the editor pass after the Step 4 validation, "separate
-  from the adversarial-validator pass." `plan-a-feature` Step 8 hands final synthesis to the project-manager.
-- **Rejected alternatives:** Run the readability pass inside the synthesis step — rejected because the synthesis agent
-  owns content decisions, not voice, and coupling the two muddies both.
-- **Driven by findings:** —
+- **Decision:** Each skill's readability step names the prose regions it covers and the reader it holds while applying
+  the standard. Coverage is the prose the skill authors or changes this run, not pre-existing prose it leaves untouched.
+  For in-place editing (`iterative-plan-review`; `coding-standard` update mode), the pass runs on the changed regions of
+  the converged document. The reader per skill: `plan-a-feature` holds the stakeholder or reviewer reading the spec;
+  `plan-a-phased-build` holds the per-run audience it already asks the user for (engineering, mixed, or customer-facing);
+  `plan-implementation`, `plan-work-items`, and `test-planning` hold the engineer who will build or test;
+  `coding-standard` holds the engineer who must follow the standard; `iterative-plan-review` holds the reader of the
+  plan it refines.
+- **Rationale:** The integrated skills all pass a named reader to the editor and self-check so the standard is applied
+  for a concrete audience rather than in the abstract. Scoping coverage to authored-or-changed regions keeps structured
+  companion files and untouched prose out of the pass, and prevents an in-place skill from re-editing prose another
+  skill already approved.
+- **Evidence:** (codebase) `investigate` names "the engineer who will implement the fix and may be paged on the bug";
+  `update-pr-description` names "the reviewer evaluating the pull request." `plan-a-phased-build/SKILL.md` already
+  collects an audience choice per run. `iterative-plan-review/SKILL.md` and `coding-standard/SKILL.md` both edit
+  existing documents in place.
+- **Rejected alternatives:** A single generic audience for all seven — rejected because the deliverables have different
+  readers. Whole-document coverage for in-place skills — rejected because it re-checks and may re-edit prose the run did
+  not touch (F5).
+- **Driven by findings:** F5, F7, F9
 - **Linked technical notes:** —
-- **Referenced in spec:** Edge Cases and Failure Modes
+- **Referenced in spec:** Outcome, Primary Flow, Alternate Flows and States, Edge Cases and Failure Modes
+- **Dependent decisions:** —
+
+### D6: Readability pass runs after the final content exists
+
+- **Decision:** The readability pass (editor for the five prose-document skills, self-check for all seven) runs after
+  the skill's final content-producing step completes — including any project-manager synthesis, review, or IA step the
+  skill already runs near the end — and before the deliverable is presented.
+- **Rationale:** The readability pass governs how final content reads. When a dispatched agent authors the final content
+  (for example `plan-a-feature`'s project-manager synthesis or `plan-work-items`'s project-manager pass), the standard
+  is in the skill's context, not the agent's, so "draft in voice" alone cannot carry voice into agent-authored content.
+  The after-the-fact pass is the lever that does. Running it before an authoritative later step would let that step
+  reintroduce voice violations, so it runs last, before presentation, matching how `investigate` places its editor pass
+  after adversarial validation.
+- **Evidence:** (codebase) `investigate/SKILL.md` Step 5 runs the editor pass after Step 4 validation, "separate from
+  the adversarial-validator pass." `plan-a-feature` Step 8 hands final synthesis to `han-core:project-manager`;
+  `plan-work-items` Step 5 returns the project-manager's output; `plan-a-phased-build`, `coding-standard`, and
+  `test-planning` each run review or IA steps before presenting.
+- **Rejected alternatives:** Run the readability pass inside or before the synthesis/review step — rejected because that
+  agent owns content decisions, not voice, and a later authoritative step would undo the readability work.
+- **Driven by findings:** F4, F6
+- **Linked technical notes:** —
+- **Referenced in spec:** Primary Flow, Edge Cases and Failure Modes
 - **Dependent decisions:** —
 
 ### D7: Reference the single canonical standard, never vendor it
 
 - **Decision:** The seven skills reach the standard only through `han-communication:readability-guidance`; they never
-  copy the rule text or the writing-voice profile into themselves.
+  copy the rule text or the writing-voice profile into themselves. The D9 scope-text clarification edits the one
+  canonical `readability-rule.md`, not any copy.
 - **Rationale:** The suite keeps one canonical source per concept. A change to the standard must reach all consumers
   without editing them.
 - **Evidence:** (codebase) CLAUDE.md: "Single canonical copy in the foundational `han-communication` plugin; no
@@ -112,28 +150,54 @@ rationale, evidence, and the alternatives a reasonable engineer would have weigh
 - **Driven by findings:** —
 - **Linked technical notes:** —
 - **Referenced in spec:** Coordinations
-- **Dependent decisions:** —
+- **Dependent decisions:** D9
 
 ### D8: Scope is exactly these seven skills
 
 - **Decision:** This feature integrates the standard into exactly the seven named skills. It excludes already-integrated
   skills, non-prose skills, and skills that inherit prose from an upstream source.
-- **Rationale:** A prior survey classified all 38 skills. The seven are the only ones that author user-facing prose and
-  lack the standard. The publishing wrappers (Confluence, Jira, GitHub, Linear, work-items publishers) inherit their
-  prose from upstream skills, so their gaps close when the upstream skill is integrated rather than by editing the
-  wrapper.
-- **Evidence:** (provided) The survey earlier in this session enumerated the integrated set (15 skills), the direct
-  gaps (these 7), the inherited gaps, and the not-applicable skills.
+- **Rationale:** A survey classified all 38 skills in the suite. Fifteen already integrate the standard. Two produce
+  code, not prose (`tdd`, `refactor`). The publishing wrappers and work-items publishers transform or republish prose an
+  upstream skill authored, so their gaps close when the upstream skill is integrated; `markdown-to-confluence`
+  republishes user prose verbatim and authors none. That leaves these seven as the only skills that author reader-facing
+  prose and lack the standard.
+- **Evidence:** (provided) The 38-skill classification produced earlier in this session, recorded here so scope is
+  auditable: integrated (15) — `architectural-analysis`, `code-overview`, `code-review`, `investigate`,
+  `edit-for-readability`, `readability-guidance`, `architectural-decision-record`, `gap-analysis`, `issue-triage`,
+  `project-documentation`, `research`, `runbook`, `update-pr-description`, `html-summary`, `stakeholder-summary`; direct
+  gaps (these 7); inherited gaps (the Confluence, Jira, GitHub, Linear publishers); not applicable (`tdd`, `refactor`,
+  `markdown-to-confluence`, `project-discovery`, and the plugin-builder authoring skills).
 - **Rejected alternatives:** Also edit the publishing wrappers — rejected because they transform prose an integrated
   upstream skill authored, so editing them would duplicate the pass.
-- **Driven by findings:** —
+- **Driven by findings:** F10, F11
 - **Linked technical notes:** —
 - **Referenced in spec:** Out of Scope
 - **Dependent decisions:** —
 
+### D9: Reader-facing scope reconciliation
+
+- **Decision:** Keep all seven skills in scope, and add a narrow clarification to `readability-rule.md`'s "who reads
+  reader-facing output" section so it distinguishes a plan-of-record or standard a human reads end to end (reader-facing,
+  applies the rule) from a pure pipeline artifact consumed only by downstream skills (not reader-facing). The rules the
+  standard enforces do not change; only the scope text is clarified.
+- **Rationale:** As written, the scope text excludes "a structured specification / plan / work-item / standard consumed
+  mainly by downstream skills," and all seven targets produce those artifact types. Left unreconciled, the standard's own
+  text would read as excluding the very skills this feature integrates, inviting a future contributor to remove the
+  integration. In Han's actual use, a solo product engineer and their stakeholders read these deliverables end to end (a
+  phased build is explicitly plain-language for demoing to real users; a coding standard is a document engineers follow;
+  a spec is read for approval), and already-integrated skills such as `issue-triage`, `gap-analysis`, and
+  `project-documentation` set the precedent that Han treats structured documents as reader-facing. Clarifying the text
+  keeps the standard internally consistent with that intent.
+- **Evidence:** (codebase) `readability-rule.md` lines 20-23 define the carve-out. (provided/user) The user chose to keep
+  all seven and clarify the rule rather than narrow scope or leave the text unchanged.
+- **Rejected alternatives:** Keep seven but leave the rule text unchanged — rejected because the text still reads as
+  excluding these skills and would drift. Narrow scope to only the clearly human-read outputs — rejected because the
+  user judges all seven reader-facing in Han's use.
+- **Driven by findings:** F1
+- **Linked technical notes:** —
+- **Referenced in spec:** Outcome, Coordinations
+- **Dependent decisions:** —
+
 ## Trivial decisions
 
-- **D4:** No tooling or dependency changes needed — the integrated skills invoke `readability-guidance` from
-  instruction text with no `Skill` tool grant, and all seven target skills already grant the `Agent` tool the editor
-  pass uses; every target plugin's dependency chain already reaches `han-communication` (verified against the integrated
-  skills' frontmatter, none of which grant `Skill`). — Referenced in spec: Actors and Triggers.
+<!-- None. D4, formerly trivial, became a full decision when review surfaced the transitive-dependency gap (F2). -->

--- a/docs/plans/readability-in-planning-coding/artifacts/decision-log.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/decision-log.md
@@ -1,0 +1,139 @@
+# Decision Log: Readability Standard in the Planning and Coding Skills
+
+Decisions behind [../feature-specification.md](../feature-specification.md). Each full decision records its outcome,
+rationale, evidence, and the alternatives a reasonable engineer would have weighed.
+
+## Full decisions
+
+### D1: Canonical integration pattern
+
+- **Decision:** Each target skill sources `han-communication:readability-guidance` from instruction text, drafts in
+  voice, and runs the standardized six-point self-check before presenting. This is the same pattern the already-integrated
+  skills use.
+- **Rationale:** The pattern is established and canonical, so copying it keeps all integrated skills consistent and lets
+  the standard evolve in one place. Inventing a new pattern would fragment the suite.
+- **Evidence:** (codebase) The integrated skills `investigate`, `issue-triage`, `update-pr-description`,
+  `stakeholder-summary`, `research`, and others all follow this shape. The canonical rule lives in
+  `han-communication/skills/readability-guidance/SKILL.md` (Step 3, "Apply the standard in stages").
+- **Rejected alternatives:** Vendor the readability rule text into each skill — rejected because it violates the
+  suite's single-canonical-source convention and would drift.
+- **Driven by findings:** —
+- **Linked technical notes:** —
+- **Referenced in spec:** Outcome, Primary Flow
+- **Dependent decisions:** D2, D3, D7
+
+### D2: Synthesis-rule split for the editor pass
+
+- **Decision:** Five skills (`plan-a-feature`, `plan-implementation`, `plan-a-phased-build`, `coding-standard`,
+  `test-planning`) get the full pattern, which adds a `han-communication:readability-editor` agent pass. Two skills
+  (`plan-work-items`, `iterative-plan-review`) get the lightweight pattern: guidance plus self-check, no editor pass.
+- **Rationale:** The canonical rule reserves the adversarial rewrite pass for synthesis output. The five full-pattern
+  skills each synthesize a substantial authored deliverable from an agent-team or project-manager pass; the two
+  lightweight skills transform or iterate on already-structured content, where a per-item or per-iteration editor
+  dispatch would be heavy for little gain. The self-check still runs everywhere as the mandatory fidelity floor.
+- **Evidence:** (codebase) `readability-guidance/SKILL.md` line 52: "If your workflow is a synthesis skill, dispatch
+  `han-communication:readability-editor` for the adversarial rewrite after your full draft exists, as the standard
+  reserves that pass for synthesis output." Integrated synthesis skills (`research`, `project-documentation`,
+  `investigate`) dispatch the editor; templated or structured skills (`issue-triage`, `runbook`, `html-summary`) run
+  self-check only.
+- **Rejected alternatives:** Full pattern for all seven — rejected because it dispatches a heavy agent pass on
+  structured and iterative skills against the standard's own guidance. Lightweight for all seven — rejected because the
+  five synthesizers would lose the rewrite the standard reserves for them.
+- **Driven by findings:** —
+- **Linked technical notes:** —
+- **Referenced in spec:** Outcome, Primary Flow, Alternate Flows and States
+- **Dependent decisions:** D5, D6
+
+### D3: Prose-regions-only scope and fact fidelity
+
+- **Decision:** The readability work (both the editor pass and the self-check) operates on prose regions only and never
+  inside code fences, tables, diagram bodies, function signatures, or citation identifiers. Every fact, quantity, named
+  entity, stated qualifier, and cross-reference identifier survives unchanged.
+- **Rationale:** These skills produce deliverables dense with load-bearing identifiers (file:line citations, D#/T#/F#
+  cross-references, work-item IDs). Rewriting inside them would break references or corrupt facts. Fidelity is the
+  point of the deliverable; readability governs only how the prose is said.
+- **Evidence:** (codebase) Every integrated skill scopes its readability pass to "prose regions only," and the
+  `readability-editor` agent definition (`han-communication/agents/readability-editor.md`) already leaves code fences,
+  diagram bodies, and citation identifiers byte-for-byte unchanged.
+- **Rejected alternatives:** Let the editor rewrite the whole document — rejected because it would rewrite citation
+  identifiers and structured tables.
+- **Driven by findings:** —
+- **Linked technical notes:** —
+- **Referenced in spec:** Outcome, Edge Cases and Failure Modes
+- **Dependent decisions:** D5
+
+### D5: Per-skill scope and named audience
+
+- **Decision:** Each skill's readability step names the specific prose regions it covers and the specific audience it
+  holds while applying the standard. The audience per skill: `plan-a-feature` and `plan-a-phased-build` hold the
+  stakeholder or reviewer reading the plan; `plan-implementation`, `plan-work-items`, and `test-planning` hold the
+  engineer who will build or test; `coding-standard` holds the engineer who must follow the standard;
+  `iterative-plan-review` holds the reader of the plan it refines.
+- **Rationale:** The integrated skills all pass a named audience to the editor and self-check so the standard is applied
+  for a concrete reader rather than in the abstract. Naming the covered regions keeps structured companion files out of
+  scope.
+- **Evidence:** (codebase) `investigate` names "the engineer who will implement the fix and may be paged on the bug";
+  `update-pr-description` names "the reviewer evaluating the pull request." Each target skill's own description states
+  its deliverable and reader.
+- **Rejected alternatives:** A single generic audience for all seven — rejected because the standard is audience-scoped
+  and the seven deliverables have different readers.
+- **Driven by findings:** —
+- **Linked technical notes:** —
+- **Referenced in spec:** Alternate Flows and States, Edge Cases and Failure Modes
+- **Dependent decisions:** —
+
+### D6: Readability pass runs after the final synthesis step
+
+- **Decision:** In skills that end with a synthesis step owning final content (notably `plan-a-feature`'s
+  project-manager synthesis), the readability pass runs after that step produces the final content and before the
+  deliverable is presented.
+- **Rationale:** The readability pass governs how final content reads. Running it before an authoritative later step
+  would let that step reintroduce voice violations. Ordering it last, before presentation, matches how `investigate`
+  places its editor pass after adversarial validation.
+- **Evidence:** (codebase) `investigate/SKILL.md` Step 5 runs the editor pass after the Step 4 validation, "separate
+  from the adversarial-validator pass." `plan-a-feature` Step 8 hands final synthesis to the project-manager.
+- **Rejected alternatives:** Run the readability pass inside the synthesis step — rejected because the synthesis agent
+  owns content decisions, not voice, and coupling the two muddies both.
+- **Driven by findings:** —
+- **Linked technical notes:** —
+- **Referenced in spec:** Edge Cases and Failure Modes
+- **Dependent decisions:** —
+
+### D7: Reference the single canonical standard, never vendor it
+
+- **Decision:** The seven skills reach the standard only through `han-communication:readability-guidance`; they never
+  copy the rule text or the writing-voice profile into themselves.
+- **Rationale:** The suite keeps one canonical source per concept. A change to the standard must reach all consumers
+  without editing them.
+- **Evidence:** (codebase) CLAUDE.md: "Single canonical copy in the foundational `han-communication` plugin; no
+  vendored copies. Consuming skills source it cross-plugin by invoking `han-communication:readability-guidance`."
+- **Rejected alternatives:** Vendor a copy per plugin for offline resilience — rejected as a direct violation of the
+  single-canonical-source convention.
+- **Driven by findings:** —
+- **Linked technical notes:** —
+- **Referenced in spec:** Coordinations
+- **Dependent decisions:** —
+
+### D8: Scope is exactly these seven skills
+
+- **Decision:** This feature integrates the standard into exactly the seven named skills. It excludes already-integrated
+  skills, non-prose skills, and skills that inherit prose from an upstream source.
+- **Rationale:** A prior survey classified all 38 skills. The seven are the only ones that author user-facing prose and
+  lack the standard. The publishing wrappers (Confluence, Jira, GitHub, Linear, work-items publishers) inherit their
+  prose from upstream skills, so their gaps close when the upstream skill is integrated rather than by editing the
+  wrapper.
+- **Evidence:** (provided) The survey earlier in this session enumerated the integrated set (15 skills), the direct
+  gaps (these 7), the inherited gaps, and the not-applicable skills.
+- **Rejected alternatives:** Also edit the publishing wrappers — rejected because they transform prose an integrated
+  upstream skill authored, so editing them would duplicate the pass.
+- **Driven by findings:** —
+- **Linked technical notes:** —
+- **Referenced in spec:** Out of Scope
+- **Dependent decisions:** —
+
+## Trivial decisions
+
+- **D4:** No tooling or dependency changes needed — the integrated skills invoke `readability-guidance` from
+  instruction text with no `Skill` tool grant, and all seven target skills already grant the `Agent` tool the editor
+  pass uses; every target plugin's dependency chain already reaches `han-communication` (verified against the integrated
+  skills' frontmatter, none of which grant `Skill`). — Referenced in spec: Actors and Triggers.

--- a/docs/plans/readability-in-planning-coding/artifacts/implementation-decision-log.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/implementation-decision-log.md
@@ -1,0 +1,166 @@
+# Implementation Decision Log: Readability Standard in the Planning and Coding Skills
+
+<!--
+This file records every implementation decision committed while planning this feature.
+Behavioral and implementation statements live in [../feature-implementation-plan.md](../feature-implementation-plan.md) —
+this file captures the question, rationale, evidence, and rejected alternatives for each decision.
+Round-by-round history lives in [implementation-iteration-history.md](implementation-iteration-history.md).
+-->
+
+## Trivial decisions
+
+<!-- None. Every committed decision carries at least one rejected alternative and rests on codebase or specialist evidence, so all are full. -->
+
+None.
+
+## Full decisions
+
+### D-1: Edit sequencing
+
+- **Question:** In what order are the edits applied, and as one atomic change or incremental commits?
+- **Decision:** Incremental, commit-and-push-as-you-go, in this order: (a) the D9 `readability-rule.md` scope-text
+  clarification plus the `readability-guidance` restatement; (b) the D4 `han-planning` dependency add; (c) the five
+  full-pattern skills; (d) the two lightweight skills; (e) verification. The seven skill edits are order-independent
+  among themselves.
+- **Rationale:** Until D9 lands, `readability-rule.md` lines 20-23 textually read as excluding the very artifact types
+  the seven skills produce, so a contributor reading the standard mid-stream would see it contradict the integrations.
+  D4's purpose is to stop `han-planning` relying on the transitive `han-core` chain to reach `han-communication`, so it
+  lands before the five planning-skill edits that invoke the sibling skill and agent. The incremental posture follows
+  the user's directive rather than a single atomic PR.
+- **Evidence:** junior-developer R1 sequencing finding; `han-communication/references/readability-rule.md` lines 20-23
+  (the carve-out text); `han-planning/.claude-plugin/plugin.json:5` (`["han-core"]`); user directive "commit and push
+  as you go" (OQ-1, resolution source user input).
+- **Rejected alternatives:**
+  - Single atomic PR of all edits — rejected by the user's commit-and-push-as-you-go directive.
+  - Skill edits before the D9 clarification — rejected because it leaves the canonical standard textually contradicting
+    the edits mid-implementation.
+  - D4 dependency after the skill edits — rejected because the transitive chain works today but the edits' purpose is to
+    stop relying on it, so the dependency must precede the skills that lean on it.
+- **Specialist owner:** han-core:project-manager (executes as the sequenced work units).
+- **Revisit criterion:** If the user reverses the commit-as-you-go directive, or if a skill edit is found to depend on
+  another skill edit (they are independent today).
+- **Dissent (if any):** —
+- **Driven by rounds:** R1
+- **Dependent decisions:** —
+- **Referenced in plan:** Implementation Approach, Decomposition and Sequencing
+
+### D-2: Two frozen canonical snippets for drift control
+
+- **Question:** How is the readability-integration text kept consistent across seven near-identical skill edits?
+- **Decision:** Freeze two canonical snippets and reuse them verbatim. FULL = the guidance-source line plus the
+  `han-communication:readability-editor` dispatch plus the six-point self-check, taken from `investigate` Step 5.
+  LIGHTWEIGHT = the guidance-source line plus the six-point self-check, explicitly no editor, with the guidance line
+  matching `issue-triage:30`. Vary only two named slots per skill: the D5 named reader and the excluded citation-ID
+  tokens. A post-edit grep is the consistency gate.
+- **Rationale:** Seven near-identical edits invite wording drift. Freezing the snippet and varying only two named slots
+  keeps the integrations consistent and greppable, and keeps the canonical pattern (D1) intact across the suite.
+- **Evidence:** junior-developer R1 drift-control finding; `han-coding/skills/investigate/SKILL.md` Step 5 (FULL
+  reference); `han-core/skills/issue-triage/SKILL.md:30` (LIGHTWEIGHT guidance line); spec
+  [D1](decision-log.md#d1-canonical-integration-pattern), [D5](decision-log.md#d5-per-skill-scope-and-named-audience).
+- **Rejected alternatives:**
+  - Hand-write each of the seven independently — rejected because it drifts across files and leaves no greppable
+    invariant.
+  - Vendor a shared snippet file into the skills — rejected because it violates the single-canonical-source convention;
+    the canonical source is `readability-guidance`, which the snippet invokes rather than copies.
+- **Specialist owner:** han-core:project-manager.
+- **Revisit criterion:** If a target skill's workflow cannot host the frozen snippet verbatim and needs a structural
+  variant.
+- **Dissent (if any):** —
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-4
+- **Referenced in plan:** Implementation Approach, Testing Strategy
+
+### D-3: Author via han-plugin-builder Guidance Mode, not the builders or guidance init
+
+- **Question:** CLAUDE.md mandates that authoring go through han-plugin-builder guidance — which path applies to editing
+  existing skills and one manifest?
+- **Decision:** Consult the han-plugin-builder guidance docs directly (Guidance Mode). Do not run `skill-builder` or
+  `agent-builder` (build-from-scratch), and do not run `guidance init` (vendors the builder skills). Docs to consult:
+  `skill-building-guidance/skill-composition.md`, `agent-dispatch-namespacing.md`, `writing-effective-instructions.md`,
+  and `claude-marketplace-and-plugin-configuration/` for the `plugin.json` edit.
+- **Rationale:** These are edits to existing skills plus one manifest, not new artifacts, so the interview-driven
+  builders do not fit. `guidance init` vendors the builder skills into a repo's `.claude/skills/`, which this work does
+  not need.
+- **Evidence:** CLAUDE.md "Creating skills, agents, or other plugin aspects" mandate; junior-developer R1 process
+  finding (the four named guidance docs confirmed to exist).
+- **Rejected alternatives:**
+  - `skill-builder` / `agent-builder` — rejected because they build artifacts from scratch, the wrong tool for editing
+    existing skills.
+  - `guidance init` — rejected because it vendors builder skills into the repo, which is unnecessary machinery here.
+- **Specialist owner:** han-core:project-manager.
+- **Revisit criterion:** If any edit turns out to require a new skill or agent rather than editing an existing one.
+- **Dissent (if any):** —
+- **Driven by rounds:** R1
+- **Dependent decisions:** —
+- **Referenced in plan:** Implementation Approach, Specialist Handoffs for Implementation
+
+### D-4: Verification is a grep/jq acceptance checklist plus one smoke run
+
+- **Question:** How is "done" verified when no behavior test harness exists?
+- **Decision:** A deterministic grep/jq acceptance checklist (items T1-T17) over the edited files, plus one
+  representative smoke run — one full-pattern skill and one lightweight skill. `plugin.json` gets free JSON validation
+  from the existing prek/Prettier lint; Markdown stays deliberately unlinted.
+- **Rationale:** No behavior test runner exists for skills. Consistency across the frozen snippets (D-2) is checkable by
+  grep, JSON validity by the existing lint, and one smoke run confirms the integrated steps actually fire without
+  dry-running all seven.
+- **Evidence:** test-engineer R1 (checklist items T1-T17, deferrals S1 and S2); `.discovery-notes.md` "Gaps / not
+  found" (no automated harness); `.pre-commit-config.yaml` (JSON lint via prek/Prettier).
+- **Rejected alternatives:**
+  - Dry-run all seven skills end to end (S1) — rejected because it adds cost without signal beyond the grep checklist
+    plus one smoke run.
+  - Build a prose-lint tool (S2) — rejected as single-use tooling with no evidence forcing it now (YAGNI).
+- **Specialist owner:** han-core:test-engineer.
+- **Revisit criterion:** If grep proves insufficient to catch a class of drift the checklist misses.
+- **Dissent (if any):** —
+- **Driven by rounds:** R1
+- **Dependent decisions:** —
+- **Referenced in plan:** Testing Strategy, Definition of Done
+
+### D-5: plugin.json dependency order and no version bump
+
+- **Question:** Exactly how is `han-planning`'s `plugin.json` edited?
+- **Decision:** Change `dependencies` from `["han-core"]` to `["han-communication", "han-core"]`, matching
+  `han-coding`'s order (`han-communication` first). Do not bump the version (stays `2.0.4`). No `han` meta-plugin or
+  marketplace change, because `han-planning` is already bundled and declared.
+- **Rationale:** The convention lists `han-communication` first, matching the sibling `han-coding` manifest. Repo memory
+  forbids unprompted version bumps. The meta-plugin already bundles `han-planning`, so no wider manifest edit is needed.
+- **Evidence:** spec [D4](decision-log.md#d4-han-planning-gains-a-direct-han-communication-dependency);
+  `han-coding/.claude-plugin/plugin.json` (`["han-communication", "han-core"]`);
+  `han-planning/.claude-plugin/plugin.json` lines 4-5 (`"version": "2.0.4"`, `"dependencies": ["han-core"]`); repo
+  memory "never bump version unprompted"; R1 evidence-check (meta-plugin and marketplace need no change).
+- **Rejected alternatives:**
+  - Append `han-communication` after `han-core` — rejected because it breaks the ordering convention set by
+    `han-coding`.
+  - Bump the version — rejected because repo memory forbids unprompted bumps.
+  - Edit the meta-plugin or marketplace manifest — rejected because `han-planning` is already bundled and declared
+    there.
+- **Specialist owner:** han-core:project-manager.
+- **Revisit criterion:** If the user directs a version bump, or a release cut requires one.
+- **Dissent (if any):** —
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-1
+- **Referenced in plan:** Implementation Approach, Decomposition and Sequencing
+
+### D-6: The readability-guidance scope restatement is new text
+
+- **Question:** What does the D9 "echo in `readability-guidance`" edit actually do?
+- **Decision:** Add a brief restatement of the clarified reader-facing scope test to
+  `readability-guidance/SKILL.md`'s own instructions. The skill carries no such restatement today (only an audience
+  frame at Step 2), so this is additive new text, not an edit to an existing summary, and it must agree with the
+  clarified `readability-rule.md` lines 20-23 scope text.
+- **Rationale:** Review finding F13 confirmed there is no existing scope summary to echo into. The deliverable is
+  therefore additive, and the two surfaces (canonical rule and guidance skill) must not disagree.
+- **Evidence:** spec [D9](decision-log.md#d9-reader-facing-scope-reconciliation); review finding F13
+  ([review-findings.md](review-findings.md)); `han-communication/skills/readability-guidance/SKILL.md` (no reader-facing
+  scope restatement present today).
+- **Rejected alternatives:**
+  - Edit an existing scope summary in the guidance skill — rejected because none exists (F13).
+  - Clarify only the canonical rule and skip `readability-guidance` — rejected by user direction (D9): a caller sees the
+    guidance summary in context, and the two surfaces must agree.
+- **Specialist owner:** han-core:project-manager.
+- **Revisit criterion:** If the `readability-rule.md` scope wording changes after this lands, the restatement must be
+  kept in sync.
+- **Dissent (if any):** —
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-1
+- **Referenced in plan:** Implementation Approach, Decomposition and Sequencing

--- a/docs/plans/readability-in-planning-coding/artifacts/implementation-iteration-history.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/implementation-iteration-history.md
@@ -1,0 +1,52 @@
+# Implementation Iteration History
+
+Round-by-round record for [../feature-implementation-plan.md](../feature-implementation-plan.md). Decisions live in
+[implementation-decision-log.md](implementation-decision-log.md).
+
+## R1
+
+- **Mode:** team (small); **Round cap:** 1
+- **Specialists engaged:** han-core:junior-developer, han-core:test-engineer (han-core:project-manager runs synthesis in
+  Step 8)
+- **New input provided:** the feature spec, decision log, and `.discovery-notes.md` (insertion points per skill, the
+  canonical pattern, non-skill edits).
+
+### Claim ledger
+
+| # | Category | Claim | Supporting specialists | State | Spec-maturity |
+|---|----------|-------|------------------------|-------|---------------|
+| C1 | sequencing | Land the D9 rule-text clarification before the 7 skill edits, so the canonical standard does not textually contradict them mid-implementation. | junior-developer | Evidenced (`readability-rule.md:20-23`) | plan-level |
+| C2 | sequencing | Land the D4 `han-planning` dependency no later than the five planning-skill edits (ideally first). | junior-developer | Evidenced (`han-planning/.claude-plugin/plugin.json:5`) | plan-level |
+| C3 | consistency | Freeze two canonical snippets (FULL, LIGHTWEIGHT) and vary only the named reader (D5) and excluded citation-ID tokens; verify with a post-edit grep. Prevents drift across 7 files. | junior-developer | Evidenced (`investigate` Step 5, `issue-triage:30`) | plan-level |
+| C4 | process | The CLAUDE.md mandate routes through han-plugin-builder **Guidance Mode** (consult skill-composition, agent-dispatch-namespacing, writing-effective-instructions, claude-marketplace-and-plugin-configuration), NOT skill-builder or `guidance init`. | junior-developer | Evidenced (guidance docs confirmed to exist) | plan-level |
+| C5 | prerequisite | All 7 skills already grant `Agent`; no tool-grant change. `readability-guidance` needs no `Skill` grant (invoked from instruction text). | junior-developer, test-engineer | Evidenced (`allowed-tools` on all 7; T14) | plan-level |
+| C6 | verification | Definition of done is a deterministic grep/jq acceptance checklist (T1-T17) plus one smoke run, since no test harness exists. plugin.json gets free JSON lint via prek/Prettier; Markdown is deliberately unlinted. | test-engineer | Evidenced (`.pre-commit-config.yaml`; T1-T17) | plan-level |
+| C7 | correctness | Editor dispatch must sit strictly between each full-pattern skill's final-content step and its present step (D6 ordering), be absent from the 2 lightweight skills (D2), pass the named reader and no rule path (D3/D5). | test-engineer | Evidenced (T5, T6, T7) | plan-level |
+| C8 | correctness | Prose-region exclusions must name each skill's own ID scheme (D-N for plan-implementation, W-N, TP-NNN, D#/T#/F#); coding-standard frontmatter untouched and self-check mode-conditional; iterative-plan-review self-check inserted once, not per loop. | test-engineer | Evidenced (T11, T12, T13) | plan-level |
+| C9 | YAGNI | Do not run all-7 end-to-end dry runs (S1), build a prose-lint tool (S2), or run the full builder/init flow — a grep checklist + one smoke run + guidance consult suffice. | test-engineer, junior-developer | Evidenced (S1, S2) | plan-level |
+
+### Open Questions
+
+- **OQ-1 (Q4): atomic PR vs incremental commits.** Resolved by user directive "commit and push as you go" → incremental,
+  sequenced so the D9 rule clarification and the D4 dependency land before the skill edits that rely on them.
+  Resolution source: user input.
+- Evidence checks run this round (resolving JD's residual guards): the carve-out phrase appears only in
+  `readability-rule.md` (no other doc paraphrases it, so D9's two edits cover every surface); the `han` meta-plugin
+  already bundles `han-planning` and declares `han-communication` directly, so no meta-plugin or marketplace change.
+
+### Spec-maturity gate
+
+Not tripped: 0 `T#`-contradictions (no `T#` notes exist), 0 `spec-level` findings, no security/PII surface. All findings
+are `plan-level` and `Evidenced`.
+
+### Next-step recommendation
+
+**Go to synthesis.** One round, all findings evidenced and plan-level, the single Open Question resolved by user
+directive.
+
+- **Decisions produced:** D-1 (edit sequencing, from C1/C2/OQ-1), D-2 (two frozen snippets, from C3), D-3 (Guidance-Mode
+  consult, from C4), D-4 (grep/jq checklist + one smoke run, from C6/C9), D-5 (plugin.json dep order + no version bump,
+  from C2), D-6 (readability-guidance restatement is new text, from F13).
+- **Changed in plan:** initial authoring of every section — Outcome, Context, Team Composition and Participation,
+  Implementation Approach, Decomposition and Sequencing, RAID Log (Assumptions), Testing Strategy, Definition of Done,
+  Specialist Handoffs for Implementation, Deferred (YAGNI), Open Items, Summary.

--- a/docs/plans/readability-in-planning-coding/artifacts/review-findings.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/review-findings.md
@@ -1,0 +1,33 @@
+# Review Findings: Readability Standard in the Planning and Coding Skills
+
+Findings from `han-planning:iterative-plan-review` (spec-aware mode, lightweight). Cross-references:
+`Raised in round:` links to [review-iteration-history.md](review-iteration-history.md); `Changed in plan:` names the
+sections of [../feature-specification.md](../feature-specification.md) edited in response.
+
+## Major findings
+
+### F13: The readability-guidance skill has no "reader-facing scope" summary to echo into
+
+- **Agent:** self-review
+- **Category:** consistency (grounding a decision against the codebase)
+- **Finding:** D9 and the spec (Coordinations, Open Items) say the scope clarification is "echoed in the
+  `readability-guidance` skill's in-context summary of who is reader-facing." No such summary exists.
+  `readability-guidance/SKILL.md` carries an audience frame (Step 2) but no restatement of the reader-facing scope test;
+  it surfaces that test only by instructing the caller to read the canonical `readability-rule.md` (Step 1). There is
+  nothing to echo into.
+- **Evidence considered:** (codebase) `han-communication/skills/readability-guidance/SKILL.md` — grep for
+  "reader-facing / who reads / downstream skill" returns no match; the file's own scope is "surface the standard by
+  reading the canonical files," not restating them.
+- **Resolution:** Reworded D9, the spec Coordinations row, and the spec Open Items note so the deliverable is stated
+  precisely: this work *adds* a brief restatement of the clarified reader-facing scope test to the
+  `readability-guidance` skill's own instructions, since the skill carries none today. Scope and intent are unchanged;
+  only the description of what the guidance-skill edit does is corrected.
+- **Resolved by:** evidence
+- **Raised in round:** R1
+- **Changed in plan:** Coordinations, Open Items; decision-log D9
+
+## Minor edits
+
+- F14: Confirmed D4's codebase claim — `han-planning/.claude-plugin/plugin.json` declares `["han-core"]`, so the direct
+  `han-communication` dependency add is correct and consistent with `han-coding`'s `["han-communication", "han-core"]`.
+  No change needed. — self-review — —

--- a/docs/plans/readability-in-planning-coding/artifacts/review-iteration-history.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/review-iteration-history.md
@@ -1,0 +1,19 @@
+# Review Iteration History: Readability Standard in the Planning and Coding Skills
+
+Rounds run by `han-planning:iterative-plan-review`. Findings live in [review-findings.md](review-findings.md).
+
+## R1
+
+- **Mode:** lightweight
+- **Spec-aware mode:** engaged
+- **Specialists engaged:** self-review
+- **Focus:** consistency of the plan with two just-made user decisions — `han-planning` gains a direct
+  `han-communication` dependency (D4), and the reader-facing scope clarification is echoed in `readability-guidance`
+  (D9, resolving the former OI-1) — grounded against `plugin.json` dependency declarations, the `readability-guidance`
+  SKILL.md, and the seven target skills.
+- **Findings raised:** F13 (major), F14 (minor)
+- **Changed in plan:** Coordinations, Open Items; decision-log D9
+- **Stability assessment:** Stable. One major finding, resolved by evidence with no scope change; one minor confirmation
+  requiring no edit. Decision counts, cross-references, and the full/lightweight split all check out.
+- **Next step:** Stop (size cap: 1 round; stop rule met — ≤2 new findings, and the one major was a wording-accuracy fix,
+  not a behavioral gap).

--- a/docs/plans/readability-in-planning-coding/artifacts/team-findings.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/team-findings.md
@@ -1,0 +1,13 @@
+# Team Findings: Readability Standard in the Planning and Coding Skills
+
+Records every finding raised by the review team and how each was resolved. Behavioral outcomes live in
+[../feature-specification.md](../feature-specification.md); decisions the findings affected live in
+[decision-log.md](decision-log.md).
+
+## Major findings
+
+<!-- Populated in Step 7 after the review team returns. -->
+
+## Minor edits
+
+<!-- Populated in Step 7 after the review team returns. -->

--- a/docs/plans/readability-in-planning-coding/artifacts/team-findings.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/team-findings.md
@@ -16,7 +16,7 @@ Records every finding raised by the review team and how each was resolved. Behav
   scope text so a human-read plan-of-record is distinguished from a pure pipeline artifact. Captured as D9; the rule
   clarification is now an in-scope deliverable and the Out of Scope section was narrowed accordingly.
 - **Resolved by:** user input
-- **Affected decisions:** D9 (new), D8
+- **Affected decisions:** D9 (new)
 - **Changed in spec:** Outcome, Coordinations, Out of Scope, Summary
 
 ### F2: "No dependency change" holds only for direct han-communication dependents

--- a/docs/plans/readability-in-planning-coding/artifacts/team-findings.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/team-findings.md
@@ -14,10 +14,12 @@ Records every finding raised by the review team and how each was resolved. Behav
   artifact types, so the standard's own text reads as excluding them.
 - **Resolution:** Escalated to the user. User chose to keep all seven in scope and add a narrow clarification to the
   scope text so a human-read plan-of-record is distinguished from a pure pipeline artifact. Captured as D9; the rule
-  clarification is now an in-scope deliverable and the Out of Scope section was narrowed accordingly.
+  clarification is now an in-scope deliverable and the Out of Scope section was narrowed accordingly. On a later user
+  direction, D9 was extended to echo the same clarification in the `readability-guidance` skill's in-context summary, and
+  the prior open item asking whether to do so was resolved and removed.
 - **Resolved by:** user input
 - **Affected decisions:** D9 (new)
-- **Changed in spec:** Outcome, Coordinations, Out of Scope, Summary
+- **Changed in spec:** Outcome, Coordinations, Out of Scope, Open Items, Summary
 
 ### F2: "No dependency change" holds only for direct han-communication dependents
 

--- a/docs/plans/readability-in-planning-coding/artifacts/team-findings.md
+++ b/docs/plans/readability-in-planning-coding/artifacts/team-findings.md
@@ -2,12 +2,107 @@
 
 Records every finding raised by the review team and how each was resolved. Behavioral outcomes live in
 [../feature-specification.md](../feature-specification.md); decisions the findings affected live in
-[decision-log.md](decision-log.md).
+[decision-log.md](decision-log.md). Reviewers: `han-core:junior-developer` (JD-*) and `han-core:gap-analyzer` (GAP-*).
 
 ## Major findings
 
-<!-- Populated in Step 7 after the review team returns. -->
+### F1: The standard's own scope text excludes the seven artifact types
+
+- **Agent:** junior-developer (JD-007 restatement), gap-analyzer (GAP-001)
+- **Finding:** `readability-rule.md` lines 20-23 say a "structured specification / plan / work-item / standard consumed
+  mainly by downstream skills" is not reader-facing and does not apply the rule. All seven targets produce those exact
+  artifact types, so the standard's own text reads as excluding them.
+- **Resolution:** Escalated to the user. User chose to keep all seven in scope and add a narrow clarification to the
+  scope text so a human-read plan-of-record is distinguished from a pure pipeline artifact. Captured as D9; the rule
+  clarification is now an in-scope deliverable and the Out of Scope section was narrowed accordingly.
+- **Resolved by:** user input
+- **Affected decisions:** D9 (new), D8
+- **Changed in spec:** Outcome, Coordinations, Out of Scope, Summary
+
+### F2: "No dependency change" holds only for direct han-communication dependents
+
+- **Agent:** junior-developer (JD-001), gap-analyzer (GAP-002)
+- **Finding:** `han-planning` depends only on `han-core`, reaching `han-communication` transitively. Every plugin whose
+  skills invoke `readability-guidance` today depends on `han-communication` directly, and Han's convention requires it.
+  The original D4 ("no dependency changes") was untested for the five planning skills.
+- **Resolution:** Add a direct `han-communication` dependency to `han-planning`. Verified `han-coding` already declares
+  it and all seven skills already grant `Agent`. D4 rewritten from a trivial decision to a full decision.
+- **Resolved by:** evidence
+- **Affected decisions:** D4
+- **Changed in spec:** Actors and Triggers
+
+### F3: The "synthesis skill" classifier misclassifies plan-work-items
+
+- **Agent:** junior-developer (JD-002), gap-analyzer (GAP-005, GAP-006)
+- **Finding:** D2's original rationale keyed the full/lightweight split on running an agent or project-manager synthesis
+  pass. But `plan-work-items` runs a project-manager synthesis yet was placed lightweight, and three of the five
+  full-pattern skills self-author and dispatch only a review agent. The stated test contradicts the chosen split.
+- **Resolution:** Kept the user's 5/2 split but reframed D2's criterion as deliverable type — a prose-heavy document read
+  end to end (full) versus an itemized or in-place-edited artifact (lightweight). The split is unchanged; the rationale
+  is now internally consistent.
+- **Resolved by:** evidence
+- **Affected decisions:** D2
+- **Changed in spec:** Outcome, Primary Flow, Alternate Flows and States
+
+### F4: Sourcing the standard into the skill's context does not reach a dispatched agent's content
+
+- **Agent:** junior-developer (JD-003)
+- **Finding:** For skills where a dispatched agent authors the final content (`plan-a-feature` Step 8 project-manager;
+  `plan-work-items` Step 5 project-manager), "draft in voice" cannot be fulfilled because the standard lives in the
+  skill's context, not the agent's. For lightweight `plan-work-items` the self-check is then the only lever, applied to
+  content the skill returns from the agent.
+- **Resolution:** Clarified that the after-the-fact pass carries voice into agent-authored content — the editor pass for
+  the five prose-document skills, the self-check for the two structured-artifact skills. Captured in D6 and the Primary
+  Flow (step 2) and Edge Cases.
+- **Resolved by:** evidence
+- **Affected decisions:** D6
+- **Changed in spec:** Primary Flow, Edge Cases and Failure Modes
+
+### F5: In-place skills' self-check scope was contradictory
+
+- **Agent:** junior-developer (JD-004, JD-005)
+- **Finding:** The spec said the self-check runs on the "converged plan" (whole document) but also that each skill covers
+  only "the regions it authors." For in-place editors (`iterative-plan-review`; `coding-standard` update mode) those are
+  different sets, and a whole-document pass would re-edit already-approved prose.
+- **Resolution:** Scoped the pass to the prose the skill authors or changes this run. For in-place editing, the pass runs
+  on the changed regions of the converged document. Captured in D5 and the "in-place skill edits an existing document"
+  alternate flow.
+- **Resolved by:** evidence
+- **Affected decisions:** D5
+- **Changed in spec:** Alternate Flows and States, Edge Cases and Failure Modes
+
+### F6: Ordering versus each skill's existing review/IA steps was unspecified
+
+- **Agent:** gap-analyzer (GAP-007)
+- **Finding:** `plan-a-phased-build`, `coding-standard`, and `test-planning` already run review or IA steps near the end
+  of their workflows. The spec fixed ordering only for `plan-a-feature`'s project-manager synthesis, leaving the others
+  undefined.
+- **Resolution:** Generalized D6 so the readability pass runs after the skill's final content-producing step, whatever
+  its name, and before presenting.
+- **Resolved by:** evidence
+- **Affected decisions:** D6
+- **Changed in spec:** Edge Cases and Failure Modes
+
+### F7: plan-a-phased-build already collects a per-run audience
+
+- **Agent:** gap-analyzer (GAP-008)
+- **Finding:** `plan-a-phased-build` asks the user which audience the outline targets (engineering, mixed, or
+  customer-facing). The original D5 hardcoded a single "stakeholder" frame for it.
+- **Resolution:** D5 updated so `plan-a-phased-build` holds the per-run audience it already collects, rather than a fixed
+  frame.
+- **Resolved by:** evidence
+- **Affected decisions:** D5
+- **Changed in spec:** Edge Cases and Failure Modes
 
 ## Minor edits
 
-<!-- Populated in Step 7 after the review team returns. -->
+- F8: The editor is dispatched with the named reader and no rule path (it reads its own canonical rule); prose-regions
+  exclusion list extended to include frontmatter and work-item IDs — gap-analyzer (GAP-003, GAP-009) — Primary Flow,
+  Coordinations, D3.
+- F9: Named audience (D5) threaded explicitly into the editor dispatch and self-check steps — gap-analyzer (GAP-004) —
+  Primary Flow.
+- F10: `markdown-to-confluence` moved to the genuinely-not-applicable bucket (republishes user prose verbatim); Out of
+  Scope list marked illustrative, not exhaustive — junior-developer (JD-006), gap-analyzer (GAP-010) — Out of Scope, D8.
+- F11: The 38-skill survey persisted into D8's Evidence field so scope is auditable — junior-developer (JD-007) — D8.
+- F12: Softened "byte-for-byte" phrasing and moved standard-file locators out of behavioral sentences — junior-developer
+  (JD-009) — Edge Cases, Coordinations.

--- a/docs/plans/readability-in-planning-coding/feature-implementation-plan.md
+++ b/docs/plans/readability-in-planning-coding/feature-implementation-plan.md
@@ -1,0 +1,237 @@
+# Feature Implementation Plan: Readability Standard in the Planning and Coding Skills
+
+Wire Han's shared readability standard into seven prose-authoring skills, add a direct `han-communication` dependency to
+`han-planning`, and clarify the standard's own reader-facing scope text. Every edit is Markdown or JSON instruction
+text; no compiled code. Posture: incremental, sequenced commits, verified by a grep/jq acceptance checklist plus one
+smoke run.
+
+## Source Specification
+
+- **Feature specification:** [feature-specification.md](feature-specification.md)
+- **Specification decision log:** [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Specification team findings:** [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Specification decisions this plan inherits:** D1, D2, D3, D4, D5, D6, D7, D8, D9
+- **Specification open items this plan must respect or resolve:** None (spec Open Items: 0)
+
+## Outcome
+
+Seven skills that author reader-facing prose but skip the shared readability standard today will source it while they
+draft and hold their output to it before presenting. In `han-planning`: `plan-a-feature`, `plan-implementation`,
+`plan-a-phased-build`, `plan-work-items`, and `iterative-plan-review`. In `han-coding`: `coding-standard` and
+`test-planning`. `han-planning`'s manifest gains a direct `han-communication` dependency. The canonical
+`readability-rule.md` scope text and the `readability-guidance` skill both gain a clarified reader-facing scope test, so
+the standard no longer reads as excluding the artifact types these skills produce.
+
+## Context
+
+- **Driving constraint:** The standard's own scope text (`readability-rule.md` lines 20-23) currently reads as excluding
+  the seven artifact types, so the integrations and the standard are textually inconsistent until the D9 clarification
+  lands. Reconciling them removes the invitation for a future contributor to strip the integration
+  ([D-1](artifacts/implementation-decision-log.md#d-1-edit-sequencing)).
+- **Stakeholders:** The engineer running each skill (gets in-voice, self-checked output); the downstream reader of each
+  deliverable (a spec, plan, phased build, work items, coding standard, or test plan they can follow); the suite
+  maintainer (one canonical standard, no vendored drift).
+- **Future-state concern:** Insertion points are named by step number in the discovery notes, and step numbers are
+  fragile. Each skill's live numbering must be re-checked at edit time so a snippet does not land at the wrong step
+  (RAID A1).
+- **Out-of-scope boundary:** No change to what the standard requires (criteria, voice, fidelity rule); only the D9 scope
+  text is clarified. No long-form doc updates under `docs/skills/*` — the repo's `han-update-documentation` skill
+  handles those after these edits land. No version bump and no CHANGELOG edit. No edits to the publishing or work-items
+  wrappers (their gaps close upstream, spec D8).
+
+## Team Composition and Participation
+
+| Specialist                   | Status      | Key Input                                                                                                    |
+| ---------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------ |
+| `han-core:project-manager`   | Coordinator | Facilitated R1 and synthesized this plan.                                                                     |
+| `han-core:junior-developer`  | Active      | Sequencing (D9 first, D4 early), two-frozen-snippet drift control, Guidance-Mode routing, prerequisite audit. |
+| `han-core:test-engineer`     | Active      | Deterministic grep/jq acceptance checklist (T1-T17) plus one smoke run; YAGNI deferrals S1, S2.               |
+
+## Implementation Approach
+
+All edits are instruction text. Two canonical snippets are frozen and reused verbatim across the seven skills, varying
+only the D5 named reader and the excluded citation-ID tokens per skill
+([D-2](artifacts/implementation-decision-log.md#d-2-two-frozen-canonical-snippets-for-drift-control)). Authoring routes
+through han-plugin-builder Guidance Mode — consulting the guidance docs, not running the interview builders or
+`guidance init` ([D-3](artifacts/implementation-decision-log.md#d-3-author-via-han-plugin-builder-guidance-mode-not-the-builders-or-guidance-init)).
+
+### The two frozen snippets
+
+- **FULL** (five skills): a guidance-source line early in the workflow, then after the final content exists a single
+  `han-communication:readability-editor` dispatch passing the named reader and no rule path (the editor reads its own
+  canonical rule), then the six-point self-check before presenting. Sourced from
+  `han-coding/skills/investigate/SKILL.md` Step 5.
+- **LIGHTWEIGHT** (two skills): the same guidance-source line plus the six-point self-check, explicitly no editor
+  dispatch. Guidance line matches `han-core/skills/issue-triage/SKILL.md:30`.
+
+The six self-check criteria mirror `readability-rule.md`'s canonical six, including the fact-fidelity criterion "every
+fact preserved," which is the only fact-preservation guard the two lightweight skills carry (spec D2).
+
+### Per-skill insertion points
+
+FULL pattern (guidance early + editor after final content + self-check before present):
+
+| Skill                | Guidance at        | Final content        | Editor + self-check      | Named reader (D5)                        | Prose-region exclusions                 |
+| -------------------- | ------------------ | -------------------- | ------------------------ | ---------------------------------------- | --------------------------------------- |
+| `plan-a-feature`     | Step 5 (Draft)     | Step 8 PM synthesis  | new pass before Step 9   | stakeholder/reviewer of the spec         | D#/T#/F# IDs, tables, code fences        |
+| `plan-implementation`| Step 2 / pre-Step 8| Step 8 PM synthesis  | before Step 9 (Present)  | the engineer who will build              | D-N citation identifiers                 |
+| `plan-a-phased-build`| Step 6 (Draft)     | Step 8 (Apply IA)    | after Step 8, before Step 9 | per-run audience collected in Step 3  | (audience is per-run, not hardcoded)     |
+| `coding-standard`    | Step 6 (Write)     | after Step 9 review  | at/after Step 10, before present | the engineer who must follow the standard | frontmatter untouched; update mode scopes to edited region |
+| `test-planning`      | Step 4 (Generate)  | Step 4               | Step 5 (Review), before present | the engineer who will implement the tests | TP-NNN IDs                          |
+
+LIGHTWEIGHT pattern (guidance + self-check only, no editor):
+
+| Skill                  | Guidance at | Self-check at                          | Named reader (D5)                  | Prose-region exclusions            |
+| ---------------------- | ----------- | -------------------------------------- | ---------------------------------- | ---------------------------------- |
+| `plan-work-items`      | step 5      | before step 7 (Print) / step 8 (Write) | the engineer who grabs a work item | W-N IDs and structured fields      |
+| `iterative-plan-review`| early       | once at Step 6/7 on the converged plan | the reader of the plan it refines  | regions this run authored/changed only |
+
+`iterative-plan-review`'s self-check is inserted once, after both review loops converge — not inside both Step 4 and
+Step 5 (spec D5; test T13). `coding-standard`'s self-check is mode-conditional: create/convert mode covers newly
+authored content, update mode covers the edited region (test T12).
+
+### Non-skill edits
+
+- `han-planning/.claude-plugin/plugin.json` — `dependencies` `["han-core"]` → `["han-communication", "han-core"]`,
+  matching `han-coding`'s order; version stays `2.0.4`; no meta-plugin or marketplace change
+  ([D-5](artifacts/implementation-decision-log.md#d-5-pluginjson-dependency-order-and-no-version-bump)).
+- `han-communication/references/readability-rule.md` lines 20-23 — clarify the "who reads reader-facing output" scope so
+  a human-read plan-of-record is distinguished from a pure pipeline artifact (spec D9).
+- `han-communication/skills/readability-guidance/SKILL.md` — add a brief restatement of the clarified scope test; this
+  is new text, since the skill carries none today
+  ([D-6](artifacts/implementation-decision-log.md#d-6-the-readability-guidance-scope-restatement-is-new-text)).
+
+Prerequisites confirmed and unchanged: all seven skills already grant the `Agent` tool the editor pass needs (no
+tool-grant change); `readability-guidance` is invoked from instruction text with no `Skill` grant; the `han` meta-plugin
+and marketplace need no change.
+
+## Decomposition and Sequencing
+
+Incremental, commit-and-push-as-you-go. The D9 clarification and the D4 dependency land before the skill edits that rely
+on them ([D-1](artifacts/implementation-decision-log.md#d-1-edit-sequencing)).
+
+| #   | Work Unit                                       | Delivers                                                             | Depends On | Verification                                              |
+| --- | ----------------------------------------------- | ------------------------------------------------------------------- | ---------- | -------------------------------------------------------- |
+| a   | D9 scope clarification                          | `readability-rule.md` lines 20-23 clarified + `readability-guidance` restatement | —          | T8, T9 (both surfaces agree; guidance diff non-empty)    |
+| b   | D4 dependency add                               | `han-planning/plugin.json` deps `["han-communication","han-core"]`, version `2.0.4` | —          | T1, T2 (`jq` on deps and version)                        |
+| c   | Five full-pattern skills                        | FULL snippet inserted per the per-skill table                       | a, b       | T3, T4, T5, T7, T10, T11, T12, T14                       |
+| d   | Two lightweight skills                          | LIGHTWEIGHT snippet inserted per the per-skill table                | a, b       | T3, T4, T6, T10, T11, T13, T14                           |
+| e   | Verification                                    | grep/jq checklist run + one smoke run + T17 no-change confirmation  | c, d       | full checklist below                                     |
+
+The five and two skill edits are order-independent among themselves (independent files).
+
+## RAID Log
+
+### Assumptions
+
+| ID  | Assumption                                                                                      | What Changes If Wrong                              | Verifier                                            | Status |
+| --- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------- | --------------------------------------------------- | ------ |
+| A1  | The step numbers named in the per-skill insertion table still match each skill's live numbering. | A snippet lands at the wrong step in the workflow. | Per-skill manual check of live numbering at edit time. | Open   |
+
+## Testing Strategy
+
+No behavior test harness exists; verification is a deterministic grep/jq acceptance checklist plus one smoke run
+([D-4](artifacts/implementation-decision-log.md#d-4-verification-is-a-grepjq-acceptance-checklist-plus-one-smoke-run)).
+`plugin.json` gets free JSON validation from the existing prek/Prettier lint; Markdown stays deliberately unlinted.
+
+Acceptance checklist:
+
+- **T1/T2 — plugin.json:** stays valid JSON; `jq -e '.dependencies==["han-communication","han-core"] and
+  .version=="2.0.4"'` on `han-planning/.claude-plugin/plugin.json` passes.
+- **T3 — guidance line:** present and positioned before the drafting step in all seven skills.
+- **T4 — self-check:** the six-criteria self-check present in all seven; criteria match `readability-rule.md`'s
+  canonical six, including "every fact preserved."
+- **T5 — editor position (full):** editor dispatch present in the five full skills, positioned
+  final-content-step < editor < present-step (line-number check).
+- **T6 — editor absent (lightweight):** `grep -c` for the editor dispatch returns 0 in `plan-work-items` and
+  `iterative-plan-review`.
+- **T7 — editor dispatch shape:** names the reader, passes no rule path, single `Agent` call.
+- **T8/T9 — scope-text agreement:** `readability-rule.md` scope text and the `readability-guidance` restatement agree;
+  the `readability-guidance` diff is non-empty.
+- **T10 — named reader:** each skill names its D5 reader; `plan-a-phased-build` uses the per-run audience from Step 3,
+  not a hardcoded frame.
+- **T11 — prose-region exclusions:** each skill names its own ID scheme (`plan-implementation` D-N; `plan-work-items`
+  W-N; `test-planning` TP-NNN; `plan-a-feature` D#/T#/F#).
+- **T12 — coding-standard:** frontmatter untouched; self-check mode-conditional (create/convert covers new content,
+  update covers the edited region).
+- **T13 — iterative-plan-review:** self-check inserted once after both loops converge, not inside both Step 4 and
+  Step 5.
+- **T14 — tool grants:** no `allowed-tools` change on any of the seven.
+- **T15 — smoke run:** one representative full-pattern skill and one lightweight skill run cleanly.
+- **T17 — unchanged manifests:** `han` meta-plugin `plugin.json` and marketplace `.json` unchanged.
+
+## Definition of Done
+
+- [ ] `han-planning/plugin.json` deps are `["han-communication","han-core"]` and version is `2.0.4` — T1, T2, D-5.
+- [ ] All seven skills source `readability-guidance` before drafting and carry the six-point self-check — T3, T4, D-2.
+- [ ] The five full skills dispatch one `readability-editor` between final content and present, with named reader and no
+      rule path — T5, T7, D-2.
+- [ ] `plan-work-items` and `iterative-plan-review` carry no editor dispatch — T6, D-2.
+- [ ] Each skill names its D5 reader and its own ID-scheme exclusions; `coding-standard` frontmatter untouched and
+      self-check mode-conditional; `iterative-plan-review` self-check inserted once — T10, T11, T12, T13.
+- [ ] `readability-rule.md` scope text and the `readability-guidance` restatement agree and are non-empty — T8, T9, D-6.
+- [ ] No `allowed-tools` change on any skill; `han` meta-plugin and marketplace unchanged — T14, T17.
+- [ ] One full-pattern and one lightweight skill smoke-run cleanly — T15, D-4.
+- [ ] Per-skill live step numbering re-checked before each insertion — A1.
+
+## Specialist Handoffs for Implementation
+
+- **`han-core:project-manager`** — executes the sequenced work units (a-e) and the edits; owns D-1, D-2, D-3, D-5, D-6.
+- **`han-core:test-engineer`** — dispatch at work unit (e); runs the grep/jq acceptance checklist and the single smoke
+  run; owns D-4.
+- **han-plugin-builder guidance docs** — consult in Guidance Mode before editing: `skill-composition.md`,
+  `agent-dispatch-namespacing.md`, `writing-effective-instructions.md`, and `claude-marketplace-and-plugin-configuration/`
+  for the `plugin.json` edit (D-3). Not the `skill-builder`/`agent-builder` interviews and not `guidance init`.
+
+## Deferred (YAGNI)
+
+### All-seven end-to-end dry runs (S1)
+
+- **Why deferred:** Simpler-version test — one smoke run (one full + one lightweight skill) plus the grep/jq checklist
+  gives the same confidence as dry-running all seven, at lower cost. The Sentry-runbook precedent does not apply; there
+  is no operational machinery here.
+- **Reopen when:** The grep checklist plus one smoke run misses a class of defect that only a per-skill run would catch.
+- **Source:** R1, test-engineer.
+
+### Prose-lint tool (S2)
+
+- **Why deferred:** Evidence test — no measured need or incident forces building a single-use lint tool; grep over the
+  frozen snippets covers the consistency invariant.
+- **Reopen when:** Manual grep proves repeatedly insufficient across multiple future integrations.
+- **Source:** R1, test-engineer.
+
+### Running the builder skills or `guidance init` instead of a guidance consult
+
+- **Why deferred:** Simpler-version test — a Guidance-Mode doc consult satisfies the CLAUDE.md authoring mandate for
+  edits to existing skills; the interview builders build from scratch and `guidance init` vendors skills, neither of
+  which this work needs (D-3).
+- **Reopen when:** An edit turns out to require authoring a new skill or agent rather than editing an existing one.
+- **Source:** R1, junior-developer.
+
+## Open Items
+
+None block implementation. OQ-1 (atomic vs. incremental) was resolved by user directive to commit and push as you go,
+sequenced so D9 and D4 land first ([D-1](artifacts/implementation-decision-log.md#d-1-edit-sequencing)). The downstream
+`han-update-documentation` pass over the seven skills' long-form docs is deliberately out of scope (spec Out of Scope)
+and runs after these edits land.
+
+## Summary
+
+- **Outcome delivered:** Seven prose-authoring skills source and apply the shared readability standard before
+  presenting, `han-planning` declares `han-communication` directly, and the standard's scope text is clarified in both
+  the canonical rule and the guidance skill.
+- **Team size:** 3 specialists — see
+  [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md)
+- **Rounds of facilitation:** 1 — see
+  [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md)
+- **Decisions committed:** 6 — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Decisions settled by evidence:** 5 — see
+  [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Decisions settled by junior-developer reframing:** 0 — see
+  [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Decisions settled by user input:** 1 (D-1 sequencing posture) — see
+  [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Rejected alternatives recorded:** 14 — see
+  [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Open items remaining:** 0
+- **Recommendation:** Ship as planned.

--- a/docs/plans/readability-in-planning-coding/feature-specification.md
+++ b/docs/plans/readability-in-planning-coding/feature-specification.md
@@ -1,0 +1,114 @@
+# Feature Specification: Readability Standard in the Planning and Coding Skills
+
+Wire Han's shared readability standard into the seven skills that author user-facing prose but currently skip it, so
+each skill's deliverable is drafted in voice and checked against the standard before it reaches the user.
+
+## Outcome
+
+Each of the seven target skills sources the shared readability standard while it drafts and holds its output to that
+standard before presenting it. Concretely, when an engineer runs one of these skills:
+
+- The skill sources `han-communication:readability-guidance` into its context before it writes its deliverable, and
+  drafts in the shared voice ([D1](artifacts/decision-log.md#d1-canonical-integration-pattern)).
+- After the draft exists, the skill runs the standardized six-point readability self-check over the deliverable's prose
+  regions and fixes every failure before presenting.
+- The five synthesis skills additionally dispatch the `han-communication:readability-editor` agent for one adversarial
+  rewrite pass before the self-check, matching the rule that reserves that pass for synthesis output
+  ([D2](artifacts/decision-log.md#d2-synthesis-rule-split)).
+- Every fact, every cross-reference identifier, and every citation survives the readability work unchanged
+  ([D3](artifacts/decision-log.md#d3-prose-regions-and-fidelity)).
+
+The seven skills are `plan-a-feature`, `plan-implementation`, `plan-a-phased-build`, `plan-work-items`, and
+`iterative-plan-review` (in `han-planning`), plus `coding-standard` and `test-planning` (in `han-coding`).
+
+## Actors and Triggers
+
+- **Actors** — the engineer who runs one of the seven skills, and the downstream reader of that skill's deliverable
+  (a stakeholder reading a spec or phased build, an implementer reading a plan or work items, an engineer following a
+  coding standard or a test plan).
+- **Triggers** — the engineer invokes one of the seven skills through its slash command or by name.
+- **Preconditions** — the foundational `han-communication` plugin is installed, so `han-communication:readability-guidance`
+  and the `han-communication:readability-editor` agent resolve. Every target plugin already declares a dependency chain
+  that reaches `han-communication`, and every target skill already grants the `Agent` tool the editor pass needs
+  ([D4](artifacts/decision-log.md#d4-no-tooling-or-dependency-changes)).
+
+## Primary Flow
+
+This flow describes what each target skill does once the readability steps are in place. The steps slot into each
+skill's existing workflow at the points named in the Coordinations section.
+
+1. Early in its workflow, before drafting the deliverable, the skill sources the shared readability standard by
+   invoking `han-communication:readability-guidance`. The standard is now in the skill's context.
+2. The skill drafts its deliverable into its own template, building the structural rules in as it writes (main point
+   first, descriptive headings, one idea per paragraph, technical detail after the prose).
+3. For the five synthesis skills only: once the full draft exists, the skill dispatches one
+   `han-communication:readability-editor` agent to audit and rewrite the deliverable's prose regions against the
+   standard, then applies the returned rewrite ([D2](artifacts/decision-log.md#d2-synthesis-rule-split)).
+4. The skill runs the standardized six-point readability self-check over the deliverable's prose regions, confirms each
+   criterion, and fixes any failure before presenting.
+5. The skill presents its deliverable to the user, unchanged in every fact from what the workflow produced.
+
+## Alternate Flows and States
+
+### Lightweight skills skip the editor pass
+
+- **Entry condition:** the running skill is `plan-work-items` or `iterative-plan-review`.
+- **Sequence:** the skill sources the standard (step 1), drafts (step 2), then runs the self-check (step 4) directly.
+  It does not dispatch the readability-editor agent.
+- **Exit:** the deliverable is presented, having passed the self-check but no separate rewrite pass. The self-check's
+  fidelity criterion is the only fact-preservation guard these skills carry, so it is mandatory
+  ([D2](artifacts/decision-log.md#d2-synthesis-rule-split)).
+
+### A skill writes companion artifact files alongside its primary deliverable
+
+- **Entry condition:** the skill produces companion files (for example `plan-a-feature`'s decision log, team findings,
+  and technical notes; `iterative-plan-review`'s findings and iteration files).
+- **Sequence:** the readability work targets the prose the skill authors for the user to read. Each skill names which
+  regions its readability pass covers, so structured cross-reference machinery is left alone
+  ([D5](artifacts/decision-log.md#d5-per-skill-scope-and-audience)).
+- **Exit:** the primary deliverable reads to the standard; the companion files keep their cross-reference integrity.
+
+## Edge Cases and Failure Modes
+
+| Condition | Required Behavior |
+| --------- | ----------------- |
+| The deliverable contains code fences, tables, diagram bodies, or citation identifiers (file:line, D#/T#/F# links). | The readability work operates on prose regions only and leaves those regions byte-for-byte unchanged. |
+| The readability-editor agent's rewrite would drop or alter a fact, a quantity, a named entity, or a stated qualifier. | The rewrite is rejected on that point; the fact is preserved with its precision intact. Fidelity wins over voice. |
+| A skill already runs a synthesis pass that owns final content (for example `plan-a-feature`'s project-manager synthesis). | The readability pass runs after that synthesis produces the final content, so it never fights an authoritative later step ([D6](artifacts/decision-log.md#d6-ordering-after-final-synthesis)). |
+| `iterative-plan-review` runs multiple review iterations over one plan. | The readability self-check runs once, on the converged plan before it is presented, not on every intermediate iteration ([D5](artifacts/decision-log.md#d5-per-skill-scope-and-audience)). |
+
+## Coordinations
+
+| Coordinating System | Direction | Interaction | Ordering / Consistency Requirement |
+| ------------------- | --------- | ----------- | ---------------------------------- |
+| `han-communication:readability-guidance` skill | outbound | Each target skill invokes it to source the standard into context. | Must run before the target skill drafts its deliverable. |
+| `han-communication:readability-editor` agent | outbound | The five synthesis skills dispatch it for one adversarial rewrite pass. | Must run after the full draft exists and after any final synthesis step, and before the self-check. |
+| The readability standard's own definition (`readability-rule.md`, `writing-voice.md`) | inbound | Sourced transitively through the guidance skill; never vendored or copied into the target skills. | The target skills reference the single canonical copy, so a change to the standard reaches all seven with no edit to them ([D7](artifacts/decision-log.md#d7-single-canonical-source)). |
+
+## Out of Scope
+
+- Changing the readability standard itself, the `readability-guidance` skill, or the `readability-editor` agent. This
+  feature only makes the seven skills consume the existing standard.
+- Adding readability integration to skills that already have it, that do not author user-facing prose (`tdd`,
+  `refactor`), or that inherit their prose from an upstream skill (the Confluence, Jira, GitHub, and Linear publishing
+  wrappers; the work-items publishers). Those inherited gaps close when their upstream source skill is integrated
+  ([D8](artifacts/decision-log.md#d8-seven-skill-scope)).
+- The long-form documentation updates for the seven skills. Documentation maintenance is handled by the repo's own
+  documentation skill after these edits land.
+
+## Open Items
+
+- **OI-1:** Populated by the review team and project-manager synthesis in later steps.
+  - **Resolves when:** review is complete.
+  - **Blocks implementation:** No.
+
+## Summary
+
+- **Outcome delivered:** Seven prose-authoring skills source and apply the shared readability standard before
+  presenting their deliverables.
+- **Primary actors:** The engineer running each skill and the downstream reader of its output.
+- **Decisions settled by evidence:** 7 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Decisions settled by user input:** 1 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Sub-agents consulted:** pending review — see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Key adjustments from review:** pending — see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Remaining open items:** 1

--- a/docs/plans/readability-in-planning-coding/feature-specification.md
+++ b/docs/plans/readability-in-planning-coding/feature-specification.md
@@ -99,7 +99,7 @@ skill's existing workflow at the points named in the Coordinations section.
 | ------------------- | --------- | ----------- | ---------------------------------- |
 | `han-communication:readability-guidance` skill | outbound | Each target skill invokes it to source the standard into context. | Must run before the target skill drafts its deliverable. |
 | `han-communication:readability-editor` agent | outbound | The five prose-document skills dispatch it for one adversarial rewrite pass, passing the named reader and no rule path. | Must run after the final content exists and after any final synthesis or review step, and before the self-check. |
-| The readability standard's scope text (`readability-rule.md`) and the `readability-guidance` skill's in-context summary | inbound and updated | The seven skills reference the single canonical standard rather than vendoring it. This work also clarifies the standard's "who reads reader-facing output" scope text so Han's plans-of-record are recognized as reader-facing, and echoes that clarification in the `readability-guidance` skill's in-context summary so both surfaces agree ([D9](artifacts/decision-log.md#d9-reader-facing-scope-reconciliation)). | A change to the standard reaches all seven skills with no edit to them, because they reference the one canonical copy ([D7](artifacts/decision-log.md#d7-reference-the-single-canonical-standard-never-vendor-it)). |
+| The readability standard's scope text (`readability-rule.md`) and the `readability-guidance` skill's in-context summary | inbound and updated | The seven skills reference the single canonical standard rather than vendoring it. This work also clarifies the standard's "who reads reader-facing output" scope text so Han's plans-of-record are recognized as reader-facing, and adds the same clarified scope test to the `readability-guidance` skill's own instructions, which today surface the scope only by having the caller read the canonical rule, so a caller sees the clarified test in context ([D9](artifacts/decision-log.md#d9-reader-facing-scope-reconciliation)). | A change to the standard reaches all seven skills with no edit to them, because they reference the one canonical copy ([D7](artifacts/decision-log.md#d7-reference-the-single-canonical-standard-never-vendor-it)). |
 
 ## Out of Scope
 
@@ -118,8 +118,9 @@ skill's existing workflow at the points named in the Coordinations section.
 ## Open Items
 
 None. The one prior open item — whether the scope-text clarification is also reflected in the `readability-guidance`
-skill's in-context summary — is now decided: the clarification is echoed there as well as in the canonical
-`readability-rule.md`, so both surfaces agree ([D9](artifacts/decision-log.md#d9-reader-facing-scope-reconciliation)).
+skill — is now decided: this work adds a brief restatement of the clarified scope test to that skill's own instructions
+(it carries none today), so a caller sees the clarified test in context and not only in the canonical
+`readability-rule.md` ([D9](artifacts/decision-log.md#d9-reader-facing-scope-reconciliation)).
 
 ## Summary
 
@@ -135,3 +136,16 @@ skill's in-context summary — is now decided: the clarification is echoed there
   full/lightweight split around deliverable type rather than "synthesis pass", and reconciled the feature against the
   standard's own reader-facing scope text — see [artifacts/team-findings.md](artifacts/team-findings.md)
 - **Remaining open items:** 0
+
+## Review History
+
+- **Review mode:** lightweight
+- **Spec-aware mode:** engaged
+- **Iterations completed:** 1 — see [artifacts/review-iteration-history.md](artifacts/review-iteration-history.md)
+- **Findings raised:** 2 — see [artifacts/review-findings.md](artifacts/review-findings.md). By resolution: 1 by
+  evidence (F13, wording accuracy), 1 confirmation requiring no change (F14).
+- **Assumptions challenged across all passes:** Verified against the codebase that `readability-guidance` carries no
+  reader-facing scope summary today (F13) and that `han-planning` declares only `han-core` (F14).
+- **Ambiguities resolved, and how:** The D9 "echo in readability-guidance" wording was made precise — the work adds a
+  scope-test restatement to that skill's instructions rather than editing a summary that does not exist.
+- **Open items remaining:** 0 — none block implementation.

--- a/docs/plans/readability-in-planning-coding/feature-specification.md
+++ b/docs/plans/readability-in-planning-coding/feature-specification.md
@@ -20,9 +20,9 @@ Concretely, when an engineer runs one of these skills:
   presenting ([D5](artifacts/decision-log.md#d5-per-skill-scope-and-named-audience)).
 - The five prose-document skills additionally dispatch the `han-communication:readability-editor` agent for one
   adversarial rewrite pass before the self-check
-  ([D2](artifacts/decision-log.md#d2-prose-document-vs-structured-artifact-split)).
+  ([D2](artifacts/decision-log.md#d2-prose-document-vs-structured-artifact-split-for-the-editor-pass)).
 - Every fact, every cross-reference identifier, and every citation survives the readability work unchanged
-  ([D3](artifacts/decision-log.md#d3-prose-regions-and-fidelity)).
+  ([D3](artifacts/decision-log.md#d3-prose-regions-only-scope-and-fact-fidelity)).
 
 The seven skills are `plan-a-feature`, `plan-implementation`, `plan-a-phased-build`, `plan-work-items`, and
 `iterative-plan-review` (in `han-planning`), plus `coding-standard` and `test-planning` (in `han-coding`).
@@ -38,7 +38,7 @@ The seven skills are `plan-a-feature`, `plan-implementation`, `plan-a-phased-bui
   `han-coding` plugin already declares `han-communication` directly; the `han-planning` plugin gains a direct
   `han-communication` dependency as part of this work, because it currently reaches the plugin only transitively through
   `han-core` and Han's convention requires every prose-producing plugin to depend on `han-communication` directly
-  ([D4](artifacts/decision-log.md#d4-han-planning-gains-a-direct-dependency)). Every target skill already grants the
+  ([D4](artifacts/decision-log.md#d4-han-planning-gains-a-direct-han-communication-dependency)). Every target skill already grants the
   `Agent` tool the editor pass needs, so no tool grants change.
 
 ## Primary Flow
@@ -52,11 +52,11 @@ skill's existing workflow at the points named in the Coordinations section.
 2. The skill produces its deliverable's final content through its existing workflow, including any review or synthesis
    step it already runs. When a dispatched agent authors the final content, the readability pass in the next steps is
    what carries voice into that content, since the standard lives in the skill's context rather than the agent's
-   ([D6](artifacts/decision-log.md#d6-readability-pass-runs-after-final-content)).
+   ([D6](artifacts/decision-log.md#d6-readability-pass-runs-after-the-final-content-exists)).
 3. For the five prose-document skills only: once the final content exists, the skill dispatches one
    `han-communication:readability-editor` agent to audit and rewrite the deliverable's prose regions against the
    standard, passing the skill's named reader and no rule path (the editor reads its own canonical rule), then applies
-   the returned rewrite ([D2](artifacts/decision-log.md#d2-prose-document-vs-structured-artifact-split)).
+   the returned rewrite ([D2](artifacts/decision-log.md#d2-prose-document-vs-structured-artifact-split-for-the-editor-pass)).
 4. The skill runs the standardized six-point readability self-check over the prose regions it authored or changed this
    run, holding the skill's named reader, confirms each criterion, and fixes any failure before presenting
    ([D5](artifacts/decision-log.md#d5-per-skill-scope-and-named-audience)).
@@ -71,7 +71,7 @@ skill's existing workflow at the points named in the Coordinations section.
   (step 4) directly. It does not dispatch the readability-editor agent.
 - **Exit:** the deliverable is presented, having passed the self-check but no separate rewrite pass. The self-check's
   fidelity criterion is the only fact-preservation guard these skills carry, so it is mandatory
-  ([D2](artifacts/decision-log.md#d2-prose-document-vs-structured-artifact-split)).
+  ([D2](artifacts/decision-log.md#d2-prose-document-vs-structured-artifact-split-for-the-editor-pass)).
 
 ### An in-place skill edits an existing document
 
@@ -89,8 +89,8 @@ skill's existing workflow at the points named in the Coordinations section.
 | --------- | ----------------- |
 | The deliverable contains code fences, tables, diagram bodies, frontmatter, or citation identifiers (file:line, D#/T#/F# links, work-item IDs). | The readability work operates on prose regions only and leaves those regions unchanged. |
 | The readability-editor agent's rewrite would drop or alter a fact, a quantity, a named entity, or a stated qualifier. | The rewrite is rejected on that point; the fact is preserved with its precision intact. Fidelity wins over voice. |
-| A dispatched agent (for example a project-manager synthesis) authors the deliverable's final content. | The standard reaches that content through the after-the-fact pass, not through the authoring agent: the editor pass for the five prose-document skills, the self-check for the two structured-artifact skills ([D6](artifacts/decision-log.md#d6-readability-pass-runs-after-final-content)). |
-| A skill already runs a synthesis, review, or IA step near the end of its workflow (`plan-a-feature`'s project-manager synthesis; the review steps in `plan-a-phased-build`, `coding-standard`, and `test-planning`). | The readability pass runs after that step produces the final content, so it never fights an authoritative later step ([D6](artifacts/decision-log.md#d6-readability-pass-runs-after-final-content)). |
+| A dispatched agent (for example a project-manager synthesis) authors the deliverable's final content. | The standard reaches that content through the after-the-fact pass, not through the authoring agent: the editor pass for the five prose-document skills, the self-check for the two structured-artifact skills ([D6](artifacts/decision-log.md#d6-readability-pass-runs-after-the-final-content-exists)). |
+| A skill already runs a synthesis, review, or IA step near the end of its workflow (`plan-a-feature`'s project-manager synthesis; the review steps in `plan-a-phased-build`, `coding-standard`, and `test-planning`). | The readability pass runs after that step produces the final content, so it never fights an authoritative later step ([D6](artifacts/decision-log.md#d6-readability-pass-runs-after-the-final-content-exists)). |
 | `plan-a-phased-build` has already asked the user which audience the outline targets (engineering, mixed, or customer-facing). | The readability pass holds that per-run audience, rather than a fixed frame ([D5](artifacts/decision-log.md#d5-per-skill-scope-and-named-audience)). |
 
 ## Coordinations
@@ -99,7 +99,7 @@ skill's existing workflow at the points named in the Coordinations section.
 | ------------------- | --------- | ----------- | ---------------------------------- |
 | `han-communication:readability-guidance` skill | outbound | Each target skill invokes it to source the standard into context. | Must run before the target skill drafts its deliverable. |
 | `han-communication:readability-editor` agent | outbound | The five prose-document skills dispatch it for one adversarial rewrite pass, passing the named reader and no rule path. | Must run after the final content exists and after any final synthesis or review step, and before the self-check. |
-| The readability standard's scope text (`readability-rule.md`) | inbound and updated | The seven skills reference the single canonical standard rather than vendoring it. This work also clarifies the standard's "who reads reader-facing output" scope text so Han's plans-of-record are recognized as reader-facing ([D9](artifacts/decision-log.md#d9-reader-facing-scope-reconciliation)). | A change to the standard reaches all seven skills with no edit to them, because they reference the one canonical copy ([D7](artifacts/decision-log.md#d7-single-canonical-source)). |
+| The readability standard's scope text (`readability-rule.md`) | inbound and updated | The seven skills reference the single canonical standard rather than vendoring it. This work also clarifies the standard's "who reads reader-facing output" scope text so Han's plans-of-record are recognized as reader-facing ([D9](artifacts/decision-log.md#d9-reader-facing-scope-reconciliation)). | A change to the standard reaches all seven skills with no edit to them, because they reference the one canonical copy ([D7](artifacts/decision-log.md#d7-reference-the-single-canonical-standard-never-vendor-it)). |
 
 ## Out of Scope
 

--- a/docs/plans/readability-in-planning-coding/feature-specification.md
+++ b/docs/plans/readability-in-planning-coding/feature-specification.md
@@ -1,20 +1,26 @@
 # Feature Specification: Readability Standard in the Planning and Coding Skills
 
-Wire Han's shared readability standard into the seven skills that author user-facing prose but currently skip it, so
-each skill's deliverable is drafted in voice and checked against the standard before it reaches the user.
+Wire Han's shared readability standard into the seven skills that author reader-facing prose but currently skip it, and
+clarify the standard's own scope text so those seven deliverables are recognized as reader-facing, so each skill's
+output is drafted in voice and checked against the standard before it reaches the user.
 
 ## Outcome
 
 Each of the seven target skills sources the shared readability standard while it drafts and holds its output to that
-standard before presenting it. Concretely, when an engineer runs one of these skills:
+standard before presenting it. The standard's scope text is also clarified so a reader cannot mistake these deliverables
+for the machine-only pipeline artifacts the standard excludes
+([D9](artifacts/decision-log.md#d9-reader-facing-scope-reconciliation)).
+
+Concretely, when an engineer runs one of these skills:
 
 - The skill sources `han-communication:readability-guidance` into its context before it writes its deliverable, and
-  drafts in the shared voice ([D1](artifacts/decision-log.md#d1-canonical-integration-pattern)).
-- After the draft exists, the skill runs the standardized six-point readability self-check over the deliverable's prose
-  regions and fixes every failure before presenting.
-- The five synthesis skills additionally dispatch the `han-communication:readability-editor` agent for one adversarial
-  rewrite pass before the self-check, matching the rule that reserves that pass for synthesis output
-  ([D2](artifacts/decision-log.md#d2-synthesis-rule-split)).
+  drafts skill-authored prose in the shared voice ([D1](artifacts/decision-log.md#d1-canonical-integration-pattern)).
+- After the deliverable's final content exists, the skill runs the standardized six-point readability self-check over
+  the prose it authored or changed this run, holding the skill's named reader, and fixes every failure before
+  presenting ([D5](artifacts/decision-log.md#d5-per-skill-scope-and-named-audience)).
+- The five prose-document skills additionally dispatch the `han-communication:readability-editor` agent for one
+  adversarial rewrite pass before the self-check
+  ([D2](artifacts/decision-log.md#d2-prose-document-vs-structured-artifact-split)).
 - Every fact, every cross-reference identifier, and every citation survives the readability work unchanged
   ([D3](artifacts/decision-log.md#d3-prose-regions-and-fidelity)).
 
@@ -27,10 +33,13 @@ The seven skills are `plan-a-feature`, `plan-implementation`, `plan-a-phased-bui
   (a stakeholder reading a spec or phased build, an implementer reading a plan or work items, an engineer following a
   coding standard or a test plan).
 - **Triggers** — the engineer invokes one of the seven skills through its slash command or by name.
-- **Preconditions** — the foundational `han-communication` plugin is installed, so `han-communication:readability-guidance`
-  and the `han-communication:readability-editor` agent resolve. Every target plugin already declares a dependency chain
-  that reaches `han-communication`, and every target skill already grants the `Agent` tool the editor pass needs
-  ([D4](artifacts/decision-log.md#d4-no-tooling-or-dependency-changes)).
+- **Preconditions** — the foundational `han-communication` plugin resolves for every target skill, so
+  `han-communication:readability-guidance` and the `han-communication:readability-editor` agent are reachable. The
+  `han-coding` plugin already declares `han-communication` directly; the `han-planning` plugin gains a direct
+  `han-communication` dependency as part of this work, because it currently reaches the plugin only transitively through
+  `han-core` and Han's convention requires every prose-producing plugin to depend on `han-communication` directly
+  ([D4](artifacts/decision-log.md#d4-han-planning-gains-a-direct-dependency)). Every target skill already grants the
+  `Agent` tool the editor pass needs, so no tool grants change.
 
 ## Primary Flow
 
@@ -38,77 +47,93 @@ This flow describes what each target skill does once the readability steps are i
 skill's existing workflow at the points named in the Coordinations section.
 
 1. Early in its workflow, before drafting the deliverable, the skill sources the shared readability standard by
-   invoking `han-communication:readability-guidance`. The standard is now in the skill's context.
-2. The skill drafts its deliverable into its own template, building the structural rules in as it writes (main point
-   first, descriptive headings, one idea per paragraph, technical detail after the prose).
-3. For the five synthesis skills only: once the full draft exists, the skill dispatches one
+   invoking `han-communication:readability-guidance`. The standard is now in the skill's context, and the skill drafts
+   its own prose in voice.
+2. The skill produces its deliverable's final content through its existing workflow, including any review or synthesis
+   step it already runs. When a dispatched agent authors the final content, the readability pass in the next steps is
+   what carries voice into that content, since the standard lives in the skill's context rather than the agent's
+   ([D6](artifacts/decision-log.md#d6-readability-pass-runs-after-final-content)).
+3. For the five prose-document skills only: once the final content exists, the skill dispatches one
    `han-communication:readability-editor` agent to audit and rewrite the deliverable's prose regions against the
-   standard, then applies the returned rewrite ([D2](artifacts/decision-log.md#d2-synthesis-rule-split)).
-4. The skill runs the standardized six-point readability self-check over the deliverable's prose regions, confirms each
-   criterion, and fixes any failure before presenting.
+   standard, passing the skill's named reader and no rule path (the editor reads its own canonical rule), then applies
+   the returned rewrite ([D2](artifacts/decision-log.md#d2-prose-document-vs-structured-artifact-split)).
+4. The skill runs the standardized six-point readability self-check over the prose regions it authored or changed this
+   run, holding the skill's named reader, confirms each criterion, and fixes any failure before presenting
+   ([D5](artifacts/decision-log.md#d5-per-skill-scope-and-named-audience)).
 5. The skill presents its deliverable to the user, unchanged in every fact from what the workflow produced.
 
 ## Alternate Flows and States
 
-### Lightweight skills skip the editor pass
+### Structured-artifact skills skip the editor pass
 
 - **Entry condition:** the running skill is `plan-work-items` or `iterative-plan-review`.
-- **Sequence:** the skill sources the standard (step 1), drafts (step 2), then runs the self-check (step 4) directly.
-  It does not dispatch the readability-editor agent.
+- **Sequence:** the skill sources the standard (step 1), produces its content (step 2), then runs the self-check
+  (step 4) directly. It does not dispatch the readability-editor agent.
 - **Exit:** the deliverable is presented, having passed the self-check but no separate rewrite pass. The self-check's
   fidelity criterion is the only fact-preservation guard these skills carry, so it is mandatory
-  ([D2](artifacts/decision-log.md#d2-synthesis-rule-split)).
+  ([D2](artifacts/decision-log.md#d2-prose-document-vs-structured-artifact-split)).
 
-### A skill writes companion artifact files alongside its primary deliverable
+### An in-place skill edits an existing document
 
-- **Entry condition:** the skill produces companion files (for example `plan-a-feature`'s decision log, team findings,
-  and technical notes; `iterative-plan-review`'s findings and iteration files).
-- **Sequence:** the readability work targets the prose the skill authors for the user to read. Each skill names which
-  regions its readability pass covers, so structured cross-reference machinery is left alone
-  ([D5](artifacts/decision-log.md#d5-per-skill-scope-and-audience)).
-- **Exit:** the primary deliverable reads to the standard; the companion files keep their cross-reference integrity.
+- **Entry condition:** the skill changes an existing document rather than authoring one from scratch
+  (`iterative-plan-review` refining a plan across iterations; `coding-standard` in its update mode).
+- **Sequence:** the readability pass covers the prose regions this run authored or changed, not pre-existing prose the
+  skill left untouched. The self-check runs once, on the converged document before it is presented, over those changed
+  regions ([D5](artifacts/decision-log.md#d5-per-skill-scope-and-named-audience)).
+- **Exit:** the changed prose reads to the standard; prose the run never touched is not re-edited, and cross-reference
+  integrity is preserved.
 
 ## Edge Cases and Failure Modes
 
 | Condition | Required Behavior |
 | --------- | ----------------- |
-| The deliverable contains code fences, tables, diagram bodies, or citation identifiers (file:line, D#/T#/F# links). | The readability work operates on prose regions only and leaves those regions byte-for-byte unchanged. |
+| The deliverable contains code fences, tables, diagram bodies, frontmatter, or citation identifiers (file:line, D#/T#/F# links, work-item IDs). | The readability work operates on prose regions only and leaves those regions unchanged. |
 | The readability-editor agent's rewrite would drop or alter a fact, a quantity, a named entity, or a stated qualifier. | The rewrite is rejected on that point; the fact is preserved with its precision intact. Fidelity wins over voice. |
-| A skill already runs a synthesis pass that owns final content (for example `plan-a-feature`'s project-manager synthesis). | The readability pass runs after that synthesis produces the final content, so it never fights an authoritative later step ([D6](artifacts/decision-log.md#d6-ordering-after-final-synthesis)). |
-| `iterative-plan-review` runs multiple review iterations over one plan. | The readability self-check runs once, on the converged plan before it is presented, not on every intermediate iteration ([D5](artifacts/decision-log.md#d5-per-skill-scope-and-audience)). |
+| A dispatched agent (for example a project-manager synthesis) authors the deliverable's final content. | The standard reaches that content through the after-the-fact pass, not through the authoring agent: the editor pass for the five prose-document skills, the self-check for the two structured-artifact skills ([D6](artifacts/decision-log.md#d6-readability-pass-runs-after-final-content)). |
+| A skill already runs a synthesis, review, or IA step near the end of its workflow (`plan-a-feature`'s project-manager synthesis; the review steps in `plan-a-phased-build`, `coding-standard`, and `test-planning`). | The readability pass runs after that step produces the final content, so it never fights an authoritative later step ([D6](artifacts/decision-log.md#d6-readability-pass-runs-after-final-content)). |
+| `plan-a-phased-build` has already asked the user which audience the outline targets (engineering, mixed, or customer-facing). | The readability pass holds that per-run audience, rather than a fixed frame ([D5](artifacts/decision-log.md#d5-per-skill-scope-and-named-audience)). |
 
 ## Coordinations
 
 | Coordinating System | Direction | Interaction | Ordering / Consistency Requirement |
 | ------------------- | --------- | ----------- | ---------------------------------- |
 | `han-communication:readability-guidance` skill | outbound | Each target skill invokes it to source the standard into context. | Must run before the target skill drafts its deliverable. |
-| `han-communication:readability-editor` agent | outbound | The five synthesis skills dispatch it for one adversarial rewrite pass. | Must run after the full draft exists and after any final synthesis step, and before the self-check. |
-| The readability standard's own definition (`readability-rule.md`, `writing-voice.md`) | inbound | Sourced transitively through the guidance skill; never vendored or copied into the target skills. | The target skills reference the single canonical copy, so a change to the standard reaches all seven with no edit to them ([D7](artifacts/decision-log.md#d7-single-canonical-source)). |
+| `han-communication:readability-editor` agent | outbound | The five prose-document skills dispatch it for one adversarial rewrite pass, passing the named reader and no rule path. | Must run after the final content exists and after any final synthesis or review step, and before the self-check. |
+| The readability standard's scope text (`readability-rule.md`) | inbound and updated | The seven skills reference the single canonical standard rather than vendoring it. This work also clarifies the standard's "who reads reader-facing output" scope text so Han's plans-of-record are recognized as reader-facing ([D9](artifacts/decision-log.md#d9-reader-facing-scope-reconciliation)). | A change to the standard reaches all seven skills with no edit to them, because they reference the one canonical copy ([D7](artifacts/decision-log.md#d7-single-canonical-source)). |
 
 ## Out of Scope
 
-- Changing the readability standard itself, the `readability-guidance` skill, or the `readability-editor` agent. This
-  feature only makes the seven skills consume the existing standard.
-- Adding readability integration to skills that already have it, that do not author user-facing prose (`tdd`,
-  `refactor`), or that inherit their prose from an upstream skill (the Confluence, Jira, GitHub, and Linear publishing
-  wrappers; the work-items publishers). Those inherited gaps close when their upstream source skill is integrated
-  ([D8](artifacts/decision-log.md#d8-seven-skill-scope)).
+- Changing what the readability standard *requires* (the self-check criteria, the voice profile, the fidelity rule).
+  The only edit to the standard is the narrow scope-text clarification in D9; the rules the standard enforces are
+  untouched.
+- Adding readability integration to skills that already have it, that do not author prose (`tdd`, `refactor`), or that
+  only republish or transform prose an upstream source produced. This includes the publishing wrappers (Confluence,
+  Jira, GitHub, Linear) and the work-items publishers, whose gaps close when their upstream source skill is integrated,
+  and `markdown-to-confluence`, which republishes user-provided prose verbatim and authors none of its own. This list
+  is illustrative, not the full enumeration; the full 38-skill classification is recorded under
+  [D8](artifacts/decision-log.md#d8-scope-is-exactly-these-seven-skills).
 - The long-form documentation updates for the seven skills. Documentation maintenance is handled by the repo's own
   documentation skill after these edits land.
 
 ## Open Items
 
-- **OI-1:** Populated by the review team and project-manager synthesis in later steps.
-  - **Resolves when:** review is complete.
+- **OI-1:** Whether the D9 scope-text clarification should also be reflected in the `readability-guidance` skill's own
+  in-context summary of who is reader-facing, or only in the canonical `readability-rule.md`.
+  - **Resolves when:** implementation confirms whether the guidance skill restates the scope test verbatim or points to
+    the rule.
   - **Blocks implementation:** No.
 
 ## Summary
 
 - **Outcome delivered:** Seven prose-authoring skills source and apply the shared readability standard before
-  presenting their deliverables.
+  presenting their deliverables, and the standard's scope text is clarified to recognize those deliverables as
+  reader-facing.
 - **Primary actors:** The engineer running each skill and the downstream reader of its output.
 - **Decisions settled by evidence:** 7 — see [artifacts/decision-log.md](artifacts/decision-log.md)
-- **Decisions settled by user input:** 1 — see [artifacts/decision-log.md](artifacts/decision-log.md)
-- **Sub-agents consulted:** pending review — see [artifacts/team-findings.md](artifacts/team-findings.md)
-- **Key adjustments from review:** pending — see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Decisions settled by user input:** 2 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Sub-agents consulted:** han-core:junior-developer, han-core:gap-analyzer — see
+  [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Key adjustments from review:** Added a direct `han-communication` dependency for `han-planning`, reframed the
+  full/lightweight split around deliverable type rather than "synthesis pass", and reconciled the feature against the
+  standard's own reader-facing scope text — see [artifacts/team-findings.md](artifacts/team-findings.md)
 - **Remaining open items:** 1

--- a/docs/plans/readability-in-planning-coding/feature-specification.md
+++ b/docs/plans/readability-in-planning-coding/feature-specification.md
@@ -99,7 +99,7 @@ skill's existing workflow at the points named in the Coordinations section.
 | ------------------- | --------- | ----------- | ---------------------------------- |
 | `han-communication:readability-guidance` skill | outbound | Each target skill invokes it to source the standard into context. | Must run before the target skill drafts its deliverable. |
 | `han-communication:readability-editor` agent | outbound | The five prose-document skills dispatch it for one adversarial rewrite pass, passing the named reader and no rule path. | Must run after the final content exists and after any final synthesis or review step, and before the self-check. |
-| The readability standard's scope text (`readability-rule.md`) | inbound and updated | The seven skills reference the single canonical standard rather than vendoring it. This work also clarifies the standard's "who reads reader-facing output" scope text so Han's plans-of-record are recognized as reader-facing ([D9](artifacts/decision-log.md#d9-reader-facing-scope-reconciliation)). | A change to the standard reaches all seven skills with no edit to them, because they reference the one canonical copy ([D7](artifacts/decision-log.md#d7-reference-the-single-canonical-standard-never-vendor-it)). |
+| The readability standard's scope text (`readability-rule.md`) and the `readability-guidance` skill's in-context summary | inbound and updated | The seven skills reference the single canonical standard rather than vendoring it. This work also clarifies the standard's "who reads reader-facing output" scope text so Han's plans-of-record are recognized as reader-facing, and echoes that clarification in the `readability-guidance` skill's in-context summary so both surfaces agree ([D9](artifacts/decision-log.md#d9-reader-facing-scope-reconciliation)). | A change to the standard reaches all seven skills with no edit to them, because they reference the one canonical copy ([D7](artifacts/decision-log.md#d7-reference-the-single-canonical-standard-never-vendor-it)). |
 
 ## Out of Scope
 
@@ -117,11 +117,9 @@ skill's existing workflow at the points named in the Coordinations section.
 
 ## Open Items
 
-- **OI-1:** Whether the D9 scope-text clarification should also be reflected in the `readability-guidance` skill's own
-  in-context summary of who is reader-facing, or only in the canonical `readability-rule.md`.
-  - **Resolves when:** implementation confirms whether the guidance skill restates the scope test verbatim or points to
-    the rule.
-  - **Blocks implementation:** No.
+None. The one prior open item — whether the scope-text clarification is also reflected in the `readability-guidance`
+skill's in-context summary — is now decided: the clarification is echoed there as well as in the canonical
+`readability-rule.md`, so both surfaces agree ([D9](artifacts/decision-log.md#d9-reader-facing-scope-reconciliation)).
 
 ## Summary
 
@@ -136,4 +134,4 @@ skill's existing workflow at the points named in the Coordinations section.
 - **Key adjustments from review:** Added a direct `han-communication` dependency for `han-planning`, reframed the
   full/lightweight split around deliverable type rather than "synthesis pass", and reconciled the feature against the
   standard's own reader-facing scope text — see [artifacts/team-findings.md](artifacts/team-findings.md)
-- **Remaining open items:** 1
+- **Remaining open items:** 0

--- a/han-coding/skills/coding-standard/SKILL.md
+++ b/han-coding/skills/coding-standard/SKILL.md
@@ -174,6 +174,11 @@ When converting an existing document into a coding standard:
 
 ## Step 6: Write the Coding Standard
 
+Before writing, invoke `han-communication:readability-guidance` to source the shared readability standard into your
+context, then apply it as you write the standard's prose (Purpose, Rationale, when-to-apply, when-not-to-apply, and
+example commentary), holding the named audience: the engineer who must follow the standard. The frame governs how a fact
+is said, never whether a required fact appears — keep the exact rules, thresholds, and anchors the standard commits to.
+
 Read the **durable-reference rule** in [durable-references.md](./references/durable-references.md) and apply it
 throughout this step — this is the rule's **authoring mode** — all rules apply. For any candidate Step 4 flagged for
 engineer review — or any example you cannot cleanly anchor yourself — surface it to the engineer with a recommended
@@ -425,3 +430,28 @@ Read back the coding standard file and confirm:
     that the failing check produced an applied revision
 12. Confirm actionable edits from Step 9 were applied, or that any skipped edits were surfaced to the user
 13. If any issues are found, fix them
+
+## Step 11: Readability Pass
+
+Once verification in Step 10 passes and the standard is final, dispatch `han-communication:readability-editor` (one Agent
+call) to audit and rewrite the standard's prose against the readability standard. Scope the pass by mode: in create or
+convert mode (Step 1), the newly authored prose is in scope; in update mode, only the region this run edited is in scope
+— do not rewrite prose the run did not touch. Pass the editor the file path, the in-scope region, and the named audience:
+the engineer who must follow the standard; the editor reads han-communication's own canonical rule, so pass no rule path.
+It must preserve every fact and operate on prose regions only — never inside the YAML frontmatter, code fences, or the
+durable-reference anchors, which must survive unchanged so they still resolve. Apply its rewrite to the file.
+
+Then run the standardized readability self-check (the shared standard is in your context from
+`han-communication:readability-guidance`) over the same in-scope prose regions only — never inside the YAML frontmatter,
+code fences, or durable-reference anchors. Confirm each criterion and fix any failure before presenting:
+
+1. The opening line states the main point.
+2. Each heading names its content and is not a generic label.
+3. Each paragraph carries one idea and leads with it.
+4. No sentence runs past the soft length flag (about thirty words) without reason.
+5. No word from the vocabulary blocklist (the writing-voice profile's "Avoided words and phrases" and "AI slop to avoid"
+   lists) is present.
+6. Every fact is preserved — every claim, quantity, named entity, and stated condition or qualifier survives with its
+   precision intact.
+
+Fidelity wins: the standard governs how the content is said, never whether a required fact appears.

--- a/han-coding/skills/test-planning/SKILL.md
+++ b/han-coding/skills/test-planning/SKILL.md
@@ -158,6 +158,11 @@ Combine findings from every dispatched agent into a unified, prioritized test pl
 
 ## Step 4: Generate Output
 
+Before generating, invoke `han-communication:readability-guidance` to source the shared readability standard into your
+context, then apply it as you write the plan's plain-language spine (Summary, What Needs Testing and Why, What Each Test
+Covers), holding the named audience: the engineer who will implement the tests. The frame governs how a fact is said,
+never whether a required fact appears — keep the file:line references, test levels, and TP-IDs the plan depends on.
+
 Use the template at [template.md](./references/template.md) for the output structure. The test plan leads with plain
 language and defers the implementation detail.
 
@@ -225,3 +230,25 @@ written to a file, pass that path instead and let the agent read it.
 
 Apply every actionable edit the agents return. For findings that require author judgment (scope or audience ambiguity),
 surface them to the user with a recommended resolution; do not silently resolve.
+
+Once every actionable edit is applied and the plan is final, dispatch `han-communication:readability-editor` (one Agent
+call) to audit and rewrite the plan's prose against the readability standard. If the plan was written to a file, pass the
+editor that file path; if it is in-channel, pass the plan text and apply the returned rewrite. Also pass the named
+audience: the engineer who will implement the tests; the editor reads han-communication's own canonical rule, so pass no
+rule path. It must preserve every fact and operate on prose regions only — never inside code fences, tables, or the
+TP-NNN test identifiers, which must survive unchanged so they still resolve. Apply its rewrite to the plan.
+
+Then run the standardized readability self-check (the shared standard is in your context from
+`han-communication:readability-guidance`) over the plan's prose regions only — never inside code fences, tables, or the
+TP-NNN identifiers. Confirm each criterion and fix any failure before presenting:
+
+1. The opening line states the main point.
+2. Each heading names its content and is not a generic label.
+3. Each paragraph carries one idea and leads with it.
+4. No sentence runs past the soft length flag (about thirty words) without reason.
+5. No word from the vocabulary blocklist (the writing-voice profile's "Avoided words and phrases" and "AI slop to avoid"
+   lists) is present.
+6. Every fact is preserved — every claim, quantity, named entity, and stated condition or qualifier survives with its
+   precision intact.
+
+Fidelity wins: the standard governs how the content is said, never whether a required fact appears.

--- a/han-communication/references/readability-rule.md
+++ b/han-communication/references/readability-rule.md
@@ -18,9 +18,11 @@ stacked instruction block reproduces the failure it exists to dodge, so a skill 
 ## Who reads reader-facing output
 
 A skill is **reader-facing** when its primary deliverable is human-facing prose that a non-author reads end to end to
-understand something: a finding, a summary, a plan of record, a document. Skills whose primary output is code, or a
-structured specification / plan / work-item / standard consumed mainly by downstream skills, are not reader-facing and
-do not apply this rule.
+understand something: a finding, a summary, a plan of record, a document. A structured specification, plan, phased build,
+work-item list, coding standard, or test plan counts as reader-facing when a human reads it end to end — to approve it,
+follow it, or build from it — even when downstream skills also consume it. Only an artifact consumed purely as a pipeline
+input, with no human reading it end to end, is not reader-facing; code output is likewise not reader-facing. Neither
+applies this rule.
 
 ## The audience frame
 

--- a/han-communication/skills/readability-guidance/SKILL.md
+++ b/han-communication/skills/readability-guidance/SKILL.md
@@ -20,6 +20,13 @@ and finish it.
 This skill is **inline** — it runs in your context, not an isolated one, so the standard it surfaces stays available to
 you after it returns. Do not treat anything here as a stopping point or a final answer.
 
+## Which outputs this standard covers
+
+A structured specification, plan, phased build, work-item list, coding standard, or test plan is reader-facing whenever a
+human reads it end to end — to approve it, follow it, or build from it — even when downstream skills also consume it. Only
+an artifact consumed purely as a pipeline input, with no human reading it end to end, falls outside the standard. If a
+human reads your deliverable end to end, apply the standard to it.
+
 ## Step 1: Read the canonical standard
 
 Read both canonical reference files, in this order, so their full content enters your context:

--- a/han-planning/.claude-plugin/plugin.json
+++ b/han-planning/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "han-planning",
   "description": "Planning-facing skills for the Han suite: specifying, planning, sequencing, breaking down, and stress-testing work before implementation. Home of plan-a-feature (build a feature specification from scratch through a relentless, evidence-based interview that walks the design tree), plan-implementation (turn a feature specification into an implementation plan through a project-manager-led team conversation), plan-a-phased-build (split a body of context into a sequence of independently demoable vertical-slice phases), plan-work-items (break a trusted implementation plan into independently-grabbable, atomic work items), and iterative-plan-review (stress-test an existing plan through multiple codebase-grounded review passes). Depends on han-core; bundled by the han meta-plugin.",
   "version": "2.0.4",
-  "dependencies": ["han-core"]
+  "dependencies": ["han-communication", "han-core"]
 }

--- a/han-planning/skills/iterative-plan-review/SKILL.md
+++ b/han-planning/skills/iterative-plan-review/SKILL.md
@@ -18,6 +18,10 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *)
 
 ## Review Approach
 
+- **Source the shared readability standard early.** Invoke `han-communication:readability-guidance` before you edit, and
+  apply it to any plan prose this review rewrites. Hold the named audience: the reader of the plan this review refines.
+  The frame governs how a fact is said, never whether a required fact appears — keep the evidence citations, file:line
+  references, and IDs the plan depends on.
 - Read the full plan before challenging — an assumption that looks wrong in isolation may make sense in context.
 - Ground challenges in codebase evidence: "The API handler at `src/api/handler.go:47` returns XML, not JSON" is
   actionable; "This assumes the API returns JSON" is not.
@@ -444,6 +448,27 @@ plan folder's root rather than in `artifacts/`.
 
 If a prior review already populated this section, append new iteration/round counts and findings rather than
 overwriting.
+
+## Step 6.5: Readability Self-Check
+
+After both the lightweight loop (Step 4) and the team rounds (Step 5) have converged and the plan is final, run the
+standardized readability self-check **once** (the shared standard is in your context from
+`han-communication:readability-guidance`) over the plan prose regions this review authored or changed — not the whole
+pre-existing plan, and never inside code fences, tables, the `F#`/`D#`/`T#`/`R#` citation identifiers, or the Review
+History companion links, which must survive unchanged so they still resolve. Run it here on the converged plan, not
+inside either loop. Confirm each criterion and fix any failure before presenting:
+
+1. The opening line states the main point.
+2. Each heading names its content and is not a generic label.
+3. Each paragraph carries one idea and leads with it.
+4. No sentence runs past the soft length flag (about thirty words) without reason.
+5. No word from the vocabulary blocklist (the writing-voice profile's "Avoided words and phrases" and "AI slop to avoid"
+   lists) is present.
+6. Every fact is preserved — every claim, quantity, named entity, and stated condition or qualifier survives with its
+   precision intact.
+
+Fidelity wins: the standard governs how the content is said, never whether a required fact appears. This skill runs no
+separate editor pass, so criterion 6 is the only fact-preservation guard the output has — it is not optional.
 
 **Preserve the cross-reference invariants across all files:**
 

--- a/han-planning/skills/plan-a-feature/SKILL.md
+++ b/han-planning/skills/plan-a-feature/SKILL.md
@@ -201,6 +201,11 @@ code) do not reach disk — Step 5 re-validates every candidate against the rout
 
 ## Step 5: Draft the Initial Feature Specification
 
+Before drafting, invoke `han-communication:readability-guidance` to source the shared readability standard into your
+context, then apply it as you write the prose sections, holding the named audience: the stakeholder or reviewer who reads
+the spec for approval. The frame governs how a fact is said, never whether a required fact appears — keep the behavioral
+precision the spec depends on.
+
 Write the files. The primary spec goes at the root of `{folder}/`; the companion artifacts go in `{folder}/artifacts/`
 (create that subfolder if it does not already exist):
 
@@ -466,6 +471,30 @@ directly. It must:
     Any leak the han-core:project-manager finds is rewritten in place during synthesis.
 
 The han-core:project-manager owns the final synthesis — its output is authoritative.
+
+## Step 8.5: Readability Pass
+
+Once the han-core:project-manager synthesis in Step 8 is complete and the spec is final, dispatch
+`han-communication:readability-editor` (one Agent call) to audit and rewrite the spec's prose against the readability
+standard. Pass the editor the file path `{folder}/feature-specification.md` and the named audience: the stakeholder or
+reviewer who reads the spec for approval; the editor reads han-communication's own canonical rule, so pass no rule path.
+It must preserve every fact and operate on prose regions only — never inside code fences, tables, or the D#/T#/F#
+citation identifiers, which must survive unchanged so they still resolve. Apply its rewrite to the spec file.
+
+Then run the standardized readability self-check (the shared standard is in your context from
+`han-communication:readability-guidance`) over the spec's prose regions only — never inside code fences, tables, or the
+D#/T#/F# citation identifiers. Confirm each criterion and fix any failure before presenting:
+
+1. The opening line states the main point.
+2. Each heading names its content and is not a generic label.
+3. Each paragraph carries one idea and leads with it.
+4. No sentence runs past the soft length flag (about thirty words) without reason.
+5. No word from the vocabulary blocklist (the writing-voice profile's "Avoided words and phrases" and "AI slop to avoid"
+   lists) is present.
+6. Every fact is preserved — every claim, quantity, named entity, and stated condition or qualifier survives with its
+   precision intact.
+
+Fidelity wins: the standard governs how the content is said, never whether a required fact appears.
 
 ## Step 9: Present the Final Specification
 

--- a/han-planning/skills/plan-a-phased-build/SKILL.md
+++ b/han-planning/skills/plan-a-phased-build/SKILL.md
@@ -186,6 +186,11 @@ it can be reflected in that phase's "why this is phase N" rationale.
 
 ## Step 6: Draft the Build-Phase Outline (Write Incrementally)
 
+Before drafting, invoke `han-communication:readability-guidance` to source the shared readability standard into your
+context, then apply it as you write the outline, holding the named audience captured in Step 3 (default: a mixed
+engineering, product, and leadership reader). The frame governs how a fact is said, never whether a required fact appears
+— keep the sequencing, dependencies, and demo steps each phase commits to.
+
 Write [`build-phase-outline.md`](./references/build-phase-outline-template.md) using the template. Write incrementally —
 save the file after every block below, never buffer the whole document in conversation memory and write at the end.
 
@@ -275,6 +280,32 @@ Read the IA agent's findings. For each finding:
 Save the file after each material change. If the IA agent surfaced findings the user must judge (e.g., "the audience
 seems mixed — should this be split into two documents?"), present those to the user with a recommendation in one short
 message before finalizing.
+
+## Step 8.5: Readability Pass
+
+Once the Step 8 IA findings are applied and the outline is final, dispatch `han-communication:readability-editor` (one
+Agent call) to audit and rewrite the outline's prose against the readability standard. Pass the editor the file path
+`{folder}/build-phase-outline.md` and the named audience captured in Step 3 (default: a mixed engineering, product, and
+leadership reader); the editor reads han-communication's own canonical rule, so pass no rule path. It must preserve every
+fact and operate on prose regions only — never inside code fences, tables, the `{#phase-N}` and `{#oq-N}` heading
+anchors, or the source-citation links, which must survive unchanged so deep links still resolve. Apply its rewrite to the
+outline file.
+
+Then run the standardized readability self-check (the shared standard is in your context from
+`han-communication:readability-guidance`) over the outline's prose regions only — never inside code fences, tables, the
+`{#phase-N}` and `{#oq-N}` anchors, or the source-citation links. Confirm each criterion and fix any failure before
+presenting:
+
+1. The opening line states the main point.
+2. Each heading names its content and is not a generic label.
+3. Each paragraph carries one idea and leads with it.
+4. No sentence runs past the soft length flag (about thirty words) without reason.
+5. No word from the vocabulary blocklist (the writing-voice profile's "Avoided words and phrases" and "AI slop to avoid"
+   lists) is present.
+6. Every fact is preserved — every claim, quantity, named entity, and stated condition or qualifier survives with its
+   precision intact.
+
+Fidelity wins: the standard governs how the content is said, never whether a required fact appears.
 
 ## Step 9: Present the Final Outline
 

--- a/han-planning/skills/plan-implementation/SKILL.md
+++ b/han-planning/skills/plan-implementation/SKILL.md
@@ -423,6 +423,11 @@ The YAGNI ledger is a synthesis input — pass it to PM in Step 8 alongside the 
 
 ## Step 8: Project Manager Synthesis
 
+Before synthesis, invoke `han-communication:readability-guidance` to source the shared readability standard into your
+context, then apply it to the plan's prose — both while directing the han-core:project-manager's synthesis and when you
+run the Step 8.5 self-check. Hold the named audience: the engineer who will build the feature. The frame governs how a
+fact is said, never whether a required fact appears — keep the technical precision the plan depends on.
+
 Launch `han-core:project-manager` in **synthesis mode** — this is the one call in this skill that runs on the
 han-core:project-manager's default model; pass no `model` override. Provide it with:
 
@@ -512,6 +517,30 @@ provided and the plan was built from conversational context only, the section mu
 what context was used.
 
 The han-core:project-manager's synthesis is authoritative.
+
+## Step 8.5: Readability Pass
+
+Once the han-core:project-manager synthesis in Step 8 is complete and the plan is final, dispatch
+`han-communication:readability-editor` (one Agent call) to audit and rewrite the plan's prose against the readability
+standard. Pass the editor the file path `{same-folder-as-source}/feature-implementation-plan.md` and the named audience:
+the engineer who will build the feature; the editor reads han-communication's own canonical rule, so pass no rule path.
+It must preserve every fact and operate on prose regions only — never inside code fences, tables, or the D-N citation
+identifiers, which must survive unchanged so they still resolve. Apply its rewrite to the plan file.
+
+Then run the standardized readability self-check (the shared standard is in your context from
+`han-communication:readability-guidance`) over the plan's prose regions only — never inside code fences, tables, or the
+D-N citation identifiers. Confirm each criterion and fix any failure before presenting:
+
+1. The opening line states the main point.
+2. Each heading names its content and is not a generic label.
+3. Each paragraph carries one idea and leads with it.
+4. No sentence runs past the soft length flag (about thirty words) without reason.
+5. No word from the vocabulary blocklist (the writing-voice profile's "Avoided words and phrases" and "AI slop to avoid"
+   lists) is present.
+6. Every fact is preserved — every claim, quantity, named entity, and stated condition or qualifier survives with its
+   precision intact.
+
+Fidelity wins: the standard governs how the content is said, never whether a required fact appears.
 
 ## Step 9: Present the Final Implementation Plan
 

--- a/han-planning/skills/plan-work-items/SKILL.md
+++ b/han-planning/skills/plan-work-items/SKILL.md
@@ -111,6 +111,11 @@ artifact.
 
 ### 5. Draft the work items
 
+Source the shared readability standard by invoking `han-communication:readability-guidance`, and apply it to the
+work-item prose. Hold the named audience: the engineer who grabs a work item and implements it. The frame governs how a
+fact is said, never whether a required fact appears — keep the plan references, contract links, and dependencies each
+work item names.
+
 Launch `han-core:project-manager` (`subagent_type: "han-core:project-manager"`) with:
 
 - The full plan or context content from Step 1.
@@ -162,6 +167,23 @@ Write one `work-items.md` in the folder resolved in Step 2. The file layout (tit
 shared-artifacts preamble) is specified in
 [references/work-items-file-format.md](./references/work-items-file-format.md). Each work item uses the template in
 [references/work-item-template.md](./references/work-item-template.md).
+
+Before writing, run the standardized readability self-check (the shared standard is in your context from
+`han-communication:readability-guidance`) over the work-item prose regions only — never inside code fences, tables, the
+W-N identifiers, or the structured fields (Type, Depends on, Plan reference, Reference artifacts, Design references),
+which must survive unchanged so they still resolve. Confirm each criterion and fix any failure before writing:
+
+1. The opening line states the main point.
+2. Each heading names its content and is not a generic label.
+3. Each paragraph carries one idea and leads with it.
+4. No sentence runs past the soft length flag (about thirty words) without reason.
+5. No word from the vocabulary blocklist (the writing-voice profile's "Avoided words and phrases" and "AI slop to avoid"
+   lists) is present.
+6. Every fact is preserved — every claim, quantity, named entity, and stated condition or qualifier survives with its
+   precision intact.
+
+Fidelity wins: the standard governs how the content is said, never whether a required fact appears. This skill runs no
+separate editor pass, so criterion 6 is the only fact-preservation guard the output has — it is not optional.
 
 Write incrementally per the operating principle: write the title and intro first, then append each work item as it is
 finalized. Save after each.


### PR DESCRIPTION
## Summary

**This PR wires Han's shared readability standard into seven planning and coding skills that previously skipped it. The specs, plans, standards, and test plans a human reads end to end now meet the same quality bar as every other prose deliverable in the suite.**

## Behavior changes

The central mechanism is a shared "readability standard" (Han's Human-Readable Output Standard: a readability rule plus a writing-voice profile, both owned by the foundational `han-communication` plugin). Seven skills that produce human-read artifacts now source that standard while drafting and hold their output to it before presenting. This closes a gap where these artifact types slipped through unchecked.

The seven skills split into two patterns. Five "full pattern" skills (`plan-a-feature`, `plan-implementation`, `plan-a-phased-build` in `han-planning`; `coding-standard`, `test-planning` in `han-coding`) gain three things: a guidance-source line before drafting, one dispatch to the `readability-editor` agent after their final content exists, and a six-point self-check before presenting. Two "lightweight pattern" skills (`plan-work-items`, `iterative-plan-review`) gain the guidance-source line and the self-check only, with no editor dispatch.

To keep the editor from touching structure, each skill names its own downstream reader (for example, `plan-implementation` writes for "the engineer who will build the feature") and its own citation-ID scheme to leave alone (`D-N`, `W-N`, `TP-NNN`, phase and open-question anchors). That way, identifiers and structured fields are never rewritten.

Two supporting changes make this work. The standard's own scope text was reconciled in `readability-rule.md` and the `readability-guidance` skill. Now a spec, plan, phased build, work-item list, coding standard, or test plan counts as reader-facing whenever a human reads it end to end. Only a pure pipeline artifact consumed solely by downstream skills is excluded. Previously that text read as excluding the exact artifacts these skills produce.

Separately, `han-planning`'s manifest now declares `han-communication` as a direct dependency instead of reaching it transitively through `han-core`.

Long-form doc updates, a version bump, and CHANGELOG edits are intentionally out of scope and handled later.

The relevant files are the ten skill, manifest, and reference files listed above. The rest of the diff is planning artifacts under `docs/plans/readability-in-planning-coding/` (spec, decision logs, review findings, implementation plan). These record how the change was designed and are not part of the shipped behavior.
