### PR TITLE
Planning readability improvements

### DIFF
--- a/han-atlassian/skills/work-items-to-jira/SKILL.md
+++ b/han-atlassian/skills/work-items-to-jira/SKILL.md
@@ -146,7 +146,8 @@ ADRs / coding standards / docs:
 - **Missing References bullet for a UI slice** — propose the design frame and document path from the feature spec's
   Visual Reference table. Cite the spec section.
 - **Process-artifact link found** — propose removing the link and (if the slice still needs the context) restating the
-  decision inline with `See plan: D-N`. Cite the include/exclude list.
+  decision in plain language, with a **Plan decisions** References bullet naming the ID plus a one-sentence description.
+  Cite the include/exclude list.
 
 After validation, report findings in plain language. For each finding name: (1) what is wrong — slice SYM, line
 reference, failing invariant; (2) the proposed fill — corrected line, new bullet, removed link; (3) the evidence — file

--- a/han-atlassian/skills/work-items-to-jira/references/jira-ticket-template.md
+++ b/han-atlassian/skills/work-items-to-jira/references/jira-ticket-template.md
@@ -12,13 +12,16 @@ allowed between required fields when a slice needs them.
 ```
 ## <SYM-N> — <short descriptive name>
 
-**Summary.** One short plain-language paragraph stating what this slice delivers and why it matters. Includes a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)`).
+**Summary.** Three to five very short, plain-language sentences stating why the work is needed and what is being done. No technical detail and no ID references — plan references live in the References block, each with a one-sentence description.
 
-**Supporting detail.** Short paragraphs or bullets, each supporting an acceptance criterion below. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code. Duplicates content from the parent plan when clarity requires it.
+**Work to be done.**
+- Plain-language bullets stating the actual work, one to two short sentences each, every bullet supporting an acceptance criterion below.
+  - Technical detail, when needed, nests under the plain-language bullet it belongs to: starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code.
 
 *(Optional `**Bold paragraph.**` blocks here — e.g., `**Note on scope boundary.**`.)*
 
 **References.**
+- **Plan decisions** — every plan decision or work unit this slice satisfies, one bullet each: the ID as a link (e.g., `[D-6](feature-implementation-plan.md#d-6-...)`) followed by one short plain sentence saying what it is. Never a bare ID list. Replaces any inline `See plan: ...` reference.
 - **API contract** — `[<file>#<anchor>](<relative-path>)`. Required when the slice produces or consumes an HTTP endpoint.
 - **Event contract** — `[<file>#<event-section>](<relative-path>)`. Required when the slice produces or consumes an event payload.
 - **Design** — design document file path plus frame IDs (purpose). Required for UI slices. Carried as a link/reference in the description; this skill does not upload or embed images into Jira (see "Design and screenshots" below).
@@ -27,7 +30,7 @@ allowed between required fields when a slice needs them.
 - Omits any bullet that does not apply. Does not link iteration histories, decision logs, review findings, team findings, facilitation summaries, or any other process artifact.
 
 **Acceptance criteria.**
-- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here (e.g., "Automated tests cover the rejection path").
+- [ ] Each criterion is an observable, verifiable outcome of this slice's own behavior. Test expectations live here (e.g., "Automated tests cover the rejection path"). Never standard operating procedure (commit pushed, CI green, PR opened), and never a prohibition without its validated reason stated alongside it.
 
 **Depends on.** `<SYM-N>` (within this file), comma-separated for multiple, or `None.`
 ```
@@ -39,7 +42,7 @@ When the skill creates a ticket for a slice, it maps the slice fields like this:
 - **Summary (Jira) ← slice title.** The text after `— ` in the `## <SYM-N> — <title>` heading becomes the Jira ticket
   summary. The `<SYM-N>` symbolic ID is not part of the summary; it is preserved only in the source work-items file's
   heading annotation.
-- **Description (Jira) ← the entire slice body.** Everything below the heading — Summary, Supporting detail, optional
+- **Description (Jira) ← the entire slice body.** Everything below the heading — Summary, Work to be done, optional
   notes, References, Acceptance criteria — is rendered into the ticket description. Pass it as Markdown; if the
   configured Jira create tool requires Atlassian Document Format (ADF), convert it. Confirm the expected format against
   the tool's input schema at call time.

--- a/han-atlassian/skills/work-items-to-jira/references/jira-ticket-template.md
+++ b/han-atlassian/skills/work-items-to-jira/references/jira-ticket-template.md
@@ -12,12 +12,12 @@ allowed between required fields when a slice needs them.
 ```
 ## <SYM-N> — <short descriptive name>
 
-**Summary.** One paragraph describing what this slice delivers. Includes a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)`).
+**Summary.** One short plain-language paragraph stating what this slice delivers and why it matters. Includes a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)`).
 
-**Description.**
-1. Numbered steps describing the full behavior to build.
-2. References implementation details by file path where helpful (`db/ent/schema/jot.go`), but does not prescribe implementation code.
-3. Duplicates content from the parent plan when clarity requires it.
+**Acceptance criteria.**
+- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here (e.g., "Automated tests cover the rejection path").
+
+**Supporting detail.** Short paragraphs or bullets, each supporting a named acceptance criterion. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code. Duplicates content from the parent plan when clarity requires it.
 
 *(Optional `**Bold paragraph.**` blocks here — e.g., `**Note on scope boundary.**`.)*
 
@@ -29,13 +29,6 @@ allowed between required fields when a slice needs them.
 - **ADR / standard / repo doc** — links to architectural decisions, coding standards, or feature docs the implementer must honor.
 - Omits any bullet that does not apply. Does not link iteration histories, decision logs, review findings, team findings, facilitation summaries, or any other process artifact.
 
-**Tests.**
-- Bullet list of tests required for the behavior above. Names the test type (unit, integration, migration, visual, etc.) and the assertion concretely.
-
-**Acceptance criteria.**
-- [ ] Criterion 1
-- [ ] Criterion 2
-
 **Depends on.** `<SYM-N>` (within this file), comma-separated for multiple, or `None.`
 ```
 
@@ -46,8 +39,8 @@ When the skill creates a ticket for a slice, it maps the slice fields like this:
 - **Summary (Jira) ← slice title.** The text after `— ` in the `## <SYM-N> — <title>` heading becomes the Jira ticket
   summary. The `<SYM-N>` symbolic ID is not part of the summary; it is preserved only in the source work-items file's
   heading annotation.
-- **Description (Jira) ← the entire slice body.** Everything below the heading — Summary, Description, optional notes,
-  References, Tests, Acceptance criteria — is rendered into the ticket description. Pass it as Markdown; if the
+- **Description (Jira) ← the entire slice body.** Everything below the heading — Summary, Acceptance criteria,
+  Supporting detail, optional notes, References — is rendered into the ticket description. Pass it as Markdown; if the
   configured Jira create tool requires Atlassian Document Format (ADF), convert it. Confirm the expected format against
   the tool's input schema at call time.
 - **Issue type ← the resolved type.** Defaults to `Story` at the project top level or under an epic. When the work items

--- a/han-atlassian/skills/work-items-to-jira/references/jira-ticket-template.md
+++ b/han-atlassian/skills/work-items-to-jira/references/jira-ticket-template.md
@@ -14,10 +14,7 @@ allowed between required fields when a slice needs them.
 
 **Summary.** One short plain-language paragraph stating what this slice delivers and why it matters. Includes a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)`).
 
-**Acceptance criteria.**
-- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here (e.g., "Automated tests cover the rejection path").
-
-**Supporting detail.** Short paragraphs or bullets, each supporting a named acceptance criterion. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code. Duplicates content from the parent plan when clarity requires it.
+**Supporting detail.** Short paragraphs or bullets, each supporting an acceptance criterion below. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code. Duplicates content from the parent plan when clarity requires it.
 
 *(Optional `**Bold paragraph.**` blocks here — e.g., `**Note on scope boundary.**`.)*
 
@@ -29,6 +26,9 @@ allowed between required fields when a slice needs them.
 - **ADR / standard / repo doc** — links to architectural decisions, coding standards, or feature docs the implementer must honor.
 - Omits any bullet that does not apply. Does not link iteration histories, decision logs, review findings, team findings, facilitation summaries, or any other process artifact.
 
+**Acceptance criteria.**
+- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here (e.g., "Automated tests cover the rejection path").
+
 **Depends on.** `<SYM-N>` (within this file), comma-separated for multiple, or `None.`
 ```
 
@@ -39,8 +39,8 @@ When the skill creates a ticket for a slice, it maps the slice fields like this:
 - **Summary (Jira) ← slice title.** The text after `— ` in the `## <SYM-N> — <title>` heading becomes the Jira ticket
   summary. The `<SYM-N>` symbolic ID is not part of the summary; it is preserved only in the source work-items file's
   heading annotation.
-- **Description (Jira) ← the entire slice body.** Everything below the heading — Summary, Acceptance criteria,
-  Supporting detail, optional notes, References — is rendered into the ticket description. Pass it as Markdown; if the
+- **Description (Jira) ← the entire slice body.** Everything below the heading — Summary, Supporting detail, optional
+  notes, References, Acceptance criteria — is rendered into the ticket description. Pass it as Markdown; if the
   configured Jira create tool requires Atlassian Document Format (ADF), convert it. Confirm the expected format against
   the tool's input schema at call time.
 - **Issue type ← the resolved type.** Defaults to `Story` at the project top level or under an epic. When the work items

--- a/han-atlassian/skills/work-items-to-jira/references/reference-artifact-inventory.md
+++ b/han-atlassian/skills/work-items-to-jira/references/reference-artifact-inventory.md
@@ -31,11 +31,12 @@ how the skill's validation step reasons about both.
   `design-frame-verification.md` may be cited; a `team-findings.md` may not).
 
 These exist to record how the plan was reached, not what the implementer needs to build. Plan-level decisions that
-survive into a slice are restated inline in the slice description, with `See plan: D-N` as the breadcrumb — never a link
-to the decision log itself.
+survive into a slice are restated in plain language in the slice description, and cited in the slice's `**References.**`
+block as the decision ID plus a one-sentence description of what it is — never an inline ID-only breadcrumb, and never a
+link to the decision log itself.
 
 If validation finds a process-artifact link in a slice, the proposed repair is to remove the link and (if the context
-the artifact held is load-bearing) restate the decision inline with `See plan: D-N`.
+the artifact held is load-bearing) restate the decision in plain language with a **Plan decisions** References bullet.
 
 ## Where each artifact should be cited
 
@@ -65,7 +66,8 @@ When validation finds a missing or excluded artifact:
 - **Missing Design link** — inspect the feature spec's Visual Reference table and inline design references; propose the
   design frame ID(s) and document path, cited by spec section.
 - **Process-artifact link found** — propose removal, evidenced by the exclude list above. If the link was load-bearing
-  for context, propose the `See plan: D-N` breadcrumb restatement.
+  for context, propose a plain-language restatement with a **Plan decisions** References bullet (ID plus a one-sentence
+  description).
 
 Every proposed fill must cite a concrete source — a file path with line number, a document section, or an ADR ID. Fills
 without evidence are surfaced as gaps for the user to resolve, not silently applied.

--- a/han-atlassian/skills/work-items-to-jira/references/reference-artifact-inventory.md
+++ b/han-atlassian/skills/work-items-to-jira/references/reference-artifact-inventory.md
@@ -47,7 +47,7 @@ the artifact held is load-bearing) restate the decision inline with `See plan: D
 
 For each slice:
 
-- If the slice produces or consumes an HTTP endpoint (detected from `**Description.**` prose mentioning a route, method,
+- If the slice produces or consumes an HTTP endpoint (detected from slice prose mentioning a route, method,
   status code, or DTO shape), an **API contract** bullet must be present in `**References.**`.
 - If the slice produces or consumes an event payload, an **Event contract** bullet must be present.
 - If the slice has a UI surface, a **Design** bullet should be present in `**References.**` (a link/path plus frame

--- a/han-github/skills/work-items-to-issues/SKILL.md
+++ b/han-github/skills/work-items-to-issues/SKILL.md
@@ -55,7 +55,7 @@ Determine which repo each slice belongs to. Use both signals and reconcile them:
 - **Primary — cross-repo work order prose.** Most `work-items.md` files include an intro paragraph naming which SYMs
   ship to which repo (e.g., "W-1 through W-4 ship to `acme-api`. W-5 through W-9 ship to `acme-web`."). Parse this for
   the mapping.
-- **Corroborating — file paths inside each slice.** Each slice's `**Description.**` and `**References.**` blocks
+- **Corroborating — file paths inside each slice.** Each slice's `**Supporting detail.**` and `**References.**` blocks
   reference files in the target repo. Path roots map cleanly: `acme-api/...` → `acme/acme-api`, `acme-web/...` →
   `acme/acme-web`, `acme-events/...` → `acme/acme-events`. Use this to verify the prose and to assign any slice the
   prose doesn't cover.

--- a/han-github/skills/work-items-to-issues/SKILL.md
+++ b/han-github/skills/work-items-to-issues/SKILL.md
@@ -55,7 +55,7 @@ Determine which repo each slice belongs to. Use both signals and reconcile them:
 - **Primary — cross-repo work order prose.** Most `work-items.md` files include an intro paragraph naming which SYMs
   ship to which repo (e.g., "W-1 through W-4 ship to `acme-api`. W-5 through W-9 ship to `acme-web`."). Parse this for
   the mapping.
-- **Corroborating — file paths inside each slice.** Each slice's `**Supporting detail.**` and `**References.**` blocks
+- **Corroborating — file paths inside each slice.** Each slice's `**Work to be done.**` and `**References.**` blocks
   reference files in the target repo. Path roots map cleanly: `acme-api/...` → `acme/acme-api`, `acme-web/...` →
   `acme/acme-web`, `acme-events/...` → `acme/acme-events`. Use this to verify the prose and to assign any slice the
   prose doesn't cover.
@@ -97,7 +97,8 @@ ADRs / coding standards / docs:
   files by inspecting the feature spec's Visual Reference table and the spec's inline screenshot embeds. Cite the spec
   section.
 - **Process-artifact link found** — propose removing the link and (if the slice still needs the context the artifact
-  held) restating the decision inline with `See plan: D-N` as the breadcrumb. Cite the include/exclude list.
+  held) restating the decision in plain language, with a **Plan decisions** References bullet naming the ID plus a
+  one-sentence description. Cite the include/exclude list.
 
 After validation, report findings in plain language. For each finding, name:
 

--- a/han-github/skills/work-items-to-issues/references/issue-template.md
+++ b/han-github/skills/work-items-to-issues/references/issue-template.md
@@ -16,10 +16,7 @@ event payload, design frame, ADR, coding standard) — omit it only when no exte
 
 **Summary.** One short plain-language paragraph stating what this slice delivers and why it matters. Includes a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)` or `See plan: D-3, D-7, and Work Unit 2`). The plan reference replaces a standalone "Work items addressed" field.
 
-**Acceptance criteria.**
-- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here (e.g., "Automated tests cover the rejection path").
-
-**Supporting detail.** Short paragraphs or bullets, each supporting a named acceptance criterion. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code. Duplicates content from the parent plan when clarity requires it.
+**Supporting detail.** Short paragraphs or bullets, each supporting an acceptance criterion below. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code. Duplicates content from the parent plan when clarity requires it.
 
 *(Optional `**Bold paragraph.**` blocks here — e.g., `**Note on scope boundary.**`, `**Note on cross-repo gate.**`.)*
 
@@ -34,6 +31,9 @@ event payload, design frame, ADR, coding standard) — omit it only when no exte
 - **Spec section** — `[feature-specification.md#<anchor>](feature-specification.md#<anchor>)` for the behavior this slice realizes.
 - **ADR / standard / repo doc** — links to architectural decisions, coding standards, or feature docs the implementer must honor.
 - Omits any bullet that does not apply. Does not link iteration histories, decision logs, review findings, team findings, facilitation summaries, or any other process artifact.
+
+**Acceptance criteria.**
+- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here (e.g., "Automated tests cover the rejection path").
 
 **Depends on.** `<SYM-N>` (within this repo), comma-separated for multiple, or `None.`
 ```

--- a/han-github/skills/work-items-to-issues/references/issue-template.md
+++ b/han-github/skills/work-items-to-issues/references/issue-template.md
@@ -14,9 +14,11 @@ event payload, design frame, ADR, coding standard) — omit it only when no exte
 ```
 ## <SYM-N> — <short descriptive name>
 
-**Summary.** One short plain-language paragraph stating what this slice delivers and why it matters. Includes a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)` or `See plan: D-3, D-7, and Work Unit 2`). The plan reference replaces a standalone "Work items addressed" field.
+**Summary.** Three to five very short, plain-language sentences stating why the work is needed and what is being done. No technical detail and no ID references — plan references live in the References block, each with a one-sentence description.
 
-**Supporting detail.** Short paragraphs or bullets, each supporting an acceptance criterion below. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code. Duplicates content from the parent plan when clarity requires it.
+**Work to be done.**
+- Plain-language bullets stating the actual work, one to two short sentences each, every bullet supporting an acceptance criterion below.
+  - Technical detail, when needed, nests under the plain-language bullet it belongs to: starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code.
 
 *(Optional `**Bold paragraph.**` blocks here — e.g., `**Note on scope boundary.**`, `**Note on cross-repo gate.**`.)*
 
@@ -25,6 +27,7 @@ event payload, design frame, ADR, coding standard) — omit it only when no exte
 - *<state-or-scenario name>* — `[![<alt text>](https://github.com/<org>/<target-repo>/raw/<branch>/.github/issue-assets/<feature-slug>/<SYM-N>/<file>.png)](https://github.com/<org>/<target-repo>/raw/<branch>/.github/issue-assets/<feature-slug>/<SYM-N>/<file>.png)`
 
 **References.**
+- **Plan decisions** — every plan decision or work unit this slice satisfies, one bullet each: the ID as a link (e.g., `[D-6](feature-implementation-plan.md#d-6-...)`) followed by one short plain sentence saying what it is. Never a bare ID list. Replaces any inline `See plan: ...` reference and any standalone "Work items addressed" field.
 - **API contract** — `[<file>#<anchor>](<relative-path>)` (e.g., `[feature-implementation-plan.md#external-interfaces](feature-implementation-plan.md#external-interfaces)`). Required when the slice produces or consumes an HTTP endpoint.
 - **Event contract** — `[<file>#<event-section>](<relative-path>)`. Required when the slice produces or consumes an event payload.
 - **Design (Pencil)** — `<pen-file-path>`, frames `<frameId>` (purpose), `<frameId>` (purpose). Required for UI slices.
@@ -33,7 +36,7 @@ event payload, design frame, ADR, coding standard) — omit it only when no exte
 - Omits any bullet that does not apply. Does not link iteration histories, decision logs, review findings, team findings, facilitation summaries, or any other process artifact.
 
 **Acceptance criteria.**
-- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here (e.g., "Automated tests cover the rejection path").
+- [ ] Each criterion is an observable, verifiable outcome of this slice's own behavior. Test expectations live here (e.g., "Automated tests cover the rejection path"). Never standard operating procedure (commit pushed, CI green, PR opened), and never a prohibition without its validated reason stated alongside it.
 
 **Depends on.** `<SYM-N>` (within this repo), comma-separated for multiple, or `None.`
 ```

--- a/han-github/skills/work-items-to-issues/references/issue-template.md
+++ b/han-github/skills/work-items-to-issues/references/issue-template.md
@@ -14,12 +14,12 @@ event payload, design frame, ADR, coding standard) — omit it only when no exte
 ```
 ## <SYM-N> — <short descriptive name>
 
-**Summary.** One paragraph describing what this slice delivers. Includes a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)` or `See plan: D-3, D-7, and Work Unit 2`). The plan reference replaces a standalone "Work items addressed" field.
+**Summary.** One short plain-language paragraph stating what this slice delivers and why it matters. Includes a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)` or `See plan: D-3, D-7, and Work Unit 2`). The plan reference replaces a standalone "Work items addressed" field.
 
-**Description.**
-1. Numbered steps describing the full behavior to build.
-2. References implementation details by file path where helpful (`db/ent/schema/jot.go`), but does not prescribe implementation code.
-3. Duplicates content from the parent plan when clarity requires it.
+**Acceptance criteria.**
+- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here (e.g., "Automated tests cover the rejection path").
+
+**Supporting detail.** Short paragraphs or bullets, each supporting a named acceptance criterion. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code. Duplicates content from the parent plan when clarity requires it.
 
 *(Optional `**Bold paragraph.**` blocks here — e.g., `**Note on scope boundary.**`, `**Note on cross-repo gate.**`.)*
 
@@ -34,13 +34,6 @@ event payload, design frame, ADR, coding standard) — omit it only when no exte
 - **Spec section** — `[feature-specification.md#<anchor>](feature-specification.md#<anchor>)` for the behavior this slice realizes.
 - **ADR / standard / repo doc** — links to architectural decisions, coding standards, or feature docs the implementer must honor.
 - Omits any bullet that does not apply. Does not link iteration histories, decision logs, review findings, team findings, facilitation summaries, or any other process artifact.
-
-**Tests.**
-- Bullet list of tests required for the behavior above. Names the test type (unit, integration, migration, visual, etc.) and the assertion concretely.
-
-**Acceptance criteria.**
-- [ ] Criterion 1
-- [ ] Criterion 2
 
 **Depends on.** `<SYM-N>` (within this repo), comma-separated for multiple, or `None.`
 ```

--- a/han-github/skills/work-items-to-issues/references/reference-artifact-inventory.md
+++ b/han-github/skills/work-items-to-issues/references/reference-artifact-inventory.md
@@ -58,7 +58,7 @@ at least one slice in that repo. When in doubt, the entry is included.
 
 For each slice:
 
-- If the slice produces or consumes an HTTP endpoint (detected from `**Description.**` prose mentioning a route, method,
+- If the slice produces or consumes an HTTP endpoint (detected from slice prose mentioning a route, method,
   status code, or DTO shape), an **API contract** bullet must be present in `**References.**`.
 - If the slice produces or consumes an event payload, an **Event contract** bullet must be present.
 - If the slice has a UI surface and the plan folder contains `ui-designs/`, the `**Screenshots.**` block must be present

--- a/han-github/skills/work-items-to-issues/references/reference-artifact-inventory.md
+++ b/han-github/skills/work-items-to-issues/references/reference-artifact-inventory.md
@@ -39,11 +39,12 @@ how the skill's Step 3 validation reasons about both.
   `design-frame-verification.md` may be cited; a `team-findings.md` may not).
 
 These exist to record how the plan was reached, not what the implementer needs to build. Plan-level decisions that
-survive into a slice are restated inline in the slice description, with `See plan: D-N` as the breadcrumb — never a link
-to the decision log itself.
+survive into a slice are restated in plain language in the slice description, and cited in the slice's `**References.**`
+block as the decision ID plus a one-sentence description of what it is — never an inline ID-only breadcrumb, and never a
+link to the decision log itself.
 
 If validation finds a process-artifact link in a slice, the proposed repair is to remove the link and (if the context
-the artifact held is load-bearing) restate the decision inline with `See plan: D-N`.
+the artifact held is load-bearing) restate the decision in plain language with a **Plan decisions** References bullet.
 
 ## Where each artifact should be cited
 
@@ -76,7 +77,8 @@ When validation finds a missing or excluded artifact:
 - **Missing Design / Screenshots block** — inspect the feature spec's Visual Reference table and inline screenshot
   embeds; propose the design frame ID(s) and screenshot file(s), cited by spec section.
 - **Process-artifact link found** — propose removal, evidenced by the exclude list above. If the link was load-bearing
-  for context, propose the `See plan: D-N` breadcrumb restatement.
+  for context, propose a plain-language restatement with a **Plan decisions** References bullet (ID plus a one-sentence
+  description).
 
 Every proposed fill must cite a concrete source — a file path with line number, a document section, or an ADR ID. Fills
 without evidence are surfaced as gaps for the user to resolve, not silently applied.

--- a/han-linear/skills/work-items-to-linear/SKILL.md
+++ b/han-linear/skills/work-items-to-linear/SKILL.md
@@ -135,7 +135,8 @@ ADRs / coding standards / docs:
 - **Missing References bullet for an HTTP-consuming or UI slice** — propose the contract section or design frame from
   the parent plan or feature spec. Cite the anchor.
 - **Process-artifact link found** — propose removing the link and, if the slice still needs the context, restating the
-  decision inline with `See plan: D-N`. Cite the include/exclude list.
+  decision in plain language with a **Plan decisions** References bullet naming the ID plus a one-sentence description.
+  Cite the include/exclude list.
 
 After validation, report findings in plain language. For each: (1) what is wrong — slice SYM, line reference, failing
 invariant; (2) the proposed fill — corrected line, new bullet, removed link; (3) the evidence — file path with line

--- a/han-linear/skills/work-items-to-linear/references/linear-issue-template.md
+++ b/han-linear/skills/work-items-to-linear/references/linear-issue-template.md
@@ -13,10 +13,7 @@ standard). Additional `**Bold paragraph.**` context blocks are allowed between r
 
 **Summary.** One short plain-language paragraph stating what this slice delivers and why it matters. Includes a plan reference inline (e.g., `See plan: D-6`).
 
-**Acceptance criteria.**
-- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here.
-
-**Supporting detail.** Short paragraphs or bullets, each supporting a named acceptance criterion. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code.
+**Supporting detail.** Short paragraphs or bullets, each supporting an acceptance criterion below. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code.
 
 **References.**
 - **API contract** — `[<file>#<anchor>](<relative-path>)`. Required when the slice produces or consumes an HTTP endpoint.
@@ -24,6 +21,9 @@ standard). Additional `**Bold paragraph.**` context blocks are allowed between r
 - **Design** — design document path plus frame IDs. Carried as a link in the issue description; this skill does not upload or embed images into Linear (see "Design and images" below).
 - **Spec section** — `[feature-specification.md#<anchor>](feature-specification.md#<anchor>)` for the behavior this slice realizes.
 - **ADR / standard / repo doc** — links the implementer must honor.
+
+**Acceptance criteria.**
+- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here.
 
 **Depends on.** `<SYM-N>` (within this file), comma-separated for multiple, or `None.`
 ```
@@ -35,8 +35,8 @@ When the skill creates an issue for a slice, it maps the slice fields like this:
 - **Title (Linear) <- slice title.** The text after `— ` in the `## <SYM-N> — <title>` heading becomes the issue title.
   The `<SYM-N>` symbolic ID is not part of the title; it is preserved only in the source work-items file's heading
   annotation.
-- **Description (Linear) <- the entire slice body.** Everything below the heading (Summary, Acceptance criteria,
-  Supporting detail, optional notes, References) is rendered into the issue description and passed as **Markdown with no
+- **Description (Linear) <- the entire slice body.** Everything below the heading (Summary, Supporting detail, optional
+  notes, References, Acceptance criteria) is rendered into the issue description and passed as **Markdown with no
   format conversion** (Linear accepts Markdown directly).
 - **Team <- the required target team.** Every slice posts into the one team you name. The skill resolves the team
   against the workspace before any create.

--- a/han-linear/skills/work-items-to-linear/references/linear-issue-template.md
+++ b/han-linear/skills/work-items-to-linear/references/linear-issue-template.md
@@ -11,11 +11,14 @@ standard). Additional `**Bold paragraph.**` context blocks are allowed between r
 ```
 ## <SYM-N> — <short descriptive name>
 
-**Summary.** One short plain-language paragraph stating what this slice delivers and why it matters. Includes a plan reference inline (e.g., `See plan: D-6`).
+**Summary.** Three to five very short, plain-language sentences stating why the work is needed and what is being done. No technical detail and no ID references — plan references live in the References block, each with a one-sentence description.
 
-**Supporting detail.** Short paragraphs or bullets, each supporting an acceptance criterion below. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code.
+**Work to be done.**
+- Plain-language bullets stating the actual work, one to two short sentences each, every bullet supporting an acceptance criterion below.
+  - Technical detail, when needed, nests under the plain-language bullet it belongs to: starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code.
 
 **References.**
+- **Plan decisions** — every plan decision or work unit this slice satisfies, one bullet each: the ID as a link (e.g., `[D-6](feature-implementation-plan.md#d-6-...)`) followed by one short plain sentence saying what it is. Never a bare ID list. Replaces any inline `See plan: ...` reference.
 - **API contract** — `[<file>#<anchor>](<relative-path>)`. Required when the slice produces or consumes an HTTP endpoint.
 - **Event contract** — `[<file>#<event-section>](<relative-path>)`. Required when the slice produces or consumes an event payload.
 - **Design** — design document path plus frame IDs. Carried as a link in the issue description; this skill does not upload or embed images into Linear (see "Design and images" below).
@@ -23,7 +26,7 @@ standard). Additional `**Bold paragraph.**` context blocks are allowed between r
 - **ADR / standard / repo doc** — links the implementer must honor.
 
 **Acceptance criteria.**
-- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here.
+- [ ] Each criterion is an observable, verifiable outcome of this slice's own behavior. Test expectations live here. Never standard operating procedure (commit pushed, CI green, PR opened), and never a prohibition without its validated reason stated alongside it.
 
 **Depends on.** `<SYM-N>` (within this file), comma-separated for multiple, or `None.`
 ```
@@ -35,7 +38,7 @@ When the skill creates an issue for a slice, it maps the slice fields like this:
 - **Title (Linear) <- slice title.** The text after `— ` in the `## <SYM-N> — <title>` heading becomes the issue title.
   The `<SYM-N>` symbolic ID is not part of the title; it is preserved only in the source work-items file's heading
   annotation.
-- **Description (Linear) <- the entire slice body.** Everything below the heading (Summary, Supporting detail, optional
+- **Description (Linear) <- the entire slice body.** Everything below the heading (Summary, Work to be done, optional
   notes, References, Acceptance criteria) is rendered into the issue description and passed as **Markdown with no
   format conversion** (Linear accepts Markdown directly).
 - **Team <- the required target team.** Every slice posts into the one team you name. The skill resolves the team

--- a/han-linear/skills/work-items-to-linear/references/linear-issue-template.md
+++ b/han-linear/skills/work-items-to-linear/references/linear-issue-template.md
@@ -11,11 +11,12 @@ standard). Additional `**Bold paragraph.**` context blocks are allowed between r
 ```
 ## <SYM-N> — <short descriptive name>
 
-**Summary.** One paragraph describing what this slice delivers. Includes a plan reference inline (e.g., `See plan: D-6`).
+**Summary.** One short plain-language paragraph stating what this slice delivers and why it matters. Includes a plan reference inline (e.g., `See plan: D-6`).
 
-**Description.**
-1. Numbered steps describing the full behavior to build.
-2. References implementation details by file path where helpful, but does not prescribe implementation code.
+**Acceptance criteria.**
+- [ ] Each criterion is an observable, verifiable outcome. Test expectations live here.
+
+**Supporting detail.** Short paragraphs or bullets, each supporting a named acceptance criterion. Describes intention and goals with starting points (a file path, a contract, a boundary), never a prescribed edit list or implementation code.
 
 **References.**
 - **API contract** — `[<file>#<anchor>](<relative-path>)`. Required when the slice produces or consumes an HTTP endpoint.
@@ -23,13 +24,6 @@ standard). Additional `**Bold paragraph.**` context blocks are allowed between r
 - **Design** — design document path plus frame IDs. Carried as a link in the issue description; this skill does not upload or embed images into Linear (see "Design and images" below).
 - **Spec section** — `[feature-specification.md#<anchor>](feature-specification.md#<anchor>)` for the behavior this slice realizes.
 - **ADR / standard / repo doc** — links the implementer must honor.
-
-**Tests.**
-- Bullet list of tests required for the behavior. Names the test type and the assertion concretely.
-
-**Acceptance criteria.**
-- [ ] Criterion 1
-- [ ] Criterion 2
 
 **Depends on.** `<SYM-N>` (within this file), comma-separated for multiple, or `None.`
 ```
@@ -41,9 +35,9 @@ When the skill creates an issue for a slice, it maps the slice fields like this:
 - **Title (Linear) <- slice title.** The text after `— ` in the `## <SYM-N> — <title>` heading becomes the issue title.
   The `<SYM-N>` symbolic ID is not part of the title; it is preserved only in the source work-items file's heading
   annotation.
-- **Description (Linear) <- the entire slice body.** Everything below the heading (Summary, Description, optional notes,
-  References, Tests, Acceptance criteria) is rendered into the issue description and passed as **Markdown with no format
-  conversion** (Linear accepts Markdown directly).
+- **Description (Linear) <- the entire slice body.** Everything below the heading (Summary, Acceptance criteria,
+  Supporting detail, optional notes, References) is rendered into the issue description and passed as **Markdown with no
+  format conversion** (Linear accepts Markdown directly).
 - **Team <- the required target team.** Every slice posts into the one team you name. The skill resolves the team
   against the workspace before any create.
 - **Workflow state <- the team's initial state by default.** The skill defaults to the team's own default/initial state

--- a/han-linear/skills/work-items-to-linear/references/reference-artifact-inventory.md
+++ b/han-linear/skills/work-items-to-linear/references/reference-artifact-inventory.md
@@ -28,11 +28,12 @@ how validation reasons about both.
 - Anything under an `artifacts/` subfolder of the plan **unless** it is a contract or design reference.
 
 These record how the plan was reached, not what the implementer needs to build. Plan-level decisions that survive into a
-slice are restated inline in the slice description, with `See plan: D-N` as the breadcrumb, never a link to the decision
-log itself.
+slice are restated in plain language in the slice description, and cited in the slice's `**References.**` block as the
+decision ID plus a one-sentence description of what it is — never an inline ID-only breadcrumb, and never a link to the
+decision log itself.
 
 If validation finds a process-artifact link in a slice, the proposed repair is to remove the link and, when the context
-it held is load-bearing, restate the decision inline with `See plan: D-N`.
+it held is load-bearing, restate the decision in plain language with a **Plan decisions** References bullet.
 
 ## Where each artifact should be cited
 
@@ -59,8 +60,8 @@ When validation finds a missing or excluded artifact:
 - **Missing event contract link** — propose the parent plan's events section, evidenced by its existence.
 - **Missing Design link** — inspect the feature spec's Visual Reference table and inline design references; propose the
   design frame IDs and document path, cited by spec section.
-- **Process-artifact link found** — propose removal, evidenced by the exclude list above. If load-bearing, propose the
-  `See plan: D-N` breadcrumb restatement.
+- **Process-artifact link found** — propose removal, evidenced by the exclude list above. If load-bearing, propose a
+  plain-language restatement with a **Plan decisions** References bullet (ID plus a one-sentence description).
 
 Every proposed fill cites a concrete source: a file path with line number, a document section, or a named source. Fills
 without evidence are surfaced as gaps for the user to resolve, not silently applied.

--- a/han-planning/docs/skills/plan-a-feature.md
+++ b/han-planning/docs/skills/plan-a-feature.md
@@ -177,7 +177,7 @@ remains. The skill surfaces it rather than inventing an answer.
   genuinely need user judgment, organized by the decision they affect. Trust that loop rather than asking for the raw
   agent output.
 - **Pair with `/plan-implementation` next.** This skill produces _what_. The `/plan-implementation` skill turns that
-  into _how_: decomposition, sequencing, RAID log, testing strategy, operational readiness, rollback. Running the two in
+  into _how_: work units, sequencing, testing strategy, operational readiness, rollback. Running the two in
   sequence is the intended flow. For the full end-to-end planning workflow from rough idea to individual work items, see
   [How to plan a feature, end to end](../../../docs/how-to/plan-a-feature.md).
 - **Re-run when the spec must change.** If the outcome materially shifts (new constraint, new stakeholder, new evidence

--- a/han-planning/docs/skills/plan-implementation.md
+++ b/han-planning/docs/skills/plan-implementation.md
@@ -41,6 +41,12 @@ _how_ to use the skill. For what the skill does internally, read the skill defin
   It never prescribes line-level edits or inlines full file contents: a non-author must be able to read it, plans are
   executed after the codebase has moved on (a prescribed edit list goes stale and misleads), and the implementer —
   human or coding agent — reads the current code at build time.
+- **Plain language leads; technical detail nests beneath it.** Every section leads with plain-language prose.
+  Technical detail is minimal references only, placed below or after the plain language it illustrates — never mixed
+  into it. When choosing between more plain language and more technical detail, the plan chooses more plain language.
+- **User stories carry the intent.** When the feature has a describable actor benefit, the plan opens the work with
+  user stories derived from the specification's committed behavior, and each work unit names the story it advances.
+  Stories give the implementer the high-level intent before any mechanics.
 - **Cross-referenced artifacts.** Every non-obvious claim carries `([D-N](...))` linking to the decision that drove it.
   Every `R#` round links to the decisions it produced and the sections it changed.
 
@@ -129,12 +135,15 @@ Three cross-referenced files in the same folder as the source specification, plu
   them. Sections include:
   - An **opening paragraph and Outcome.** What is being built, the implementation posture the plan commits to, and what
     exists when the work is done — in plain language.
+  - **User stories.** The intent of the work at a high level, derived from behavior the specification commits to:
+    "As a {actor}, I want {capability}, so that {benefit}", each with a `US-N` ID. Present whenever an actor benefits
+    in a describable way; omitted otherwise.
   - An **implementation approach.** The shape of the implementation as prose: what it plugs into, what it reuses, what
-    it introduces, where the boundaries are. Focused subsections appear only for surfaces the plan commits a real
-    decision on (a schema change, a new external interface); each is a few sentences of intention plus decision links,
-    not an inventory of changes.
-  - A **work units and sequencing** table. The plan broken into work units sized to ship, each with what it delivers
-    (in outcome terms), what it depends on, and how it is verified.
+    it introduces, where the boundaries are. Technical identifiers appear only after the plain-language sentence they
+    illustrate. Focused subsections appear only for surfaces the plan commits a real decision on (a schema change, a
+    new external interface); each is a few sentences of intention plus decision links, not an inventory of changes.
+  - A **work units and sequencing** table. The plan broken into work units sized to ship, each with the user story it
+    advances, what it delivers (in outcome terms), what it depends on, and how it is verified.
   - A **definition of done** (testable, unambiguous, agreed across specialists) and a **testing strategy** grounded in
     the `test-engineer`'s observable-behavior recommendations.
   - **Lazily created specialist sections**, each present only when there is real content: security posture, operational

--- a/han-planning/docs/skills/plan-implementation.md
+++ b/han-planning/docs/skills/plan-implementation.md
@@ -36,9 +36,11 @@ _how_ to use the skill. For what the skill does internally, read the skill defin
   pass audits and corrects the artifacts, not just writes and populates them: the PM reconciles the artifacts against
   each other and rewrites inconsistencies in place, such as a decision-log title copied from another entry, or a path
   one section assumes that another section's layout never places there.
-- **Planning altitude.** The plan names and references config and code artifacts; it does not inline their full
-  contents. Only decision-bearing values (a flag default, a key name, a threshold) appear inline. A full file block
-  belongs in the file it configures, not in the plan.
+- **Planning altitude — intention over prescription.** The plan carries the intention and goals of the work, its touch
+  points (a module, a contract, a boundary), and the decision-bearing values (a flag default, a key name, a threshold).
+  It never prescribes line-level edits or inlines full file contents: a non-author must be able to read it, plans are
+  executed after the codebase has moved on (a prescribed edit list goes stale and misleads), and the implementer —
+  human or coding agent — reads the current code at build time.
 - **Cross-referenced artifacts.** Every non-obvious claim carries `([D-N](...))` linking to the decision that drove it.
   Every `R#` round links to the decisions it produced and the sections it changed.
 
@@ -121,44 +123,31 @@ proceeding. But pointing at the spec path directly is faster.
 Three cross-referenced files in the same folder as the source specification, plus an in-channel summary:
 
 - A **`feature-implementation-plan.md`** file at `{same-folder-as-source}/feature-implementation-plan.md`. The primary
-  plan. Non-obvious claims carry inline markers (for example,
+  plan, structured for progressive disclosure: a plain-language opening a reader can stop after, then intention-level
+  sections, then the deeper records. Non-obvious claims carry inline markers (for example,
   `([D-3](artifacts/implementation-decision-log.md#d-3-rollout-strategy))`) linking back to the decision that drove
   them. Sections include:
-  - A **Source Specification** section. A markdown link back to the `feature-specification.md`, plus links to the spec's
-    `artifacts/decision-log.md`, `artifacts/team-findings.md`, and `artifacts/feature-technical-notes.md` if those
-    exist. Legacy spec folders may have these files at the folder root instead; the project-manager records whichever
-    path is correct. The `feature-technical-notes.md` entry appears only when the file exists; its absence is not a gap.
-    If the plan was built from conversational context only, the section states that explicitly and summarizes what
-    context was used.
-  - A **team composition and participation record.** Every specialist the skill engaged, whether they contributed
-    actively or stood down with "no concerns," and a one-line summary of each specialist's input with citation.
-  - An **implementation approach** section covering architecture and integration points, data model and persistence,
-    runtime behavior, and external interfaces. Technical details are welcome here (this is the _how_ document), all
-    grounded in evidence from the codebase, ADRs, and coding standards.
-  - A **decomposition and sequencing** table. The plan broken into work units sized to ship, each with what it delivers,
-    what it depends on, and how it is verified.
-  - A **RAID log**, when there is anything to track. Risks (with likelihood, severity, blast radius, reversibility,
-    owner, mitigation), Assumptions (with what-changes-if-wrong), Issues (with owner and next step), and Dependencies
-    (with owner and status). Only the sub-tables with entries appear, and a small plan with no risks, assumptions,
-    issues, or dependencies omits the section rather than rendering empty tables.
-  - A **testing strategy** grounded in the `test-engineer`'s observable-behavior recommendations (and
-    `edge-case-explorer`'s findings if engaged). Covers test levels, test-doubles posture, and the edge cases requiring
-    coverage.
-  - A **security posture** section (when `adversarial-security-analyst` contributed) with the concrete threat vectors
-    addressed and the mitigations the plan commits to. Omitted entirely when the feature has no threat surface, rather
-    than rendering a "no security concerns" stub.
-  - An **operational readiness** section (when `devops-engineer` contributed) covering observability signals, SLO
-    touchpoints, feature-flag strategy, rollout and rollback steps, cost posture, and compliance controls. Omitted
-    entirely when the change introduces no operational surface.
-  - An **on-call resilience posture** section (when `on-call-engineer` contributed) covering application-source
-    resilience commitments: timeouts and deadlines, retry strategy, idempotency, bulkheads, backpressure, kill switches,
-    graceful degradation, failure-path observability, data integrity, and migration safety. Omitted entirely when the
-    change adds no resilience surface.
-  - A **definition of done.** Testable, unambiguous, agreed across specialists.
-  - A **specialist handoffs for implementation** list. Which sibling agents should be re-engaged during implementation,
-    when, and with what input.
+  - An **opening paragraph and Outcome.** What is being built, the implementation posture the plan commits to, and what
+    exists when the work is done — in plain language.
+  - An **implementation approach.** The shape of the implementation as prose: what it plugs into, what it reuses, what
+    it introduces, where the boundaries are. Focused subsections appear only for surfaces the plan commits a real
+    decision on (a schema change, a new external interface); each is a few sentences of intention plus decision links,
+    not an inventory of changes.
+  - A **work units and sequencing** table. The plan broken into work units sized to ship, each with what it delivers
+    (in outcome terms), what it depends on, and how it is verified.
+  - A **definition of done** (testable, unambiguous, agreed across specialists) and a **testing strategy** grounded in
+    the `test-engineer`'s observable-behavior recommendations.
+  - **Lazily created specialist sections**, each present only when there is real content: security posture, operational
+    readiness, on-call resilience posture, risks and assumptions, deferred (YAGNI) items, and specialist handoffs for
+    implementation. An absent section records the judgment that the surface is genuinely absent, never an empty stub.
   - A **remaining open items** list. Questions the project-manager could not resolve through evidence, junior-developer
     reframing, or user input. Each one names what would resolve it and whether it blocks implementation.
+  - A **sources and plan records** section closing the file: links to the source `feature-specification.md` and its
+    companions (whichever exist, in `artifacts/` or at the folder root for legacy layouts), the decisions the plan
+    inherits, and the two companion artifacts where decision rationale, team composition, and round-by-round history
+    live. A one-or-two-sentence **recommendation** (ship as planned, hold, or blocked) ends the plan. There is no
+    team-composition table and no statistics summary in the plan itself — that detail lives one hop away in the
+    artifacts.
 - An **`artifacts/implementation-decision-log.md`** file at
   `{same-folder-as-source}/artifacts/implementation-decision-log.md`. One `D-N` entry per decision committed during the
   loop. Each entry records the choice, rationale, evidence, rejected alternatives with reasons, the specialist owner,
@@ -289,9 +278,10 @@ question the specialists can answer among themselves. Only when evidence and ref
 the question to you, with the evidence considered, the reframing, a recommended answer, and the alternatives.
 
 The `project-manager` owns the final synthesis pass and writes the authoritative plan. The primary artifact
-(`feature-implementation-plan.md` at the folder root) covers decomposition, sequencing, RAID log, testing strategy,
-security posture, operational readiness, definition of done, specialist handoffs, and open items. It also links back to
-the upstream _what_ document in a Source Specification section. Decision history and round-by-round iteration history
+(`feature-implementation-plan.md` at the folder root) covers work units and sequencing, testing strategy, definition of
+done, open items, and the lazily created specialist sections (security, operational readiness, resilience, risks and
+assumptions, handoffs). It links back to the upstream _what_ document in a closing Sources and Plan Records section.
+Decision history and round-by-round iteration history
 live alongside it, in `artifacts/implementation-decision-log.md` and `artifacts/implementation-iteration-history.md`,
 cross-referenced by `D-N` / `R#` ID. This keeps the primary plan focused on the implementation narrative, while
 rationale, rejected alternatives, and discussion history stay one hop away. Once the final plan content exists, the
@@ -340,10 +330,10 @@ URLs: https://www.mindtools.com/a81qk8y/round-robin-brainstorming/ and https://g
 ### RAID Log
 
 The RAID log (Risks, Assumptions, Issues, Decisions) is the standard project-management artifact for tracking,
-continuously, the four items a plan cannot survive without. The skill's output plan encodes a full RAID log carried
-forward from facilitation: risks with likelihood/severity/blast-radius/reversibility/owner/mitigation, assumptions with
-what-changes-if-wrong, issues with owner/next-step, and decisions (separately recorded) with
-rationale/rejected-alternatives/evidence.
+continuously, the four items a plan cannot survive without. The skill's output distributes those four across its
+layers: risks (with impact, mitigation, owner) and assumptions (with what-changes-if-wrong and a verification status)
+in the plan's Risks and Assumptions section, unresolved issues as Open Items, and decisions with
+rationale/rejected-alternatives/evidence in the companion decision log.
 
 URLs: https://asana.com/resources/raid-log and https://www.smartsheet.com/content/raid-logs
 
@@ -384,7 +374,7 @@ https://www.projectmanager.com/blog/acceptance-criteria-project-management
 The expand-and-contract pattern (expand the schema / interface / contract, migrate consumers, backfill, flip, contract)
 is the default recommendation the skill's `devops-engineer` and `data-engineer` sub-agents produce. They recommend it
 whenever the feature touches data migration or interface change. The skill's output plan encodes this into the
-Decomposition and Sequencing table when applicable, because big-bang changes co-deployed with dependent code violate
+Work Units and Sequencing table when applicable, because big-bang changes co-deployed with dependent code violate
 every rollback constraint.
 
 URL: https://martinfowler.com/bliki/ParallelChange.html

--- a/han-planning/docs/skills/plan-work-items.md
+++ b/han-planning/docs/skills/plan-work-items.md
@@ -25,9 +25,15 @@ _how_ to use the skill. For what the skill does internally, read the skill defin
   over few thick ones.
 - **Acceptance criteria carry the item.** Each work item is drafted summary-first, criteria-second, so every block of
   detail is written in support of a criterion; in the rendered output the summary opens the item and the acceptance
-  criteria sit at the bottom, with test expectations inside them. Technical detail stays minimal — intention, goals,
-  and touch points, never a prescribed edit list — because work items are often implemented long after they are
-  written, and a prescribed edit list goes stale against the moving codebase while intention and criteria stay valid.
+  criteria sit at the bottom, with test expectations inside them. Criteria are outcomes of the work item only: never
+  standard operating procedure (commit pushed, CI green), and never an unexplained prohibition.
+- **Plain language first, technical detail nested.** The summary is three to five very short plain sentences saying why
+  the work is needed and what is being done, with no technical detail and no ID references. The body is a
+  `Work to be done` bullet list in the same plain language, with technical detail nested beneath the bullet it supports
+  — intention, goals, and touch points, never a prescribed edit list — because work items are often implemented long
+  after they are written, and a prescribed edit list goes stale against the moving codebase while intention and
+  criteria stay valid. Plan references live in the References block, each ID paired with a one-sentence description of
+  what it is.
 - **Symbolic ID.** Each work item gets a stable identifier (`W-N`). IDs are for cross-referencing work items within the
   file and citing them in tickets, threads, and follow-up work. They are stable for the life of the file.
 - **One file, no repository awareness.** The output is exactly one `work-items.md`. The skill never splits work by
@@ -90,8 +96,9 @@ One file on disk plus an in-channel summary:
 - **`work-items.md`** in the resolved folder. The stakeholder-readable artifact. It opens with a title line and an intro
   paragraph that links the parent plan (or names the source context) and explains the `W-N` ID scheme. When a single
   reference artifact applies to more than one work item, a **Shared reference artifacts** preamble cites it once. Then
-  one section per work item, in dependency order. Each work item carries: `Summary` (plain language, with an inline plan
-  reference), `Supporting detail` (written in support of the criteria), optional `Design references`, `References`,
+  one section per work item, in dependency order. Each work item carries: `Summary` (three to five very short plain
+  sentences), `Work to be done` (plain-language bullets with technical detail nested beneath), optional
+  `Design references`, `References` (including plan decisions, each ID with a one-sentence description),
   `Acceptance criteria` (at the bottom, test expectations included), and `Depends on`.
 - An **in-channel summary** with the file path, a count of work items by type (HITL / AFK), and the next concrete
   action.
@@ -108,7 +115,7 @@ One file on disk plus an in-channel summary:
   phase it first, plan the implementation of a single phase, then run this skill against that phase's plan. Each
   work-items file then covers one phase.
 - **Pair with `/tdd` downstream.** Once the breakdown is written, `/tdd` implements a work item test-first. The work
-  item's `Summary`, `Acceptance criteria`, and `Supporting detail` become the behavior test list.
+  item's `Summary`, `Acceptance criteria`, and `Work to be done` list become the behavior test list.
 - **Pair with `/work-items-to-issues` downstream when you track work on GitHub.** Once the breakdown is written,
   `/work-items-to-issues` publishes each item as a GitHub issue in its target repo. It needs the `han-github` plugin and
   the `gh` CLI.

--- a/han-planning/docs/skills/plan-work-items.md
+++ b/han-planning/docs/skills/plan-work-items.md
@@ -23,11 +23,11 @@ _how_ to use the skill. For what the skill does internally, read the skill defin
 - **HITL and AFK.** Every work item is classified as HITL (requires a human sync: an architectural decision, a design
   review) or AFK (can be implemented and merged without one). The skill prefers AFK and prefers many thin work items
   over few thick ones.
-- **Acceptance criteria carry the item.** Every work item opens with a plain-language summary, then the acceptance
-  criteria that say when it is done. All remaining detail is written in support of a named criterion, and test
-  expectations live inside the criteria. Technical detail stays minimal — intention, goals, and touch points, never a
-  prescribed edit list — because work items are often implemented long after they are written, and a prescribed edit
-  list goes stale against the moving codebase while intention and criteria stay valid.
+- **Acceptance criteria carry the item.** Each work item is drafted summary-first, criteria-second, so every block of
+  detail is written in support of a criterion; in the rendered output the summary opens the item and the acceptance
+  criteria sit at the bottom, with test expectations inside them. Technical detail stays minimal — intention, goals,
+  and touch points, never a prescribed edit list — because work items are often implemented long after they are
+  written, and a prescribed edit list goes stale against the moving codebase while intention and criteria stay valid.
 - **Symbolic ID.** Each work item gets a stable identifier (`W-N`). IDs are for cross-referencing work items within the
   file and citing them in tickets, threads, and follow-up work. They are stable for the life of the file.
 - **One file, no repository awareness.** The output is exactly one `work-items.md`. The skill never splits work by
@@ -91,8 +91,8 @@ One file on disk plus an in-channel summary:
   paragraph that links the parent plan (or names the source context) and explains the `W-N` ID scheme. When a single
   reference artifact applies to more than one work item, a **Shared reference artifacts** preamble cites it once. Then
   one section per work item, in dependency order. Each work item carries: `Summary` (plain language, with an inline plan
-  reference), `Acceptance criteria` (test expectations included), `Supporting detail` (written in support of the
-  criteria), optional `Design references`, `References`, and `Depends on`.
+  reference), `Supporting detail` (written in support of the criteria), optional `Design references`, `References`,
+  `Acceptance criteria` (at the bottom, test expectations included), and `Depends on`.
 - An **in-channel summary** with the file path, a count of work items by type (HITL / AFK), and the next concrete
   action.
 

--- a/han-planning/docs/skills/plan-work-items.md
+++ b/han-planning/docs/skills/plan-work-items.md
@@ -23,6 +23,11 @@ _how_ to use the skill. For what the skill does internally, read the skill defin
 - **HITL and AFK.** Every work item is classified as HITL (requires a human sync: an architectural decision, a design
   review) or AFK (can be implemented and merged without one). The skill prefers AFK and prefers many thin work items
   over few thick ones.
+- **Acceptance criteria carry the item.** Every work item opens with a plain-language summary, then the acceptance
+  criteria that say when it is done. All remaining detail is written in support of a named criterion, and test
+  expectations live inside the criteria. Technical detail stays minimal — intention, goals, and touch points, never a
+  prescribed edit list — because work items are often implemented long after they are written, and a prescribed edit
+  list goes stale against the moving codebase while intention and criteria stay valid.
 - **Symbolic ID.** Each work item gets a stable identifier (`W-N`). IDs are for cross-referencing work items within the
   file and citing them in tickets, threads, and follow-up work. They are stable for the life of the file.
 - **One file, no repository awareness.** The output is exactly one `work-items.md`. The skill never splits work by
@@ -85,8 +90,9 @@ One file on disk plus an in-channel summary:
 - **`work-items.md`** in the resolved folder. The stakeholder-readable artifact. It opens with a title line and an intro
   paragraph that links the parent plan (or names the source context) and explains the `W-N` ID scheme. When a single
   reference artifact applies to more than one work item, a **Shared reference artifacts** preamble cites it once. Then
-  one section per work item, in dependency order. Each work item carries: `Summary` (with an inline plan reference),
-  `Description`, optional `Design references`, `References`, `Tests`, `Acceptance criteria`, and `Depends on`.
+  one section per work item, in dependency order. Each work item carries: `Summary` (plain language, with an inline plan
+  reference), `Acceptance criteria` (test expectations included), `Supporting detail` (written in support of the
+  criteria), optional `Design references`, `References`, and `Depends on`.
 - An **in-channel summary** with the file path, a count of work items by type (HITL / AFK), and the next concrete
   action.
 
@@ -102,7 +108,7 @@ One file on disk plus an in-channel summary:
   phase it first, plan the implementation of a single phase, then run this skill against that phase's plan. Each
   work-items file then covers one phase.
 - **Pair with `/tdd` downstream.** Once the breakdown is written, `/tdd` implements a work item test-first. The work
-  item's `Description`, `Tests`, and `Acceptance criteria` become the behavior test list.
+  item's `Summary`, `Acceptance criteria`, and `Supporting detail` become the behavior test list.
 - **Pair with `/work-items-to-issues` downstream when you track work on GitHub.** Once the breakdown is written,
   `/work-items-to-issues` publishes each item as a GitHub issue in its target repo. It needs the `han-github` plugin and
   the `gh` CLI.
@@ -187,8 +193,8 @@ URL: https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary
 
 Cohn's INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable) inform the per-work-item shape.
 Each work item is independent enough to grab on its own, small enough to ship as a unit, and testable through its
-`Tests` and `Acceptance criteria` fields. The HITL/AFK split is the skill's read of the Independent criterion: an AFK
-work item can be merged without a human sync.
+`Acceptance criteria`, which carry the test expectations. The HITL/AFK split is the skill's read of the Independent
+criterion: an AFK work item can be merged without a human sync.
 
 URL: https://www.mountaingoatsoftware.com/books/user-stories-applied
 

--- a/han-planning/skills/plan-implementation/SKILL.md
+++ b/han-planning/skills/plan-implementation/SKILL.md
@@ -48,6 +48,14 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(git *)
   goes stale and misleads), and the implementer — human or coding agent — reads the current code at build time. Deeper
   detail lives one hop away in the companion artifacts. YAGNI gates whether an item is _included_; this principle gates
   how _verbose_ an included item is.
+- **Plain language leads; technical detail nests beneath it.** Every section leads with plain-language prose a
+  non-author can follow. Technical detail is minimal references only — a path, a contract name, a decision-bearing
+  value — placed below or after the plain language it illustrates, never mixed into it and never free-standing. When
+  choosing between more plain language and more technical detail, choose more plain language.
+- **Frame the work around user stories when possible.** User stories give the implementer the intent at a high level
+  before any mechanics. Derive them from behavior the specification already commits to — never invent behavior — and
+  anchor work units to the story each one advances. When the feature has no user-facing behavior, frame stories around
+  the operator or consuming system; skip stories only when no actor benefits in a describable way.
 - **The plan lives in three cross-referenced files.** `feature-implementation-plan.md` is the primary plan and lives at
   the root of `{folder}/`; `implementation-decision-log.md` records every decision and
   `implementation-iteration-history.md` records each round of discussion — both companion artifacts live in
@@ -465,10 +473,12 @@ Ask the han-core:project-manager to produce the final synthesis across all three
    bullet (`D-N: {title} — {outcome}. — Referenced in plan: {sections}.`). The D-N counter is shared across both
    sections, and every plan inline link still resolves to a D-N whether full or trivial.
 2. **Write `feature-implementation-plan.md`** — the primary plan, following the template's progressive-disclosure
-   order: a plain-language opening paragraph, Outcome, Constraints and Boundaries, Implementation Approach, Work Units
-   and Sequencing, Definition of Done, Testing Strategy, the lazy specialist sections, Open Items, Sources and Plan
-   Records, and Recommendation. The upper layers stay in plain language at intention altitude per the Operating
-   Principles; the template's guidance comments carry the per-section rules. The lazy sections are written only when
+   order: a plain-language opening paragraph, Outcome, User Stories (when the feature has a describable actor benefit),
+   Constraints and Boundaries, Implementation Approach, Work Units and Sequencing, Definition of Done, Testing
+   Strategy, the lazy specialist sections, Open Items, Sources and Plan Records, and Recommendation. The upper layers
+   stay in plain language at intention altitude per the Operating Principles: plain language leads every section,
+   technical detail appears only as minimal references below the plain language it illustrates, and work units name the
+   user story each one advances. The template's guidance comments carry the per-section rules. The lazy sections are written only when
    they have real content and omitted entirely otherwise, never as an empty stub: `Security Posture` (threat surface or
    `han-core:adversarial-security-analyst` contributed), `Operational Readiness` (operational surface or
    `han-core:devops-engineer` contributed), `On-Call Resilience Posture` (resilience surface or

--- a/han-planning/skills/plan-implementation/SKILL.md
+++ b/han-planning/skills/plan-implementation/SKILL.md
@@ -41,11 +41,13 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(git *)
   precedent — operational machinery shipped before the system that drives it actually produces the data, traffic, or
   failures it covers is YAGNI by default. Every committed implementation item is ongoing maintenance and a pattern
   future agents will copy.
-- **Keep the plan at planning altitude.** Name and reference config and code artifacts; do not inline their full
-  contents. Inline only the specific values that are themselves decisions (a flag default, a key name, a threshold). A
-  full file block — a complete plist, a whole config file, a multi-line XML or JSON document — belongs in the file it
-  configures, not in the plan. YAGNI gates whether an item is _included_; this principle gates how _verbose_ an included
-  item is.
+- **Keep the plan at planning altitude — intention over prescription.** The plan is the reader's layer: it carries the
+  intention and goals of the work, the touch points (a module, a contract, a boundary), and the decision-bearing values
+  (a flag default, a key name, a threshold). NEVER inline full file contents or prescribe line-level edits, BECAUSE a
+  non-author must be able to read the plan, plans are executed after the codebase has moved on (a prescribed edit list
+  goes stale and misleads), and the implementer — human or coding agent — reads the current code at build time. Deeper
+  detail lives one hop away in the companion artifacts. YAGNI gates whether an item is _included_; this principle gates
+  how _verbose_ an included item is.
 - **The plan lives in three cross-referenced files.** `feature-implementation-plan.md` is the primary plan and lives at
   the root of `{folder}/`; `implementation-decision-log.md` records every decision and
   `implementation-iteration-history.md` records each round of discussion — both companion artifacts live in
@@ -462,23 +464,22 @@ Ask the han-core:project-manager to produce the final synthesis across all three
    `Dependent decisions:`, `Referenced in plan:`). Trivial decisions go under `## Trivial decisions` as a one-line
    bullet (`D-N: {title} — {outcome}. — Referenced in plan: {sections}.`). The D-N counter is shared across both
    sections, and every plan inline link still resolves to a D-N whether full or trivial.
-2. **Write `feature-implementation-plan.md`** — the primary plan covering Source Specification, Outcome, Context, Team
-   Composition, Implementation Approach, Decomposition and Sequencing, RAID Log, Testing Strategy, Security Posture,
-   Operational Readiness, On-Call Resilience Posture, Definition of Done, Specialist Handoffs, Deferred (YAGNI), Open
-   Items, and Summary. Several sections are **lazily created** — write each only when it has real content and omit it
-   entirely otherwise, never rendering an empty stub: `RAID Log` (include only the sub-tables that have entries; omit
-   the section when all four are empty), `Security Posture` (only when there is a threat surface or
-   `han-core:adversarial-security-analyst` contributed), `Operational Readiness` (only when there is an operational
-   surface or `han-core:devops-engineer` contributed), `On-Call Resilience Posture` (only when there is a resilience
-   surface or `han-core:on-call-engineer` contributed), and `Deferred (YAGNI)` (only if at least one item was deferred
-   under the YAGNI rule, per Step 7.5's ledger and PM's own application of the rule during synthesis). Omitting a lazy
-   section records the judgment that the surface is genuinely absent, not a skipped concern — confirm before omitting.
-   This keeps a small plan proportionate: sizing already caps the team and rounds, and lazy sections stop a small plan
-   from carrying empty operational scaffolding. For each deferred item, record: the item, why deferred (which gate
-   failed), the reopening trigger, and the source (specialist or round that proposed it). For every claim that embodies
-   a non-obvious decision, append an inline parenthetical link to the decision, e.g.
-   `([D-3](artifacts/implementation-decision-log.md#d-3-rollout-strategy))`. Link only non-obvious claims. Do not inline
-   rationale or rejected alternatives. Do not repeat round-by-round history.
+2. **Write `feature-implementation-plan.md`** — the primary plan, following the template's progressive-disclosure
+   order: a plain-language opening paragraph, Outcome, Constraints and Boundaries, Implementation Approach, Work Units
+   and Sequencing, Definition of Done, Testing Strategy, the lazy specialist sections, Open Items, Sources and Plan
+   Records, and Recommendation. The upper layers stay in plain language at intention altitude per the Operating
+   Principles; the template's guidance comments carry the per-section rules. The lazy sections are written only when
+   they have real content and omitted entirely otherwise, never as an empty stub: `Security Posture` (threat surface or
+   `han-core:adversarial-security-analyst` contributed), `Operational Readiness` (operational surface or
+   `han-core:devops-engineer` contributed), `On-Call Resilience Posture` (resilience surface or
+   `han-core:on-call-engineer` contributed), `Risks and Assumptions` (at least one real entry), `Deferred (YAGNI)` (at
+   least one item deferred per Step 7.5's ledger), and `Specialist Handoffs for Implementation` (at least one planned
+   handoff). Omitting a lazy section records the judgment that the surface is genuinely absent, not a skipped concern —
+   confirm before omitting. The plan carries no team-composition table and no statistics summary — both live in the
+   companion artifacts, linked from Sources and Plan Records. For every claim that embodies a non-obvious decision,
+   append an inline parenthetical link, e.g. `([D-3](artifacts/implementation-decision-log.md#d-3-rollout-strategy))`.
+   Link only non-obvious claims. Do not inline rationale or rejected alternatives. Do not repeat round-by-round
+   history.
 3. **Backfill `artifacts/implementation-iteration-history.md`** — for each `R#` entry already present from Step 6,
    populate `Decisions produced:` with the `D#` IDs added or changed that round and `Changed in plan:` with the plan
    sections updated that round.
@@ -507,12 +508,12 @@ Ask the han-core:project-manager to produce the final synthesis across all three
      structural-invariant preservation, not a replacement for it; LLM generation is probabilistic, so the audit lowers
      the odds of a copy-paste title or path mismatch rather than guaranteeing zero.
 
-**The `Source Specification` section of `feature-implementation-plan.md` must be populated.** If a feature specification
-file was provided, the han-core:project-manager must include a relative markdown link to it (typically
+**The `Sources and Plan Records` section of `feature-implementation-plan.md` must be populated.** If a feature
+specification file was provided, the han-core:project-manager must include a relative markdown link to it (typically
 `[feature-specification.md](feature-specification.md)` since both files live in the same folder). If the spec's
 `decision-log.md`, `team-findings.md`, and/or `feature-technical-notes.md` also exist (in `artifacts/` for the current
-layout, or at the folder root for legacy layouts), list them under Source Specification with the correct relative path.
-The `feature-technical-notes.md` entry is present only when the file exists — its absence is not a gap. If no file was
+layout, or at the folder root for legacy layouts), list them there with the correct relative path. The
+`feature-technical-notes.md` entry is present only when the file exists — its absence is not a gap. If no file was
 provided and the plan was built from conversational context only, the section must state that explicitly and summarize
 what context was used.
 

--- a/han-planning/skills/plan-implementation/references/feature-implementation-plan-template.md
+++ b/han-planning/skills/plan-implementation/references/feature-implementation-plan-template.md
@@ -1,254 +1,131 @@
 # Feature Implementation Plan: {Feature Name}
 
-<!-- One-to-two-sentence summary of what the feature is and the implementation posture this plan commits to (e.g., "ship behind a feature flag, expand-and-contract migration, two-week slice"). -->
+<!-- Opening paragraph, two to four plain-language sentences: what is being built, the implementation posture this plan commits to (e.g., "ship behind a feature flag, expand-and-contract migration"), and the one thing a reader must know first. A reader who stops here still knows what this plan does. -->
 
 <!--
-CROSS-REFERENCING GUIDANCE
+HOW THIS FILE IS LAYERED. This file is the reader's layer: intention, goals, and sequence in
+plain language, ordered by how much a reader needs each section. Deeper layers live one hop away:
+decision rationale and rejected alternatives in artifacts/implementation-decision-log.md; team
+composition and round-by-round history in artifacts/implementation-iteration-history.md. When a
+claim embodies a non-obvious decision, append an inline link, e.g.
+"([D-3](artifacts/implementation-decision-log.md#d-3-rollout-strategy))". Link only claims a
+reader would ask "why this?" about. Never inline rationale, alternatives, or round history here.
 
-This file is the primary implementation plan. Decision records live in
-[artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md) and round-by-round
-iteration history lives in [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md).
-
-Inline decision references:
-- When a claim in this file embodies a non-obvious decision, append a parenthetical
-  link to the decision in artifacts/implementation-decision-log.md, e.g.
-  "...behind a LaunchDarkly flag ([D-3](artifacts/implementation-decision-log.md#d-3-rollout-strategy))."
-- Link only non-obvious claims — not every sentence. "Non-obvious" means a reader
-  would reasonably ask "why this and not something else?"
-- Do not inline rationale or rejected alternatives — those belong in the decision log.
-- Do not record round-by-round history here — that belongs in the iteration history.
+MINIMAL TECHNICAL DETAIL. Give the implementer a starting point — the intention of each piece of
+work, its touch points (a module, a contract, a boundary), and the decision-bearing values (a
+flag default, a key name, a threshold). Never prescribe line-level changes, inline full file
+contents, or enumerate every edit: a non-author must be able to read the plan, plans are executed
+after the codebase has moved (so edit lists go stale and mislead), and the implementer — human or
+coding agent — reads the current code at build time. Technical identifiers appear after the prose
+that explains them, only when the reader needs them.
 -->
-
-## Source Specification
-
-- **Feature specification:** [{filename}]({relative-path-to-feature-specification.md})
-  <!-- Markdown link to the source spec so readers can jump to it. If no file was provided (e.g., conversational context only), state "No source specification file — inputs were: {one-line summary of what was provided}". -->
-- **Specification decision log:** [artifacts/decision-log.md](artifacts/decision-log.md)
-  <!-- Omit if the source spec is not one produced by plan-a-feature or has no companion decision log. -->
-- **Specification team findings:** [artifacts/team-findings.md](artifacts/team-findings.md)
-  <!-- Omit if the source spec has no companion findings file. -->
-- **Specification decisions this plan inherits:** D1, D2, D3…
-  <!-- IDs from the spec's decision-log.md. Omit the line if no spec decision log existed. -->
-- **Specification open items this plan must respect or resolve:** OI-1, OI-2…
-  <!-- IDs from the spec's Open Items. Omit the line if no spec file existed. -->
 
 ## Outcome
 
-<!-- Restate, in implementation terms, the outcome the completed work delivers. What will exist in the codebase, the runtime, and the user's hands when this plan is executed. -->
+<!-- Plain language: what exists in the codebase, the runtime, and the user's hands when this plan is executed, and who it serves. Two short paragraphs at most. -->
 
-## Context
+## Constraints and Boundaries
 
-- **Driving constraint:** <!-- Why now — deadline, incident, customer commitment, strategic bet -->
-- **Stakeholders:** <!-- Who cares about the outcome and what success looks like to each -->
-- **Future-state concern:** <!-- What must be watched after ship so the system remains operable at scale -->
-- **Out-of-scope boundary:** <!-- What this plan deliberately does not do, and why -->
+<!-- Only the bullets with real content — omit the rest. -->
 
-## Team Composition and Participation
-
-<!-- Which specialists contributed to the plan, with one line each on the input they fed into decisions. If a specialist was invited and stood down with "no concerns," record that. Full round-by-round detail lives in artifacts/implementation-iteration-history.md. -->
-
-| Specialist         | Status                       | Key Input                                              |
-| ------------------ | ---------------------------- | ------------------------------------------------------ |
-| `project-manager`  | Coordinator                  | <!-- Facilitated rounds and synthesized final plan --> |
-| `junior-developer` | Reframer                     | <!-- Reframed open questions; noted assumptions -->    |
-| `{specialist}`     | <!-- Active / Stood down --> | <!-- One-line summary with citation -->                |
+- **Driving constraint:** <!-- why now — deadline, incident, commitment -->
+- **Out of scope:** <!-- what this plan deliberately does not do, and why -->
+- **Watch after ship:** <!-- omit when nothing qualifies -->
 
 ## Implementation Approach
 
-<!-- The shape of the implementation: how the feature fits into the system, what it reuses, what it introduces, where boundaries are drawn. Technical details are welcome here — this is the *how* document. Keep statements grounded in evidence (existing code paths, ADRs, conventions). Append inline `([D-N](artifacts/implementation-decision-log.md#...))` links to non-obvious choices.
+<!-- The shape of the implementation in plain prose: how the feature fits into the system, what it reuses, what it introduces, where the boundaries are. Lead with intention; name touch points, not edits. Add a focused subsection ONLY for a surface the plan commits a real decision on (e.g., "Data model changes", "External interfaces") — a few sentences of intention plus its D-N links, not an inventory of changes. Omit every surface with nothing decided. -->
 
-ALTITUDE: name and reference config and code artifacts; do not inline their full contents. Inline only the specific values that are themselves decisions (a flag default, a key name, a threshold). A full file block belongs in the file it configures, not in the plan. -->
+### {decision-bearing surface}
 
-### Architecture and Integration Points
+## Work Units and Sequencing
 
-<!-- Modules, services, or layers the implementation touches. How the feature plugs into existing interfaces. What new interfaces it introduces. Link non-obvious choices to the decision log. -->
+<!-- Work units sized to ship. Keep Delivers at intention altitude ("invite emails send through the existing mailer"), not a file list. Link non-obvious shapes to D-N. -->
 
-### Data Model and Persistence
-
-<!-- Schema changes, migrations, data movement. Expand-and-contract steps if applicable. Reference ADRs that constrain choices. Link non-obvious choices to the decision log. -->
-
-### Runtime Behavior
-
-<!-- How the feature behaves at runtime: call paths, control flow, state transitions, concurrency model. Cite existing patterns the feature follows. Link non-obvious choices to the decision log. -->
-
-### External Interfaces
-
-<!-- APIs, events, queues, third-party integrations the feature calls or exposes. Contract shape and versioning posture. Link non-obvious choices to the decision log. -->
-
-## Decomposition and Sequencing
-
-<!-- Break the implementation into work units sized to ship. For each unit, name what it delivers, what it depends on, and how it is verified. Append `([D-N](artifacts/implementation-decision-log.md#...))` links where a unit's shape reflects a non-obvious decision. -->
-
-| #   | Work Unit                              | Delivers                          | Depends On | Verification                           |
-| --- | -------------------------------------- | --------------------------------- | ---------- | -------------------------------------- |
-| 1   | <!-- e.g., Schema expand migration --> | <!-- new column, backfill job --> | <!-- — --> | <!-- migration test + staging run -->  |
-| 2   | <!-- e.g., Write path behind flag -->  | <!-- dual-write, flag off -->     | 1          | <!-- integration test + flag audit --> |
-| 3   | …                                      | …                                 | …          | …                                      |
-
-## RAID Log
-
-<!--
-LAZILY CREATED — include only the sub-tables that have at least one real entry,
-and omit the whole RAID Log section when none of the four do. A small plan with
-no tracked risks, assumptions, issues, or dependencies omits this section rather
-than rendering empty tables. Confirm each sub-table is genuinely empty before
-omitting it — omission records the judgment that nothing qualified, not a
-skipped step.
--->
-
-### Risks
-
-| ID  | Risk | Likelihood | Severity | Blast Radius | Reversibility | Owner | Mitigation |
-| --- | ---- | ---------- | -------- | ------------ | ------------- | ----- | ---------- |
-| R1  | …    | …          | …        | …            | …             | …     | …          |
-
-### Assumptions
-
-<!--
-Status is exactly one of: `Verified` (a source cite settles it: file:line, ADR,
-or standard), `Runtime-only` (cannot be known until it runs), or `Open` (not yet
-checked). One status per assumption. If it is confirmed from source, it is
-`Verified`. Do not tack on "but unverified at runtime". A separate runtime
-unknown gets its own row. Mixing the two hides a settled fact and makes later
-steps gate on it for no reason.
--->
-
-| ID  | Assumption | What Changes If Wrong | Verifier | Status |
-| --- | ---------- | --------------------- | -------- | ------ |
-| A1  | …          | …                     | …        | …      |
-
-### Issues
-
-| ID  | Issue | Owner | Next Step |
-| --- | ----- | ----- | --------- |
-| I1  | …     | …     | …         |
-
-### Dependencies
-
-| ID   | Dependency | Owner | Status |
-| ---- | ---------- | ----- | ------ |
-| Dep1 | …          | …     | …      |
-
-## Testing Strategy
-
-<!-- Observable-behavior test plan sourced from test-engineer (and edge-case-explorer if engaged). Cover unit, integration, and end-to-end layers as applicable. Cite the specialist findings this section rests on. Append `([D-N](artifacts/implementation-decision-log.md#...))` links where the strategy reflects a non-obvious decision. -->
-
-- **Observable behaviors to test:** …
-- **Test doubles posture:**
-  <!-- stubs for queries, mock expectations for commands — or inline what the specialist recommended -->
-- **Edge cases requiring coverage:** …
-- **Test levels:** <!-- unit / integration / end-to-end mapping -->
-
-## Security Posture
-
-<!-- LAZILY CREATED — write this section only if `adversarial-security-analyst` contributed findings or the plan commits to a concrete security mitigation. If the feature has no threat surface (no authentication, authorization, PII, untrusted input, or secrets), omit the section entirely rather than writing "no security concerns". Confirm there is genuinely no surface before omitting — omission records that judgment, not a skipped step.
-
-If `adversarial-security-analyst` contributed, capture their concrete findings and the mitigations this plan commits to. Name the specific threat vectors addressed; do not paraphrase into vague "we'll be secure" language. Append `([D-N](artifacts/implementation-decision-log.md#...))` links where the posture reflects a non-obvious decision. -->
-
-## Operational Readiness
-
-<!-- LAZILY CREATED — write this section only if `devops-engineer` contributed or the plan commits to a concrete production-readiness step. If the change introduces no new observability, rollout, flag, scale, or cost concern, omit the section entirely rather than rendering empty bullets. Confirm there is genuinely no operational surface before omitting — omission records that judgment, not a skipped step.
-
-If `devops-engineer` contributed, capture the production-readiness requirements this plan commits to: observability signals, SLO touchpoints, feature-flag strategy, rollout and rollback steps, cost posture, compliance controls. Append `([D-N](artifacts/implementation-decision-log.md#...))` links where the posture reflects a non-obvious decision. -->
-
-- **Observability:** <!-- metrics, logs, traces to add; dashboards to touch -->
-- **SLO impact:** …
-- **Feature flag:** <!-- name, default, widening criteria, rollback criterion -->
-- **Rollout:** <!-- stages, gates, who watches what -->
-- **Rollback:** <!-- exact procedure and decision criterion -->
-- **Cost and scale:** …
-
-## On-Call Resilience Posture
-
-<!-- LAZILY CREATED — write this section only if `on-call-engineer` contributed or the plan commits to a concrete application-source resilience measure. If the change adds no outbound calls, retries, queues, async paths, or other resilience surface, omit the section entirely rather than rendering empty bullets. Confirm there is genuinely no resilience surface before omitting — omission records that judgment, not a skipped step.
-
-If `on-call-engineer` contributed, capture the application-source resilience commitments this plan makes. Each row maps to a named anti-pattern the agent flagged. Application source level only; infrastructure and pipeline concerns live in Operational Readiness above. Append `([D-N](artifacts/implementation-decision-log.md#...))` links where the commitment reflects a non-obvious decision. -->
-
-- **Timeouts and deadlines:** <!-- which outbound calls get which timeouts; deadline propagation through the chain -->
-- **Retry strategy:** <!-- backoff, jitter, total cap; coordination with retries elsewhere in the chain -->
-- **Idempotency:**
-  <!-- which retried side effects are guarded, and by what mechanism (caller-provided key, unique constraint, conditional update) -->
-- **Bulkheads and concurrency caps:** <!-- which dependencies get isolated resource pools; what limits fan-out -->
-- **Queue and backpressure:** <!-- bounded vs. unbounded; producer slowdown signal; visibility timeout; DLQ -->
-- **Kill switches:** <!-- which risky new code paths are flag-gated; operator can flip without a redeploy -->
-- **Graceful degradation:** <!-- what happens when each dependency is unavailable -->
-- **Observability of failure paths:**
-  <!-- log lines, metrics, spans, and SLI contributions that make new code paths observable per the ODD gate -->
-- **Data integrity:**
-  <!-- column lengths, integer types on monetary or rate-counter values, encoding boundaries, partial-write recovery -->
-- **Migration safety:** <!-- expand/contract sequencing for any schema change; never co-deployed with dependent code -->
+| #   | Work Unit | Delivers | Depends On | Verification |
+| --- | --------- | -------- | ---------- | ------------ |
+| 1   | …         | …        | —          | …            |
 
 ## Definition of Done
 
-<!-- Testable, unambiguous, agreed across specialists. Cite the decisions each criterion satisfies. -->
+<!-- Testable and unambiguous. Cite the decisions a criterion satisfies. -->
 
 - [ ] <!-- Behavior X is observable when action Y occurs -->
-- [ ] <!-- Test coverage added for decisions ([D-1](artifacts/implementation-decision-log.md#d-1-...), [D-2](artifacts/implementation-decision-log.md#d-2-...)) -->
-- [ ] <!-- Feature flag configured per Operational Readiness -->
-- [ ] <!-- Observability signals live and dashboards updated -->
-- [ ] <!-- Rollback procedure tested in staging -->
-- [ ] <!-- Post-ship owner named and notified -->
+- [ ] <!-- Tests cover ([D-1](artifacts/implementation-decision-log.md#d-1-...)) -->
 
-## Specialist Handoffs for Implementation
+## Testing Strategy
 
-<!-- For each specialist whose work will be called during implementation — name the specialist, when they should be dispatched, and what they will need as input. This is the reader's guide for who gets pulled back in. -->
+<!-- Lead with the behaviors that prove the feature works; one line each for mechanics. -->
 
-- **`{specialist}`** — dispatch when <!-- condition -->; needs <!-- input artifact -->.
+- **Observable behaviors to test:** …
+- **Edge cases requiring coverage:** …
+- **Test doubles posture and levels:** <!-- stubs for queries, mocks for commands; unit / integration / e2e mapping -->
+
+## Security Posture
+
+<!-- LAZILY CREATED — only if `adversarial-security-analyst` contributed or the plan commits to a concrete mitigation. No threat surface → omit the section entirely (confirm first; omission records that judgment). Name the specific threat vectors and committed mitigations — never vague "we'll be secure" language. -->
+
+## Operational Readiness
+
+<!-- LAZILY CREATED — only if `devops-engineer` contributed or the plan commits to a concrete production-readiness step; otherwise omit (confirm first). Only the bullets with real commitments: observability signals, SLO touchpoints, feature flag (name, default, widening criteria, rollback criterion), rollout and rollback steps, cost, compliance. -->
+
+## On-Call Resilience Posture
+
+<!-- LAZILY CREATED — only if `on-call-engineer` contributed or the plan commits to a concrete application-source resilience measure; otherwise omit (confirm first). Only the bullets with real commitments: timeouts, retries, idempotency, bulkheads, backpressure, kill switches, degradation, failure-path observability, data integrity, migration safety. Application source only; infrastructure lives in Operational Readiness. -->
+
+## Risks and Assumptions
+
+<!-- LAZILY CREATED — only when at least one real entry exists; omit an empty sub-table, omit the whole section when both are empty (confirm first). -->
+
+### Risks
+
+| ID  | Risk | Impact | Mitigation | Owner |
+| --- | ---- | ------ | ---------- | ----- |
+| R1  | …    | …      | …          | …     |
+
+### Assumptions
+
+<!-- Status is exactly one of: `Verified` (a source cite settles it: file:line, ADR, standard), `Runtime-only` (unknowable until it runs), or `Open`. One status per assumption; a separate runtime unknown gets its own row. -->
+
+| ID  | Assumption | What Changes If Wrong | Status |
+| --- | ---------- | --------------------- | ------ |
+| A1  | …          | …                     | …      |
 
 ## Deferred (YAGNI)
 
-<!--
-Items considered during implementation planning but deferred under the YAGNI rule
-([../../references/yagni-rule.md](../../../references/yagni-rule.md)).
-
-LAZILY CREATED — write this section only if at least one item was deferred. If
-nothing qualified, omit the section entirely. Do not write an empty stub.
-
-For each deferred item:
-- Item — the abstraction, configuration knob, runbook, observability hook,
-  alert, dashboard, SLO, feature flag, infrastructure component, schema column,
-  index, audit machinery, retention pipeline, test category, or other
-  implementation artifact that was considered.
-- Why deferred — which gate failed (evidence test or simpler-version test) and
-  the specific reason. Cite the named anti-pattern from the rule doc when
-  applicable (e.g., "runbook for never-fired alert", "single-implementation
-  interface", "index for query that doesn't run").
-- Reopen when — the concrete trigger that would justify revisiting (a measured
-  metric, a real incident, a third concrete use of an abstraction, a customer
-  commitment, a regulation taking effect).
-- Source — the round (R#) or specialist that originally proposed the item.
--->
+<!-- LAZILY CREATED — only if at least one item was deferred under the YAGNI rule; never an empty stub. -->
 
 ### {item name}
 
-- **Why deferred:** {gate failure with specific reason; named anti-pattern when applicable}
+- **Why deferred:** {gate failure; named anti-pattern when applicable}
 - **Reopen when:** {concrete trigger}
 - **Source:** {R#, specialist name}
 
 ## Open Items
 
-<!-- Questions or concerns the project-manager could not resolve through evidence, junior-developer reframing, or user input. For each, why the plan is shippable anyway or what specifically is blocking ship. -->
+<!-- Questions the project-manager could not resolve through evidence, reframing, or user input. -->
 
 - **OI-1:** <!-- question or concern -->
   - **Resolves when:** …
   - **Blocks implementation:** Yes / No — <!-- reason -->
 
-## Summary
+## Specialist Handoffs for Implementation
 
-- **Outcome delivered:** <!-- One sentence -->
-- **Team size:** <!-- N specialists --> — see
-  [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md)
-- **Rounds of facilitation:** N — see
-  [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md)
-- **Decisions committed:** N — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
-- **Decisions settled by evidence:** N — see
-  [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
-- **Decisions settled by junior-developer reframing:** N — see
-  [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
-- **Decisions settled by user input:** N — see
-  [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
-- **Rejected alternatives recorded:** N — see
-  [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
-- **Open items remaining:** N
-- **Recommendation:**
-  <!-- Ship as planned | Hold for specialist handoff X | Return to facilitation — open item Y unresolved -->
+<!-- LAZILY CREATED — only when at least one specialist should be re-engaged during implementation. -->
+
+- **`{specialist}`** — dispatch when <!-- condition -->; needs <!-- input artifact -->.
+
+## Sources and Plan Records
+
+<!-- Provenance plus where the deeper layers live. This section replaces any team-composition table or statistics summary — those live in the artifacts. Omit any line whose file does not exist. -->
+
+- **Feature specification:** [{filename}]({relative-path})
+  <!-- No spec file? State: "No source specification file — inputs were: {one-line summary}". -->
+- **Specification companions:** [decision log](artifacts/decision-log.md), [team findings](artifacts/team-findings.md), [technical notes](artifacts/feature-technical-notes.md)
+- **Specification decisions inherited / open items to respect:** D1, D2… / OI-1…
+- **Decision rationale and rejected alternatives:** [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Team composition and round-by-round history:** [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md)
+
+## Recommendation
+
+<!-- One or two sentences: Ship as planned | Hold for specialist handoff X | Blocked — OI-N unresolved — and why. -->

--- a/han-planning/skills/plan-implementation/references/feature-implementation-plan-template.md
+++ b/han-planning/skills/plan-implementation/references/feature-implementation-plan-template.md
@@ -11,18 +11,27 @@ claim embodies a non-obvious decision, append an inline link, e.g.
 "([D-3](artifacts/implementation-decision-log.md#d-3-rollout-strategy))". Link only claims a
 reader would ask "why this?" about. Never inline rationale, alternatives, or round history here.
 
-MINIMAL TECHNICAL DETAIL. Give the implementer a starting point — the intention of each piece of
-work, its touch points (a module, a contract, a boundary), and the decision-bearing values (a
-flag default, a key name, a threshold). Never prescribe line-level changes, inline full file
-contents, or enumerate every edit: a non-author must be able to read the plan, plans are executed
-after the codebase has moved (so edit lists go stale and mislead), and the implementer — human or
-coding agent — reads the current code at build time. Technical identifiers appear after the prose
-that explains them, only when the reader needs them.
+MINIMAL TECHNICAL DETAIL, BELOW THE PLAIN LANGUAGE IT BELONGS TO. Every section leads with
+plain-language prose a non-author can follow. Technical detail is minimal references only — a
+path, a contract name, a decision-bearing value (a flag default, a key name, a threshold) —
+placed below or after the plain language it illustrates, never mixed into it: in prose, the
+identifier follows the sentence that explains it; in lists, it nests as a sub-bullet under the
+plain-language bullet it supports. Never prescribe line-level changes, inline full file contents,
+or enumerate every edit: a non-author must be able to read the plan, plans are executed after
+the codebase has moved (so edit lists go stale and mislead), and the implementer — human or
+coding agent — reads the current code at build time. When choosing between more plain language
+and more technical detail, choose more plain language.
 -->
 
 ## Outcome
 
 <!-- Plain language: what exists in the codebase, the runtime, and the user's hands when this plan is executed, and who it serves. Two short paragraphs at most. -->
+
+## User Stories
+
+<!-- The intent of the work at a high level, before any mechanics. Derive each story from behavior the specification already commits to — never invent behavior. One story per bullet: "As a {actor}, I want {capability}, so that {benefit}." Give each a US-N ID so work units can name the story they advance. When the feature has no end-user surface, frame stories around the operator or consuming system. Omit the section only when no actor benefits in a describable way. -->
+
+- **US-1:** As a {actor}, I want {capability}, so that {benefit}.
 
 ## Constraints and Boundaries
 
@@ -34,17 +43,17 @@ that explains them, only when the reader needs them.
 
 ## Implementation Approach
 
-<!-- The shape of the implementation in plain prose: how the feature fits into the system, what it reuses, what it introduces, where the boundaries are. Lead with intention; name touch points, not edits. Add a focused subsection ONLY for a surface the plan commits a real decision on (e.g., "Data model changes", "External interfaces") — a few sentences of intention plus its D-N links, not an inventory of changes. Omit every surface with nothing decided. -->
+<!-- The shape of the implementation in plain prose: how the feature fits into the system, what it reuses, what it introduces, where the boundaries are. Lead with intention; name touch points, not edits. Technical identifiers appear only after the plain-language sentence they illustrate, or as a nested sub-bullet under it. Add a focused subsection ONLY for a surface the plan commits a real decision on (e.g., "Data model changes", "External interfaces") — a few sentences of intention plus its D-N links, not an inventory of changes. Omit every surface with nothing decided. -->
 
 ### {decision-bearing surface}
 
 ## Work Units and Sequencing
 
-<!-- Work units sized to ship. Keep Delivers at intention altitude ("invite emails send through the existing mailer"), not a file list. Link non-obvious shapes to D-N. -->
+<!-- Work units sized to ship. Keep Delivers at intention altitude ("invite emails send through the existing mailer"), not a file list. Story names the US-N each unit advances (or `—` when none applies; drop the column when the User Stories section was omitted). Link non-obvious shapes to D-N. -->
 
-| #   | Work Unit | Delivers | Depends On | Verification |
-| --- | --------- | -------- | ---------- | ------------ |
-| 1   | …         | …        | —          | …            |
+| #   | Work Unit | Story | Delivers | Depends On | Verification |
+| --- | --------- | ----- | -------- | ---------- | ------------ |
+| 1   | …         | US-1  | …        | —          | …            |
 
 ## Definition of Done
 

--- a/han-planning/skills/plan-work-items/SKILL.md
+++ b/han-planning/skills/plan-work-items/SKILL.md
@@ -49,6 +49,17 @@ up the plan.
   block is written in support of a criterion, and detail that supports no criterion is cut. In the rendered work item,
   the summary opens and the acceptance criteria sit at the bottom, immediately before Depends on. Test expectations
   live inside the acceptance criteria; there is no separate Tests block.
+- **The summary is plain context, three to five very short sentences.** It states why the work is needed and what work
+  is being done, in plain language a reader can follow without the plan open. No technical detail and no ID references —
+  plan references live in the References block, each ID paired with a one-sentence description of what it is. Never
+  write an inline `See plan: D-1, D-5` breadcrumb; an ID list without descriptions is clutter, not information.
+- **The detail block is a plain-language work list.** After the summary, the body is a `Work to be done` bullet list:
+  each bullet one to two short sentences of plain language stating a piece of the actual work. Technical detail, when
+  needed, goes in a nested bullet under the plain-language bullet it belongs to — never mixed into the parent bullet
+  and never as free-floating technical prose.
+- **Acceptance criteria are outcomes of this work item only.** Never include standard operating procedure (commit
+  pushed, CI green, PR opened, review done) — baseline practice is not a criterion. Never include a prohibition
+  ("no new test files") unless there is an explicit, validated reason, and then state the reason with the criterion.
 - **Minimal technical detail — intention over prescription.** A work item gives the implementer a starting point: the
   intention and goals of the work plus the touch points (a file path, a contract, a boundary). NEVER prescribe
   line-level changes or enumerate every edit, BECAUSE work items are often implemented long after they are written — a
@@ -63,8 +74,9 @@ up the plan.
 - `Depends on` lists other work items **in this same file** that must complete first, or `None`.
 - NEVER include process artifacts in work item bodies or the preamble. Excluded categories: iteration histories,
   decision logs, review findings, team findings, facilitation summaries, gap analyses, and anything under an
-  `artifacts/` subfolder of the plan that is not a contract or design reference. Restate plan-level decisions inline in
-  the work item with `See plan: D-N` as the breadcrumb. Full include/exclude list in
+  `artifacts/` subfolder of the plan that is not a contract or design reference. Restate plan-level decisions in plain
+  language in the work item body, and cite the decision in the References block as the ID plus a one-sentence
+  description of what it is. Full include/exclude list in
   [references/reference-artifact-inventory.md](./references/reference-artifact-inventory.md).
 
 ## Process
@@ -136,9 +148,12 @@ Launch `han-core:project-manager` (`subagent_type: "han-core:project-manager"`) 
   interaction: an architectural decision, a design review) or **AFK** (can be implemented and merged without a sync).
   Prefer AFK over HITL. Prefer many thin work items over few thick ones.
 - A directive on drafting order and altitude: draft each work item summary-first, then its acceptance criteria, then
-  only the supporting detail those criteria need. Write the criteria before the detail so the detail is forced to serve
-  them; the criteria still render at the bottom of the finished work item per the template. Keep technical detail
-  minimal — intention, goals, and touch points, never a prescribed edit list — per the Rules above.
+  only the work-to-be-done bullets those criteria need. Write the criteria before the detail so the detail is forced to
+  serve them; the criteria still render at the bottom of the finished work item per the template. The summary is three
+  to five very short plain sentences with no technical detail and no ID references; the work list is plain-language
+  bullets with technical detail nested beneath — intention, goals, and touch points, never a prescribed edit list — per
+  the Rules above. Criteria are outcomes of the work item only: no standard operating procedure, no unexplained
+  prohibitions.
 - A directive on unverified assumptions: do not mark a work item HITL only because the plan calls an assumption
   unverified. First check two things. (a) Can you settle it by reading the code? Do that, and move on if it holds. (b)
   If the assumption turns out wrong, does something break, or does it fall back to a safe default? Mark it HITL only

--- a/han-planning/skills/plan-work-items/SKILL.md
+++ b/han-planning/skills/plan-work-items/SKILL.md
@@ -44,6 +44,15 @@ up the plan.
 - Do NOT modify, annotate, or comment on the source implementation plan or context. It is read-only input.
 - Each work item is a **vertical slice**: a narrow but complete path through the relevant layers (schema, API, UI,
   tests) that is demoable or verifiable on its own. Not a layer, not a stub.
+- **Summary first, acceptance criteria second, everything else in support.** Every work item opens with a plain-language
+  summary of what it delivers and why, followed by the acceptance criteria that say when it is done. All remaining
+  detail is written in support of a named criterion — detail that supports no criterion is cut. Test expectations live
+  inside the acceptance criteria; there is no separate Tests block.
+- **Minimal technical detail — intention over prescription.** A work item gives the implementer a starting point: the
+  intention and goals of the work plus the touch points (a file path, a contract, a boundary). NEVER prescribe
+  line-level changes or enumerate every edit, BECAUSE work items are often implemented long after they are written — a
+  prescribed edit list goes stale against the moving codebase and misleads the human or coding agent who finally picks
+  it up, while intention and criteria stay valid. The implementer reads the current code at build time.
 - Every work item body MUST link the reference artifacts an implementer needs: API/event contracts, design frames,
   schema docs, runbooks, ADRs, coding standards. A work item that consumes an HTTP endpoint or event payload MUST link
   the contract section that defines it.
@@ -125,6 +134,10 @@ Launch `han-core:project-manager` (`subagent_type: "han-core:project-manager"`) 
   (schema, API, UI, tests), demoable or verifiable on its own. Classify each work item as **HITL** (requires human
   interaction: an architectural decision, a design review) or **AFK** (can be implemented and merged without a sync).
   Prefer AFK over HITL. Prefer many thin work items over few thick ones.
+- A directive on drafting order and altitude: draft each work item summary-first, then its acceptance criteria, then
+  only the supporting detail those criteria need. Write the criteria before the detail so the detail is forced to serve
+  them. Keep technical detail minimal — intention, goals, and touch points, never a prescribed edit list — per the
+  Rules above.
 - A directive on unverified assumptions: do not mark a work item HITL only because the plan calls an assumption
   unverified. First check two things. (a) Can you settle it by reading the code? Do that, and move on if it holds. (b)
   If the assumption turns out wrong, does something break, or does it fall back to a safe default? Mark it HITL only
@@ -170,8 +183,8 @@ shared-artifacts preamble) is specified in
 
 Before writing, run the standardized readability self-check (the shared standard is in your context from
 `han-communication:readability-guidance`) over the work-item prose regions only — never inside code fences, tables, the
-W-N identifiers, or the structured fields (Type, Depends on, Plan reference, Reference artifacts, Design references),
-which must survive unchanged so they still resolve. Confirm each criterion and fix any failure before writing:
+W-N identifiers, the acceptance-criteria checkboxes, or the structured fields (Depends on, inline plan references,
+References, Design references), which must survive unchanged so they still resolve. Confirm each criterion and fix any failure before writing:
 
 1. The opening line states the main point.
 2. Each heading names its content and is not a generic label.

--- a/han-planning/skills/plan-work-items/SKILL.md
+++ b/han-planning/skills/plan-work-items/SKILL.md
@@ -44,10 +44,11 @@ up the plan.
 - Do NOT modify, annotate, or comment on the source implementation plan or context. It is read-only input.
 - Each work item is a **vertical slice**: a narrow but complete path through the relevant layers (schema, API, UI,
   tests) that is demoable or verifiable on its own. Not a layer, not a stub.
-- **Summary first, acceptance criteria second, everything else in support.** Every work item opens with a plain-language
-  summary of what it delivers and why, followed by the acceptance criteria that say when it is done. All remaining
-  detail is written in support of a named criterion — detail that supports no criterion is cut. Test expectations live
-  inside the acceptance criteria; there is no separate Tests block.
+- **Summary and acceptance criteria drive the item; criteria render at the bottom.** Draft each work item's
+  plain-language summary first and its acceptance criteria immediately after — before any detail — so every remaining
+  block is written in support of a criterion, and detail that supports no criterion is cut. In the rendered work item,
+  the summary opens and the acceptance criteria sit at the bottom, immediately before Depends on. Test expectations
+  live inside the acceptance criteria; there is no separate Tests block.
 - **Minimal technical detail — intention over prescription.** A work item gives the implementer a starting point: the
   intention and goals of the work plus the touch points (a file path, a contract, a boundary). NEVER prescribe
   line-level changes or enumerate every edit, BECAUSE work items are often implemented long after they are written — a
@@ -136,8 +137,8 @@ Launch `han-core:project-manager` (`subagent_type: "han-core:project-manager"`) 
   Prefer AFK over HITL. Prefer many thin work items over few thick ones.
 - A directive on drafting order and altitude: draft each work item summary-first, then its acceptance criteria, then
   only the supporting detail those criteria need. Write the criteria before the detail so the detail is forced to serve
-  them. Keep technical detail minimal — intention, goals, and touch points, never a prescribed edit list — per the
-  Rules above.
+  them; the criteria still render at the bottom of the finished work item per the template. Keep technical detail
+  minimal — intention, goals, and touch points, never a prescribed edit list — per the Rules above.
 - A directive on unverified assumptions: do not mark a work item HITL only because the plan calls an assumption
   unverified. First check two things. (a) Can you settle it by reading the code? Do that, and move on if it holds. (b)
   If the assumption turns out wrong, does something break, or does it fall back to a safe default? Mark it HITL only

--- a/han-planning/skills/plan-work-items/references/reference-artifact-inventory.md
+++ b/han-planning/skills/plan-work-items/references/reference-artifact-inventory.md
@@ -33,8 +33,9 @@ same folder as the plan and from the plan's links.
   `design-frame-verification.md` may be cited; a `team-findings.md` may not).
 
 These exist to record how the plan was reached, not what the implementer needs to build. Plan-level decisions that
-survive into the work item are restated inline in the work item's summary or supporting detail, with `See plan: D-N` as
-the breadcrumb — never a link to the decision log itself.
+survive into the work item are restated in plain language in the work item body, and cited in the work item's
+`**References.**` block as the decision ID plus a one-sentence description of what it is — never an inline ID-only
+breadcrumb, and never a link to the decision log itself.
 
 ## Where to cite each artifact
 

--- a/han-planning/skills/plan-work-items/references/reference-artifact-inventory.md
+++ b/han-planning/skills/plan-work-items/references/reference-artifact-inventory.md
@@ -33,8 +33,8 @@ same folder as the plan and from the plan's links.
   `design-frame-verification.md` may be cited; a `team-findings.md` may not).
 
 These exist to record how the plan was reached, not what the implementer needs to build. Plan-level decisions that
-survive into the work item are restated inline in the work item description, with `See plan: D-N` as the breadcrumb —
-never a link to the decision log itself.
+survive into the work item are restated inline in the work item's summary or supporting detail, with `See plan: D-N` as
+the breadcrumb — never a link to the decision log itself.
 
 ## Where to cite each artifact
 

--- a/han-planning/skills/plan-work-items/references/work-item-template.md
+++ b/han-planning/skills/plan-work-items/references/work-item-template.md
@@ -1,20 +1,24 @@
 # Work item template
 
-Each work item in `work-items.md` uses this template. Required fields appear in the order shown. The `**References.**`
-block is required whenever the work item consumes any artifact identified in Step 4 of the skill — omit it only when no
-external artifact applies. Additional `**Bold paragraph.**` context blocks are allowed between required fields when a
-work item needs them — common ones: `**Note on scope boundary with <other work>.**` for boundary clarifications,
-`**Note on <subsystem> capability.**` for SDK or platform caveats that affect acceptance.
+Each work item in `work-items.md` uses this template. The template is built for a reader first, using progressive
+disclosure: the summary says what the work item delivers and why, the acceptance criteria say how anyone knows it is
+done, and everything below them exists to support a criterion. Required fields appear in the order shown. The
+`**References.**` block is required whenever the work item consumes any artifact identified in Step 4 of the skill —
+omit it only when no external artifact applies. Additional `**Bold paragraph.**` context blocks are allowed between the
+supporting detail and the reference blocks when a work item needs them — common ones:
+`**Note on scope boundary with <other work>.**` for boundary clarifications, `**Note on <subsystem> capability.**` for
+SDK or platform caveats that affect acceptance.
 
 ```
 ## <W-N> — <short descriptive name>
 
-**Summary.** One paragraph describing what this work item delivers. Include a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)` or `See plan: D-3, D-7, and Work Unit 2`). The plan reference replaces a standalone "Work items addressed" field — do not add one.
+**Summary.** One short paragraph, in plain language, stating what this work item delivers and why it matters. A reader who stops here still knows the goal. Include a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)` or `See plan: D-3, D-7, and Work Unit 2`). The plan reference replaces a standalone "Work items addressed" field — do not add one.
 
-**Description.**
-1. Numbered steps describing the full behavior to build.
-2. Reference implementation details by file path where helpful (`db/ent/schema/jot.go`), but do not prescribe implementation code.
-3. Duplicate content from the parent plan into this description when clarity requires it.
+**Acceptance criteria.**
+- [ ] Each criterion is an observable, verifiable outcome: a behavior that occurs, a state that exists, a check that passes. A person can mark it done without interpreting intent.
+- [ ] When the behavior needs automated test coverage, one criterion names that coverage in plain terms (e.g., "Automated tests cover the rejection path and the happy path").
+
+**Supporting detail.** Short paragraphs or bullets, each written in support of a named acceptance criterion — detail that supports no criterion is cut. Describe the intention and goals of the work, not the edits: give the implementer a starting point (a file path, a contract, a boundary to respect) and stop short of prescribing line-level changes or implementation code. Work items are often implemented long after they are written, so a prescribed edit list goes stale and misleads; intention and criteria stay valid, and the implementer reads the current code at build time. Duplicate content from the parent plan here when clarity requires it.
 
 *(Insert additional `**Bold paragraph.**` blocks here when needed — e.g., `**Note on scope boundary.**`.)*
 
@@ -30,13 +34,6 @@ work item needs them — common ones: `**Note on scope boundary with <other work
 - **ADR / standard / repo doc** — link any architectural decision, coding standard, or feature doc the implementer must honor.
 - Omit any bullet that does not apply. Do not link iteration histories, decision logs, review findings, team findings, facilitation summaries, or any other process artifact.
 
-**Tests.**
-- Bullet list of tests required for the behavior above. Be concrete: name the test type (unit, integration, migration, visual, etc.) and the assertion.
-
-**Acceptance criteria.**
-- [ ] Criterion 1
-- [ ] Criterion 2
-
 **Depends on.** `<W-N>` (within this file), comma-separated for multiple, or `None.`
 ```
 
@@ -45,6 +42,8 @@ work item needs them — common ones: `**Note on scope boundary with <other work
 - Heading line begins with `## ` followed by `<W-N>` (the prefix letters, a dash, then digits), then `—` (em-dash with
   surrounding spaces), then the title.
 - A work item body ends at the next `## ` heading or end of file.
+- `**Summary.**` comes first and `**Acceptance criteria.**` second. Every block after the criteria supports a criterion;
+  there is no separate `**Tests.**` block — test expectations live inside the acceptance criteria.
 - Design-reference paths are relative to the `work-items.md` file (e.g., `ui-designs/<file>.png` when the screenshots
   live in the plan folder). Never use an absolute path or a cross-repository URL.
 - The `**Depends on.**` line uses the literal bold marker, comma-separates dependencies, and ends with `.` (the trailing

--- a/han-planning/skills/plan-work-items/references/work-item-template.md
+++ b/han-planning/skills/plan-work-items/references/work-item-template.md
@@ -1,8 +1,10 @@
 # Work item template
 
 Each work item in `work-items.md` uses this template. The template is built for a reader first, using progressive
-disclosure: the summary says what the work item delivers and why, the acceptance criteria say how anyone knows it is
-done, and everything below them exists to support a criterion. Required fields appear in the order shown. The
+disclosure: the summary says what the work item delivers and why, the acceptance criteria at the bottom say how anyone
+knows it is done, and everything in between exists to support a criterion. The criteria are drafted immediately after
+the summary — before any detail — even though they render at the bottom, so the detail is forced to serve them.
+Required fields appear in the order shown. The
 `**References.**` block is required whenever the work item consumes any artifact identified in Step 4 of the skill —
 omit it only when no external artifact applies. Additional `**Bold paragraph.**` context blocks are allowed between the
 supporting detail and the reference blocks when a work item needs them — common ones:
@@ -14,11 +16,7 @@ SDK or platform caveats that affect acceptance.
 
 **Summary.** One short paragraph, in plain language, stating what this work item delivers and why it matters. A reader who stops here still knows the goal. Include a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)` or `See plan: D-3, D-7, and Work Unit 2`). The plan reference replaces a standalone "Work items addressed" field — do not add one.
 
-**Acceptance criteria.**
-- [ ] Each criterion is an observable, verifiable outcome: a behavior that occurs, a state that exists, a check that passes. A person can mark it done without interpreting intent.
-- [ ] When the behavior needs automated test coverage, one criterion names that coverage in plain terms (e.g., "Automated tests cover the rejection path and the happy path").
-
-**Supporting detail.** Short paragraphs or bullets, each written in support of a named acceptance criterion — detail that supports no criterion is cut. Describe the intention and goals of the work, not the edits: give the implementer a starting point (a file path, a contract, a boundary to respect) and stop short of prescribing line-level changes or implementation code. Work items are often implemented long after they are written, so a prescribed edit list goes stale and misleads; intention and criteria stay valid, and the implementer reads the current code at build time. Duplicate content from the parent plan here when clarity requires it.
+**Supporting detail.** Short paragraphs or bullets, each written in support of an acceptance criterion below — detail that supports no criterion is cut. Describe the intention and goals of the work, not the edits: give the implementer a starting point (a file path, a contract, a boundary to respect) and stop short of prescribing line-level changes or implementation code. Work items are often implemented long after they are written, so a prescribed edit list goes stale and misleads; intention and criteria stay valid, and the implementer reads the current code at build time. Duplicate content from the parent plan here when clarity requires it.
 
 *(Insert additional `**Bold paragraph.**` blocks here when needed — e.g., `**Note on scope boundary.**`.)*
 
@@ -34,6 +32,10 @@ SDK or platform caveats that affect acceptance.
 - **ADR / standard / repo doc** — link any architectural decision, coding standard, or feature doc the implementer must honor.
 - Omit any bullet that does not apply. Do not link iteration histories, decision logs, review findings, team findings, facilitation summaries, or any other process artifact.
 
+**Acceptance criteria.**
+- [ ] Each criterion is an observable, verifiable outcome: a behavior that occurs, a state that exists, a check that passes. A person can mark it done without interpreting intent.
+- [ ] When the behavior needs automated test coverage, one criterion names that coverage in plain terms (e.g., "Automated tests cover the rejection path and the happy path").
+
 **Depends on.** `<W-N>` (within this file), comma-separated for multiple, or `None.`
 ```
 
@@ -42,8 +44,9 @@ SDK or platform caveats that affect acceptance.
 - Heading line begins with `## ` followed by `<W-N>` (the prefix letters, a dash, then digits), then `—` (em-dash with
   surrounding spaces), then the title.
 - A work item body ends at the next `## ` heading or end of file.
-- `**Summary.**` comes first and `**Acceptance criteria.**` second. Every block after the criteria supports a criterion;
-  there is no separate `**Tests.**` block — test expectations live inside the acceptance criteria.
+- `**Summary.**` comes first; `**Acceptance criteria.**` renders at the bottom, immediately before `**Depends on.**`.
+  Every block between them supports a criterion; there is no separate `**Tests.**` block — test expectations live
+  inside the acceptance criteria.
 - Design-reference paths are relative to the `work-items.md` file (e.g., `ui-designs/<file>.png` when the screenshots
   live in the plan folder). Never use an absolute path or a cross-repository URL.
 - The `**Depends on.**` line uses the literal bold marker, comma-separates dependencies, and ends with `.` (the trailing

--- a/han-planning/skills/plan-work-items/references/work-item-template.md
+++ b/han-planning/skills/plan-work-items/references/work-item-template.md
@@ -1,22 +1,26 @@
 # Work item template
 
 Each work item in `work-items.md` uses this template. The template is built for a reader first, using progressive
-disclosure: the summary says what the work item delivers and why, the acceptance criteria at the bottom say how anyone
-knows it is done, and everything in between exists to support a criterion. The criteria are drafted immediately after
-the summary — before any detail — even though they render at the bottom, so the detail is forced to serve them.
-Required fields appear in the order shown. The
-`**References.**` block is required whenever the work item consumes any artifact identified in Step 4 of the skill —
-omit it only when no external artifact applies. Additional `**Bold paragraph.**` context blocks are allowed between the
-supporting detail and the reference blocks when a work item needs them — common ones:
+disclosure: the summary says why the work is needed and what is being done, the work-to-be-done list says what the
+implementer will do, the acceptance criteria at the bottom say how anyone knows it is done, and everything in between
+exists to support a criterion. The criteria are drafted immediately after the summary — before any detail — even though
+they render at the bottom, so the detail is forced to serve them. Required fields appear in the order shown. The
+`**References.**` block is required whenever the work item consumes any artifact identified in Step 4 of the skill or
+restates a plan decision — omit it only when neither applies. Additional `**Bold paragraph.**` context blocks are
+allowed between the work-to-be-done list and the reference blocks when a work item needs them — common ones:
 `**Note on scope boundary with <other work>.**` for boundary clarifications, `**Note on <subsystem> capability.**` for
 SDK or platform caveats that affect acceptance.
 
 ```
 ## <W-N> — <short descriptive name>
 
-**Summary.** One short paragraph, in plain language, stating what this work item delivers and why it matters. A reader who stops here still knows the goal. Include a plan reference inline (e.g., `See plan: [D-6](feature-implementation-plan.md#d-6-...)` or `See plan: D-3, D-7, and Work Unit 2`). The plan reference replaces a standalone "Work items addressed" field — do not add one.
+**Summary.** Three to five very short, plain-language sentences. State the context for why this work is needed, then what work is being done. No technical detail: no file paths, no type names, no tool commands. No IDs or reference lists — plan references belong in the References block, each with a one-sentence description. A reader who stops here knows the goal and nothing they must decode.
 
-**Supporting detail.** Short paragraphs or bullets, each written in support of an acceptance criterion below — detail that supports no criterion is cut. Describe the intention and goals of the work, not the edits: give the implementer a starting point (a file path, a contract, a boundary to respect) and stop short of prescribing line-level changes or implementation code. Work items are often implemented long after they are written, so a prescribed edit list goes stale and misleads; intention and criteria stay valid, and the implementer reads the current code at build time. Duplicate content from the parent plan here when clarity requires it.
+**Work to be done.**
+- A bullet point list of the actual work to do, in plain language with no technical detail. Each bullet is one to two short sentences.
+  - When technical detail is needed, put it in a nested bullet under the plain-language bullet it belongs to: the file path, the contract, the constraint, the boundary to respect.
+  - Nested detail gives the implementer a starting point and stops short of prescribing line-level changes or implementation code. Work items are often implemented long after they are written, so a prescribed edit list goes stale and misleads; intention and criteria stay valid, and the implementer reads the current code at build time.
+- Every bullet supports an acceptance criterion below — work that supports no criterion is cut.
 
 *(Insert additional `**Bold paragraph.**` blocks here when needed — e.g., `**Note on scope boundary.**`.)*
 
@@ -25,6 +29,7 @@ SDK or platform caveats that affect acceptance.
 - *<state-or-scenario name>* — `[![<alt text>](ui-designs/<file>.png)](ui-designs/<file>.png)`
 
 **References.**
+- **Plan decisions** — every plan decision or work unit this item satisfies, one bullet each: the ID as a link (e.g., `[D-6](feature-implementation-plan.md#d-6-...)`) followed by one short plain sentence saying what that decision or work unit actually is. Never a bare ID list — a reader must not need the plan open to know what the ID means. This block replaces any inline `See plan: ...` reference and any standalone "Work items addressed" field — do not add either.
 - **API contract** — `[<file>#<anchor>](<relative-path>)` (e.g., `[api-contracts.md#post-v1-parent_kind-id-comments-create](api-contracts.md#post-v1parent_kindidcomments--create)`). Required when the work item produces or consumes an HTTP endpoint.
 - **Event contract** — `[<file>#<event-section>](<relative-path>)`. Required when the work item produces or consumes an event payload.
 - **Design (Pencil)** — `<pen-file-path>`, frames `<frameId>` (purpose), `<frameId>` (purpose). Required for UI work items.
@@ -33,11 +38,20 @@ SDK or platform caveats that affect acceptance.
 - Omit any bullet that does not apply. Do not link iteration histories, decision logs, review findings, team findings, facilitation summaries, or any other process artifact.
 
 **Acceptance criteria.**
-- [ ] Each criterion is an observable, verifiable outcome: a behavior that occurs, a state that exists, a check that passes. A person can mark it done without interpreting intent.
+- [ ] Each criterion is an observable, verifiable outcome of this work item's own behavior: a behavior that occurs, a state that exists, a check that passes. A person can mark it done without interpreting intent.
 - [ ] When the behavior needs automated test coverage, one criterion names that coverage in plain terms (e.g., "Automated tests cover the rejection path and the happy path").
 
 **Depends on.** `<W-N>` (within this file), comma-separated for multiple, or `None.`
 ```
+
+## What is never an acceptance criterion
+
+- **Standard operating procedure.** Committing, pushing, opening a PR, passing CI, getting review — baseline software
+  practice that applies to every change. Stating it adds noise and implies other items are exempt. Never include it.
+- **Unexplained prohibitions.** Negative constraints like "no new test files are added" or "do not touch X" send
+  implementers down bad paths. Include a prohibition only when there is an explicit, validated reason for it, and state
+  that reason with the criterion (e.g., "No new migration is added, because the schema change shipped in W-2 and a
+  second migration would conflict"). A prohibition with no stated reason is cut.
 
 ## Format invariants
 
@@ -47,6 +61,8 @@ SDK or platform caveats that affect acceptance.
 - `**Summary.**` comes first; `**Acceptance criteria.**` renders at the bottom, immediately before `**Depends on.**`.
   Every block between them supports a criterion; there is no separate `**Tests.**` block — test expectations live
   inside the acceptance criteria.
+- Plan references live only in the `**References.**` block, each ID paired with a one-sentence description. The summary
+  and work-to-be-done bullets never carry an ID-only reference such as `See plan: D-1, D-5`.
 - Design-reference paths are relative to the `work-items.md` file (e.g., `ui-designs/<file>.png` when the screenshots
   live in the plan folder). Never use an absolute path or a cross-repository URL.
 - The `**Depends on.**` line uses the literal bold marker, comma-separates dependencies, and ends with `.` (the trailing


### PR DESCRIPTION
## Summary

**This PR restructures planning and ticket artifacts into a summary-first, acceptance-criteria-driven shape, so work items and implementation plans read top-down and stop prescribing edit lists that go stale as the codebase moves.**

## Behavior changes

The central change replaces `Description` and `Tests` in every work item and ticket with `Supporting detail` plus acceptance criteria that carry the test expectations as observable outcomes. Work items are now drafted summary-first and criteria-second, so every block of supporting detail backs a specific criterion and detail that backs none is cut. In the rendered output, a plain-language summary opens the item and the acceptance criteria sit at the bottom, just before `Depends on`.

The `plan-work-items` and `plan-implementation` skills also shift to an "intention over prescription" altitude: an item names the goal and its touch points, such as a file path, a contract, or a boundary, but never enumerates line-level edits. Plans and tickets are often executed after the code has moved, and a prescribed edit list would mislead whoever picks up the work.

The `feature-implementation-plan` template is reordered for progressive disclosure (plain-language opening, then intention-level sections, then deeper records) and drops its inline team-composition table and statistics summary, which now live one hop away in the companion artifacts. Three sections are renamed to match: `RAID Log` splits into a lazy `Risks and Assumptions` section plus `Open Items`, `Decomposition and Sequencing` becomes `Work Units and Sequencing`, and `Source Specification` becomes a closing `Sources and Plan Records` section. The downstream ticket templates in `han-github` (GitHub issues), `han-atlassian` (Jira), and `han-linear` (Linear) are updated to match the new work-item field shape, keeping published tickets consistent with the source `work-items.md`.
