### PR TITLE
Apply Orwell's six rules of writing to the han-communication guidance

### DIFF
--- a/docs/plans/orwell-six-rules/artifacts/.discovery-notes.md
+++ b/docs/plans/orwell-six-rules/artifacts/.discovery-notes.md
@@ -1,0 +1,58 @@
+# Discovery Notes: Orwell Six Rules Applied to han-communication
+
+Source document: `docs/research/orwell-six-rules-of-writing.md` (adversarially validated research report; its
+Recommendation section is the "what" for this plan). No feature-specification.md exists for this work; the research
+report is the source artifact. No `feature-technical-notes.md` exists (no T# notes apply).
+
+## Tech stack
+
+- Markdown-only Claude Code plugin suite. No application code, no build step, no test runner.
+- Pre-commit hooks: prettier (markdown), whitespace/EOF fixers. Commits on branch `orwell-6-rules-of-writing`.
+- Plugin versioning: per-plugin `plugin.json`. Memory rule: never bump a version unprompted.
+
+## Governing conventions (CLAUDE.md)
+
+- One canonical source per concept; no vendored copies of the readability standard. `han-communication` owns it.
+- All skill/agent edits must follow han-plugin-builder guidance (`han-plugin-builder/skills/guidance/references/`);
+  agent changes should be reviewed against `agent-builder`/`guidance` skill rules.
+- Voice is uniform per `han-communication/references/writing-voice.md`; YAGNI applies to docs.
+- Documentation is plugin-first: long-form docs live in `{plugin}/docs/`; cross-plugin surfaces under repo `docs/`.
+
+## Touch points (from the research report's O2, verified by codebase exploration)
+
+- `han-communication/references/readability-rule.md` (135 lines) — nine output properties, length guidance,
+  fidelity-wins section, six-point self-check with explicit keep-it-small design principle (lines 111-113). Read in
+  full by every reader-facing skill via `readability-guidance` (wide blast radius).
+- `han-communication/references/writing-voice.md` (326 lines) — voice attributes; "Avoided words and phrases"
+  (lines 98-114) and "AI slop to avoid" (lines 220-224) are the authoritative blocklist; sports-metaphor
+  load-bearing-vs-decorative test at line 110; physical-world analogies named a signature move (lines 30-33).
+- `han-communication/agents/readability-editor.md` (103 lines) — hardcoded six-criterion rubric (lines 55-74) closing
+  with "They are the whole rubric."; fidelity override at lines 29-33 and 94-102.
+- Possible doc surfaces if guidance text changes: `han-communication/docs/skills/readability-guidance.md`,
+  `han-communication/docs/skills/edit-for-readability.md`, `han-communication/docs/agents/readability-editor.md`,
+  repo-root `docs/readability.md`. The `han-update-documentation` skill exists for post-change doc sweeps.
+
+## Prior art in-repo
+
+- `docs/plans/readability-output-standard/` — the original spec for the standard (feature-specification.md +
+  artifacts/decision-log.md + team-findings.md). Precedent for plan format and for the standard's design decisions.
+- `docs/plans/readability-in-planning-coding/` — later spec + implementation plan extending readability to the
+  planning/coding plugins; commit 2b884f2 shows a D9 "scope reconciliation in rule + guidance" precedent.
+- Recent churn (90 days): han-communication was created (Phase 1), consumers rewired cross-plugin (Phase 3),
+  docs reorg moved long-form docs into plugins.
+
+## Gaps (searched, not found)
+
+- No `docs/adr/` or ADR directory anywhere.
+- No `docs/coding-standards/` or `.github/CODING_STANDARDS.md`.
+- No feature specification or technical notes for this work; the research report stands in.
+
+## Constraints carried from the research report's validation (V-findings)
+
+- V5: edits to reference files alone never reach the rewrite pass; the agent's rubric must also be touched.
+- V6: `readability-rule.md` has suite-wide blast radius; consider the smallest surface that still reaches all paths.
+- V7: the stale-figures principle needs the load-bearing-vs-decorative dividing line to avoid conflicting with the
+  voice profile's signature analogies.
+- V1: the jargon edit is scoped to naming foreign/Latinate/archaic diction as examples of the existing replace-first
+  rule, not a new framework.
+- Self-check stays at six criteria (compliance-decay design principle, readability-rule.md lines 111-113).

--- a/docs/plans/orwell-six-rules/artifacts/implementation-decision-log.md
+++ b/docs/plans/orwell-six-rules/artifacts/implementation-decision-log.md
@@ -1,0 +1,146 @@
+# Implementation Decision Log: Orwell's Six Rules Applied to han-communication
+
+<!--
+This file records every implementation decision committed while planning the Orwell six-rules edits.
+Behavioral and implementation statements live in [../feature-implementation-plan.md](../feature-implementation-plan.md).
+This file captures the question, rationale, evidence, and rejected alternatives for each decision.
+Round-by-round history lives in [implementation-iteration-history.md](implementation-iteration-history.md).
+
+Source artifact: docs/research/orwell-six-rules-of-writing.md. No feature-specification.md exists; the
+research report's O2 and Recommendation served as the "what". No feature-technical-notes.md exists.
+-->
+
+## Trivial decisions
+
+<!-- None. Every committed decision below rests on codebase evidence or a rejected alternative, so all are full. -->
+
+## Full decisions
+
+### D-1: Escape-clause placement and scoping
+
+- **Question:** Where does Orwell's rule 6 ("break a rule rather than write something clumsy") belong in the standard, and how far does it reach?
+- **Decision:** Add a new H2 section to `readability-rule.md` between "Fidelity wins" (ends line 95) and "The standardized self-check" (line 97): when following a rule would make the prose read worse, break the rule. Scope it to the drafting properties and rewrite moves only. It never licenses a blocklisted word and never licenses a fidelity loss, so it yields to both hard gates. Give the section a descriptive heading.
+- **Rationale:** Orwell subordinates the five mechanical rules to clarity, and the standard lacks any general statement of that principle (research gaps section, rule 6). The mature plain-language guides all attach a named, scoped exception rather than an unqualified override, which is the pattern this follows. Scoping the clause to yield to both hard gates keeps it from swallowing the blocklist or the fidelity guard, the ambiguity JD raised as OQ-1.
+- **Evidence:**
+  - `docs/research/orwell-six-rules-of-writing.md` Recommendation and gaps section (rule 6 confirmed gap, V2); A1 (Orwell rule 6); A9, A10 (scoped-exception pattern in plainlanguage.gov and GOV.UK).
+  - `han-communication/references/readability-rule.md:90-95` (Fidelity wins), `:97` (self-check start), `:106` (sentence-length escape "without reason"), `:111-113` (keep-it-small design principle).
+  - R1 claim ledger C1 (placement), C8 and OQ-1 resolution (scope boundary against the hard gates).
+- **Rejected alternatives:**
+  - Add it as a seventh self-check criterion (research option O1), rejected because the self-check is kept small on purpose to avoid compliance decay (`readability-rule.md:111-113`), and break-the-rule judgment is not the yes/no criterion the self-check requires.
+  - State it as an unqualified override, rejected because an unscoped clause can excuse a blocklisted word or a fidelity loss, which OQ-1 evidence rules out (self-check criterion 5 and "Fidelity wins" stay absolute).
+- **Specialist owner:** `information-architect`
+- **Revisit criterion:** A drafted or rewritten deliverable is observed using the escape clause to justify a blocklisted word or a dropped fact.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-4
+- **Referenced in plan:** Implementation Approach, Work Units and Sequencing, Definition of Done, Risks and Assumptions
+
+### D-2: Stale-figures principle placement, dividing line, and carve-out
+
+- **Question:** Where does the general principle against stale figures of speech live, and how does an editor tell a worn cliche from a signature analogy?
+- **Decision:** Add a general principle against stale figures of speech and pretentious or archaic diction to the "Avoided words and phrases" section of `writing-voice.md` (lines 98-114), stated principle-first with examples second, beside the existing load-bearing-versus-decorative test (line 110). Point it explicitly at the signature-move carve-out (lines 30-33) so fresh, load-bearing physical-world analogies stay legal.
+- **Rationale:** The AI-slop list bans specific worn phrases but no file states a general principle against reaching for a stale metaphor (research gaps section, rule 1, confirmed by V2). The voice profile encourages physical-world analogies as a signature move, so a bare "avoid stale figures" principle would over-flag them (V7). Reusing the line-110 load-bearing-versus-decorative test gives the editor a dividing line, and naming the carve-out at lines 30-33 keeps signature analogies safe.
+- **Evidence:**
+  - `docs/research/orwell-six-rules-of-writing.md` O2 edit 2, gaps section (rule 1), V7 (dividing line required).
+  - `han-communication/references/writing-voice.md:98-114` ("Avoided words and phrases"), `:110` (load-bearing-vs-decorative test), `:30-33` (physical-world-analogy signature move).
+  - R1 claim ledger C2 (placement, principle-first), C12 (must point at the carve-out or physical-world analogies get over-flagged).
+- **Rejected alternatives:**
+  - Land the principle in the "AI slop to avoid" section (lines 220-224), rejected because that section enumerates a specific modern corpus, not a general drafting principle, and C2 places the general principle beside the existing dividing-line test.
+  - State a bare "avoid stale figures" principle with no dividing line, rejected because V7 shows it gives the editor no way to separate a signature analogy from a cliche, over-flagging the carve-out at lines 30-33.
+- **Specialist owner:** `information-architect`
+- **Revisit criterion:** Signature physical-world analogies are flagged as stale figures in a rewrite pass.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-4
+- **Referenced in plan:** Implementation Approach, Work Units and Sequencing, Risks and Assumptions
+
+### D-3: Foreign and archaic diction lands only in the writing-voice blocklist
+
+- **Question:** Where do foreign or Latinate stock phrases and archaic formal words get named, and does `readability-rule.md` need its own copy?
+- **Decision:** Add foreign and Latinate stock phrases ("in lieu of," "per se") and archaic formal words ("aforementioned," "herein") to the same "Avoided words and phrases" section of `writing-voice.md`, as examples of the existing replace-first pattern. Do not add them to `readability-rule.md`.
+- **Rationale:** The replace-versus-define framework already exists in the rule; the only gap is that the guidance never names this specific category (research V1 rescoped the rule 5 edit from "add a framework" to "name the missing categories"). `readability-rule.md:78-80` designates the writing-voice blocklist authoritative for the words it covers, so adding a word list to the rule would create a competing list (C3, OQ-5).
+- **Evidence:**
+  - `docs/research/orwell-six-rules-of-writing.md` O2 edit 3 as rescoped by V1; A19, A20 (current word-guidance state).
+  - `han-communication/references/readability-rule.md:78-80` (blocklist is authoritative; the rule must not duplicate it).
+  - R1 claim ledger C3 and OQ-5 resolution (the single canonical home is the writing-voice blocklist).
+- **Rejected alternatives:**
+  - Add the words to the "Common words" property in `readability-rule.md`, rejected because `readability-rule.md:78-80` makes the writing-voice blocklist authoritative, and a second list would compete with it (C3).
+- **Specialist owner:** `information-architect`
+- **Revisit criterion:** A second authoritative word list is proposed for the readability rule.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-4
+- **Referenced in plan:** Implementation Approach, Work Units and Sequencing
+
+### D-4: Agent-edit shape keeps the rubric at six
+
+- **Question:** How does the readability-editor agent absorb the new principles without growing its six-criterion rubric?
+- **Decision:** In `readability-editor.md`, add the escape clause as a governing principle beside the fidelity principle (lines 29-33), not as a seventh criterion. Weave the stale-figures and foreign/archaic-diction scope into the existing criterion 5. The rubric stays at exactly six criteria and "They are the whole rubric" (line 57) stays literally true.
+- **Rationale:** Edits to the reference files alone never reach the rewrite pass, because the agent carries its own hardcoded rubric and reads only the rule and the draft, never `writing-voice.md` (V5, C5). So the principles must be named inline in the agent. Keeping the rubric at six preserves the keep-it-small design and keeps the "six criteria" count true across the seven-plus surfaces that echo it (C6). Placing the escape clause beside the fidelity principle mirrors its home in the rule (D-1), and folding the diction scope into criterion 5 mirrors the blocklist reference already there (line 68).
+- **Evidence:**
+  - `docs/research/orwell-six-rules-of-writing.md` V5 (reference-file edits miss the rewrite pass; the agent must be touched), Recommendation.
+  - `han-communication/agents/readability-editor.md:29-33` (fidelity governing principle), `:57` ("They are the whole rubric"), `:68` (criterion 5 blocklist reference), `:78` (agent reads only the rule and the draft).
+  - R1 claim ledger C4 (shape), C5 (inline naming required), C6 (seven-plus count surfaces stay true only if the rubric stays six), OQ-2 resolution.
+- **Rejected alternatives:**
+  - Add a seventh rubric criterion, rejected because it breaks the keep-it-small design (research O1) and falsifies the "six criteria" count on the seven-plus surfaces that echo it (C6, F10).
+  - Rely on reference-file inheritance only, rejected because V5 shows the agent's hardcoded rubric never reads the reference files, so a principle added only there is invisible to the rewrite pass (C5).
+- **Specialist owner:** `information-architect`
+- **Revisit criterion:** The agent is observed overriding a rubric criterion, or an operator reports confusion about the rubric count.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-5, D-6, D-7
+- **Referenced in plan:** Implementation Approach, Work Units and Sequencing, Definition of Done
+
+### D-5: Manual dry-run acceptance check
+
+- **Question:** How is the behavior of the edited editor agent verified when the repo has no automated tests?
+- **Decision:** Run the edited editor agent on a sample document that contains a stale metaphor, "in lieu of," an archaic word such as "aforementioned," and one load-bearing signature analogy that must survive unchanged. The edit passes when the first three are corrected and the signature analogy is preserved.
+- **Rationale:** The research names the missing dry run as a residual risk, and the repo has no test runner, so a manual dry run is the only behavior-level verification available. The sample is built to exercise both the new flagging behavior (D-2, D-3) and the carve-out that must not fire (D-2's dividing line).
+- **Evidence:**
+  - `docs/research/orwell-six-rules-of-writing.md` Confidence Assessment (no dry run performed; named residual risk).
+  - `docs/plans/orwell-six-rules/artifacts/.discovery-notes.md` (markdown-only suite, no test runner).
+  - R1 claim ledger C10 (no acceptance check exists), OQ-3 resolution (manual dry run is in scope).
+- **Rejected alternatives:**
+  - Ship with no verification, rejected because the research flags the missing dry run as a residual risk and there is no automated coverage to catch a regression.
+- **Specialist owner:** `test-engineer`
+- **Revisit criterion:** Automated coverage for the readability standard is introduced, at which point the manual dry run can be encoded.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** None
+- **Referenced in plan:** Work Units and Sequencing, Definition of Done, Testing Strategy
+
+### D-6: Guidance-review prerequisite for the agent edit
+
+- **Question:** Does the agent edit need a han-plugin-builder review, and if so, a full interview or a review pass?
+- **Decision:** Run a han-plugin-builder guidance review over the edited `readability-editor.md`, as a review pass rather than a full agent-builder interview.
+- **Rationale:** CLAUDE.md mandates han-plugin-builder guidance for agent definitions, and the four-edit plan did not name this prerequisite (C11). The guidance skill's stated purpose includes reviewing an existing agent against the guidance, which fits an edit; the full agent-builder interview is for authoring an agent from scratch.
+- **Evidence:**
+  - `CLAUDE.md` (all agent edits must follow han-plugin-builder guidance).
+  - `docs/plans/orwell-six-rules/artifacts/.discovery-notes.md` (governing convention: agent changes reviewed against agent-builder/guidance rules).
+  - R1 claim ledger C11 (prerequisite not named in the four-edit plan), OQ-4 resolution (review pass, not full interview).
+- **Rejected alternatives:**
+  - Run a full agent-builder interview, rejected because that process authors an agent from scratch, while this is a scoped edit to an existing agent, which the guidance skill's review purpose covers.
+- **Specialist owner:** `information-architect`
+- **Revisit criterion:** The agent edit grows beyond the escape-clause and criterion-5 amendment into a structural rewrite.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** None
+- **Referenced in plan:** Work Units and Sequencing, Definition of Done
+
+### D-7: Scoped doc-consistency check and no consuming-skill edits
+
+- **Question:** After the edits, which downstream surfaces need updating, and which do not?
+- **Decision:** Run a scoped doc-consistency check (the `han-update-documentation` skill on this branch) limited to statements the edits make false. The "six criteria" count claims on the seven-plus surfaces stay untouched and true. Make no consuming-skill edits; reference-file changes propagate through readability-guidance's live reads.
+- **Rationale:** The C4 agent shape keeps the rubric at six, so the count claims stay true and must not be touched (C6, C9). Criterion-5 paraphrases in the agent's long-form doc are the only statements at risk, so the check is scoped to them. Consuming skills read the reference files live through `readability-guidance` (SKILL.md:32-40), so no consuming-skill edit is needed (C7).
+- **Evidence:**
+  - `han-communication/skills/readability-guidance/SKILL.md:32-40` (live cross-plugin reads; edits propagate without consumer changes).
+  - R1 claim ledger C6 (grep-confirmed count surfaces stay true), C7 (no consuming-skill edits), C9 (criterion-5 paraphrase check still needed).
+- **Rejected alternatives:**
+  - Run a full-repo documentation sweep, rejected because the edits keep the rubric at six, so only statements the edits make false need review; a broad sweep risks touching count claims that must stay as they are (C6).
+  - Edit consuming skills to carry the new principles, rejected because they read the reference files live through readability-guidance, so the edits reach them without consumer changes (C7).
+- **Specialist owner:** `information-architect`
+- **Revisit criterion:** A consuming skill is found to cache or copy the reference-file text rather than read it live.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** None
+- **Referenced in plan:** Work Units and Sequencing, Definition of Done

--- a/docs/plans/orwell-six-rules/artifacts/implementation-iteration-history.md
+++ b/docs/plans/orwell-six-rules/artifacts/implementation-iteration-history.md
@@ -1,0 +1,68 @@
+# Implementation Iteration History: Orwell Six Rules Applied to han-communication
+
+<!--
+This file records how the implementation plan evolved across discussion rounds. Committed decisions live in
+[implementation-decision-log.md](implementation-decision-log.md) and the primary plan lives in
+[../feature-implementation-plan.md](../feature-implementation-plan.md).
+
+Source artifact: docs/research/orwell-six-rules-of-writing.md (no feature-specification.md exists; the research
+report's Recommendation is the "what"). No feature-technical-notes.md exists, so no T# tags apply.
+-->
+
+## R1: Parallel specialist review (information-architect + junior-developer)
+
+- **Specialists engaged:** han-core:information-architect, han-core:junior-developer
+- **New input provided:** Research report (`docs/research/orwell-six-rules-of-writing.md`), discovery notes
+  (`.discovery-notes.md`), the four committed edits from research O2, and the hard constraint that the six-point
+  self-check stays six.
+- **Claim ledger:**
+
+  | # | Claim | Raised by | Category | State |
+  | - | ----- | --------- | -------- | ----- |
+  | C1 | Escape clause belongs as its own H2 in readability-rule.md between "Fidelity wins" (ends line 95) and "The standardized self-check" (line 97), phrased subordinate to fidelity, with a descriptive heading | IA (F1, F2, F3) | placement | Evidenced |
+  | C2 | Edits 2 and 3 both land in writing-voice.md "Avoided words and phrases" (lines 98-114), principle first then examples, beside the existing load-bearing-vs-decorative test (line 110); not in "AI slop to avoid" | IA (F4, F7) | placement | Evidenced |
+  | C3 | Edit 3's words go only in the writing-voice blocklist; adding them to readability-rule.md would create a competing word list (readability-rule.md:78-80 designates the blocklist authoritative) | IA (F6), answers JD-007 | placement | Evidenced |
+  | C4 | Agent edit shape: escape clause sits beside the fidelity governing principle (readability-editor.md:29-33), stale-figures/diction scope amends existing criterion 5; rubric stays exactly six, "they are the whole rubric" stays literally true | IA (F8, F9), answers JD-002 | structural | Evidenced |
+  | C5 | The stale-figures principle must be named inline in the editor because the agent reads only the rule and the draft, never writing-voice.md (readability-editor.md:78) | IA (F9, F14) | mechanic | Evidenced |
+  | C6 | Seven-plus surfaces echo the "six criteria" count and all stay true only if no rubric grows to seven (grep-confirmed list in F10) | IA (F10) | guard | Evidenced |
+  | C7 | No consuming-skill edits needed; reference-file edits propagate via readability-guidance's live reads (SKILL.md:32-40) | IA (F11) | scope | Evidenced |
+  | C8 | The escape clause needs a defined boundary against the self-check's hard gates or it can swallow the blocklist | JD (JD-001) | ambiguity | Evidenced (resolved, see OQ-1) |
+  | C9 | With the C4 shape, agent long-form doc count claims stay true; a scoped doc-consistency check still needed for criterion-5 paraphrases | JD (JD-003) + IA (F13) | overlap | Evidenced |
+  | C10 | No acceptance check exists; the research itself flags the missing dry run as residual risk | JD (JD-004) | edge-case | Evidenced |
+  | C11 | CLAUDE.md requires han-plugin-builder guidance for agent changes; the four-edit plan does not name this prerequisite | JD (JD-005) | convention | Evidenced |
+  | C12 | The line-110 dividing-line test was written for sports metaphors; edit 2 must also point at the signature-move carve-out (writing-voice.md:30-33) or physical-world analogies get over-flagged | JD (JD-006) | ambiguity | Evidenced |
+  | C13 | On self-check-only skills, edits 1-2 are drafting guidance every skill loads but nothing enforces; keep added prose tight | JD (JD-008) | polish | Evidenced |
+  | C14 | Escape clause copies in docs/readability.md and the editor operator doc fail the YAGNI evidence test | IA (F12, F13) | YAGNI-candidate | Evidenced |
+
+- **Open Questions raised:**
+  - OQ-1 (from JD-001): does the escape clause override the six self-check gates or only the drafting properties?
+  - OQ-2 (from JD-002): extend the agent rubric, weave in, or sit beside; does "exactly six" bind the agent rubric?
+  - OQ-3 (from JD-004): is a manual dry run in scope as the acceptance check?
+  - OQ-4 (from JD-005): does the agent edit require a han-plugin-builder guidance review?
+  - OQ-5 (from JD-007): which single section is edit 3's canonical home?
+- **Spec-maturity tags:** all 5 OQs plan-level; 0 spec-level; T#-contradiction not applicable (no technical notes).
+  Spec-maturity gate: not tripped (and not trippable at this team size).
+- **Resolution source:**
+  - OQ-1: evidence. The escape clause is scoped: it governs the drafting properties and rewrite moves, and yields to
+    both hard gates. It never licenses a blocklisted word (self-check criterion 5 stays absolute) and never licenses a
+    fidelity loss (criterion 6, "Fidelity wins"). Sentence length already carries its own scoped escape ("without
+    reason," readability-rule.md:106; "review trigger, not a hard cap," lines 71-73). This matches the research's own
+    corroborated pattern that mature guides attach named, scoped exceptions rather than an unqualified override
+    (research A9, A10) and IA F2's subordinate-to-fidelity phrasing guard.
+  - OQ-2: evidence, cross-specialist. IA F8/F9 settle the shape the research left open: governing principle beside
+    fidelity plus a scope amendment to existing criterion 5. The rubric stays six; the constraint binds both sixes in
+    effect because seven surfaces echo the count (F10). The junior-developer's own simpler-version watch item agreed
+    the non-seventh-criterion shape is the simpler version.
+  - OQ-3: evidence. Yes, in scope. The research's Confidence Assessment names the missing dry run as residual risk,
+    and the repo has no automated tests, so a manual acceptance dry run is the only behavior-level verification.
+    JD-004's design is adopted: a sample document with a stale metaphor, a Latinate stock phrase, an archaic word,
+    and a load-bearing signature analogy that must survive.
+  - OQ-4: evidence. Yes, a guidance-based review. CLAUDE.md mandates han-plugin-builder guidance for agent
+    definitions, and the guidance skill's stated purpose includes "reviewing, hardening, or checking one against the
+    guidance." A full agent-builder interview is for authoring from scratch; a review pass fits an edit.
+  - OQ-5: evidence. writing-voice.md "Avoided words and phrases" (IA F4/F6): the blocklist is authoritative for the
+    words it covers, and readability-rule.md must not carry a competing list.
+- **Decisions produced:** D-1, D-2, D-3, D-4, D-5, D-6, D-7 (backfilled at synthesis)
+- **Changed in plan:** all sections (initial write at synthesis)
+- **Project-manager next-step recommendation:** Go to synthesis (deterministic: all OQs resolved by evidence, no
+  handoffs outstanding, round cap for small size reached).

--- a/docs/plans/orwell-six-rules/artifacts/implementation-iteration-history.md
+++ b/docs/plans/orwell-six-rules/artifacts/implementation-iteration-history.md
@@ -62,7 +62,12 @@ report's Recommendation is the "what"). No feature-technical-notes.md exists, so
     guidance." A full agent-builder interview is for authoring from scratch; a review pass fits an edit.
   - OQ-5: evidence. writing-voice.md "Avoided words and phrases" (IA F4/F6): the blocklist is authoritative for the
     words it covers, and readability-rule.md must not carry a competing list.
-- **Decisions produced:** D-1, D-2, D-3, D-4, D-5, D-6, D-7 (backfilled at synthesis)
-- **Changed in plan:** all sections (initial write at synthesis)
+- **Decisions produced:** D-1 (escape-clause placement and scoping), D-2 (stale-figures principle placement, dividing
+  line, and carve-out), D-3 (foreign and archaic diction lands only in the writing-voice blocklist), D-4 (agent-edit
+  shape keeps the rubric at six), D-5 (manual dry-run acceptance check), D-6 (guidance-review prerequisite for the
+  agent edit), D-7 (scoped doc-consistency check and no consuming-skill edits).
+- **Changed in plan:** Outcome; User Stories; Constraints and Boundaries; Implementation Approach (with the
+  Editor-agent rubric integrity subsection); Work Units and Sequencing; Definition of Done; Testing Strategy; Risks
+  and Assumptions; Deferred (YAGNI); Sources and Plan Records; Recommendation.
 - **Project-manager next-step recommendation:** Go to synthesis (deterministic: all OQs resolved by evidence, no
   handoffs outstanding, round cap for small size reached).

--- a/docs/plans/orwell-six-rules/feature-implementation-plan.md
+++ b/docs/plans/orwell-six-rules/feature-implementation-plan.md
@@ -1,12 +1,18 @@
 # Feature Implementation Plan: Orwell's Six Rules Applied to the han-communication Guidance
 
-This plan closes three gaps between George Orwell's six rules of writing and the han-communication readability standard, using four targeted edits to the standard's guidance files and its editor agent. Two edits add general principles the standard lacks (break a rule when it hurts the prose; avoid stale figures and pretentious diction), one names a missing word category, and one carries the new principles into the editor agent so they reach the rewrite pass. The self-check stays at exactly six criteria, on purpose. This is a markdown-only documentation change with no application code, no runtime surface, and no build step.
+This plan closes three gaps between George Orwell's six rules of writing and the han-communication readability standard. It makes four targeted edits to the standard's guidance files and its editor agent. Two edits add general principles the standard lacks: break a rule when it hurts the prose, and avoid stale figures and pretentious diction. A third names a missing word category. A fourth carries the new principles into the editor agent so they reach the rewrite pass. The self-check stays at exactly six criteria, on purpose.
+
+This is a markdown-only documentation change with no application code, no runtime surface, and no build step.
 
 ## Outcome
 
-When this plan is executed, the readability standard states the escape clause Orwell made his most important rule: when following a rule would make the prose read worse, break the rule ([D-1](artifacts/implementation-decision-log.md#d-1-escape-clause-placement-and-scoping)). The writing-voice profile names a general principle against stale figures of speech and pretentious or archaic diction, with a dividing line that keeps the profile's signature physical-world analogies legal ([D-2](artifacts/implementation-decision-log.md#d-2-stale-figures-principle-placement-dividing-line-and-carve-out)), and names the specific foreign, Latinate, and archaic stock phrases the word guidance never called out ([D-3](artifacts/implementation-decision-log.md#d-3-foreign-and-archaic-diction-lands-only-in-the-writing-voice-blocklist)). The readability-editor agent carries the escape clause and the new diction scope inline, so the rewrite pass acts on them ([D-4](artifacts/implementation-decision-log.md#d-4-agent-edit-shape-keeps-the-rubric-at-six)).
+When this plan is executed, the readability standard states the escape clause Orwell made his most important rule: when following a rule would make the prose read worse, break the rule ([D-1](artifacts/implementation-decision-log.md#d-1-escape-clause-placement-and-scoping)).
 
-The work serves two audiences. Readers of any Han skill's output get prose free of worn figures and pretentious diction. The readability standard's own maintainers get a standard that matches the tempered, exception-bearing form of Orwell's rules that modern evidence supports, without growing the six-point self-check that keeps compliance from decaying.
+The writing-voice profile names a general principle against stale figures of speech and pretentious or archaic diction. A dividing line keeps the profile's signature physical-world analogies legal ([D-2](artifacts/implementation-decision-log.md#d-2-stale-figures-principle-placement-dividing-line-and-carve-out)). The profile also names the specific foreign, Latinate, and archaic stock phrases the word guidance never called out ([D-3](artifacts/implementation-decision-log.md#d-3-foreign-and-archaic-diction-lands-only-in-the-writing-voice-blocklist)).
+
+The readability-editor agent carries the escape clause and the new diction scope inline, so the rewrite pass acts on them ([D-4](artifacts/implementation-decision-log.md#d-4-agent-edit-shape-keeps-the-rubric-at-six)).
+
+The work serves two audiences. Readers of any Han skill's output get prose free of worn figures and pretentious diction. The readability standard's own maintainers get a standard that matches the tempered, exception-bearing form of Orwell's rules that modern evidence supports. They get it without growing the six-point self-check that keeps compliance from decaying.
 
 ## User Stories
 
@@ -16,19 +22,19 @@ The work serves two audiences. Readers of any Han skill's output get prose free 
 
 ## Constraints and Boundaries
 
-- **Driving constraint:** The research report is validated and its recommendation is committed. The escape-clause gap in particular leaves an editor following the rules mechanically with no license to break one when the result reads badly, the exact failure Orwell's rule 6 exists to prevent.
+- **Driving constraint:** The research report is validated and its recommendation is committed. The escape-clause gap in particular leaves an editor following the rules mechanically, with no license to break one when the result reads badly. That is the exact failure Orwell's rule 6 exists to prevent.
 - **Out of scope:** Growing the six-point self-check ([D-1](artifacts/implementation-decision-log.md#d-1-escape-clause-placement-and-scoping)); adding a competing word list to `readability-rule.md` ([D-3](artifacts/implementation-decision-log.md#d-3-foreign-and-archaic-diction-lands-only-in-the-writing-voice-blocklist)); editing consuming skills, which read the reference files live ([D-7](artifacts/implementation-decision-log.md#d-7-scoped-doc-consistency-check-and-no-consuming-skill-edits)); copying the escape clause into operator-facing docs (see Deferred).
 - **Watch after ship:** Whether the escape clause is used to excuse a blocklisted word or a dropped fact, and whether the stale-figures principle over-flags the profile's signature analogies.
 
 ## Implementation Approach
 
-The four edits touch three files, all owned by `han-communication`. Each edit reuses an existing structure in its target file rather than introducing a new one, which keeps the added prose tight, a deliberate constraint because `readability-rule.md` is read in full by every reader-facing skill in the suite.
+The four edits touch three files, all owned by `han-communication`. Each edit reuses an existing structure in its target file rather than introducing a new one. This keeps the added prose tight, a deliberate constraint: `readability-rule.md` is read in full by every reader-facing skill in the suite.
 
 The escape clause lands in `readability-rule.md` as a new section between "Fidelity wins" and "The standardized self-check" ([D-1](artifacts/implementation-decision-log.md#d-1-escape-clause-placement-and-scoping)). It is scoped: it governs the drafting properties and rewrite moves, and yields to both hard gates, so it never licenses a blocklisted word or a fidelity loss. This mirrors the standard's existing scoped escapes and the pattern mature plain-language guides use.
 
-The stale-figures principle and the foreign, Latinate, and archaic diction land together in the "Avoided words and phrases" section of `writing-voice.md`, principle first and examples second ([D-2](artifacts/implementation-decision-log.md#d-2-stale-figures-principle-placement-dividing-line-and-carve-out), [D-3](artifacts/implementation-decision-log.md#d-3-foreign-and-archaic-diction-lands-only-in-the-writing-voice-blocklist)). The stale-figures principle reuses the section's existing load-bearing-versus-decorative test as its dividing line and points at the physical-world-analogy carve-out, so a fresh signature analogy stays legal while a worn cliche does not.
+The stale-figures principle and the foreign, Latinate, and archaic diction land together in the "Avoided words and phrases" section of `writing-voice.md`, principle first and examples second ([D-2](artifacts/implementation-decision-log.md#d-2-stale-figures-principle-placement-dividing-line-and-carve-out), [D-3](artifacts/implementation-decision-log.md#d-3-foreign-and-archaic-diction-lands-only-in-the-writing-voice-blocklist)). The stale-figures principle reuses the section's existing load-bearing-versus-decorative test as its dividing line, and points at the physical-world-analogy carve-out. As a result, a fresh signature analogy stays legal while a worn cliche does not.
 
-The agent edit carries the new principles into the rewrite pass ([D-4](artifacts/implementation-decision-log.md#d-4-agent-edit-shape-keeps-the-rubric-at-six)). This step is required because the editor agent runs its own hardcoded rubric and reads only the rule and the draft, never `writing-voice.md`, so edits to the reference files alone would never reach it. The escape clause joins the agent's fidelity principle as a governing principle, and the diction scope folds into the agent's existing criterion 5. The rubric stays at six criteria, so the "six criteria" count stays true on every surface that echoes it.
+The agent edit carries the new principles into the rewrite pass ([D-4](artifacts/implementation-decision-log.md#d-4-agent-edit-shape-keeps-the-rubric-at-six)). This step is required because the editor agent runs its own hardcoded rubric. It reads only the rule and the draft, never `writing-voice.md`, so edits to the reference files alone would never reach it. The escape clause joins the agent's fidelity principle as a governing principle, and the diction scope folds into the agent's existing criterion 5. The rubric stays at six criteria, so the "six criteria" count stays true on every surface that echoes it.
 
 ### Editor-agent rubric integrity
 
@@ -59,7 +65,7 @@ The one shape decision worth naming is that the new principles enter the agent a
 
 The repo has no automated test runner, so verification is a manual dry run plus a guidance review.
 
-- **Observable behaviors to test:** The edited editor agent, run on a sample document, corrects a stale metaphor, "in lieu of," and an archaic word such as "aforementioned," and leaves a load-bearing signature analogy unchanged ([D-5](artifacts/implementation-decision-log.md#d-5-manual-dry-run-acceptance-check)).
+- **Observable behaviors to test:** The edited editor agent, run on a sample document, corrects a stale metaphor, "in lieu of," and an archaic word such as "aforementioned." It leaves a load-bearing signature analogy unchanged ([D-5](artifacts/implementation-decision-log.md#d-5-manual-dry-run-acceptance-check)).
 - **Edge cases requiring coverage:** The load-bearing signature analogy is the carve-out case; it must survive to prove the stale-figures principle does not over-flag ([D-2](artifacts/implementation-decision-log.md#d-2-stale-figures-principle-placement-dividing-line-and-carve-out)).
 - **Test doubles posture and levels:** None. The dry run exercises the real agent against a real sample document.
 

--- a/docs/plans/orwell-six-rules/feature-implementation-plan.md
+++ b/docs/plans/orwell-six-rules/feature-implementation-plan.md
@@ -1,0 +1,106 @@
+# Feature Implementation Plan: Orwell's Six Rules Applied to the han-communication Guidance
+
+This plan closes three gaps between George Orwell's six rules of writing and the han-communication readability standard, using four targeted edits to the standard's guidance files and its editor agent. Two edits add general principles the standard lacks (break a rule when it hurts the prose; avoid stale figures and pretentious diction), one names a missing word category, and one carries the new principles into the editor agent so they reach the rewrite pass. The self-check stays at exactly six criteria, on purpose. This is a markdown-only documentation change with no application code, no runtime surface, and no build step.
+
+## Outcome
+
+When this plan is executed, the readability standard states the escape clause Orwell made his most important rule: when following a rule would make the prose read worse, break the rule ([D-1](artifacts/implementation-decision-log.md#d-1-escape-clause-placement-and-scoping)). The writing-voice profile names a general principle against stale figures of speech and pretentious or archaic diction, with a dividing line that keeps the profile's signature physical-world analogies legal ([D-2](artifacts/implementation-decision-log.md#d-2-stale-figures-principle-placement-dividing-line-and-carve-out)), and names the specific foreign, Latinate, and archaic stock phrases the word guidance never called out ([D-3](artifacts/implementation-decision-log.md#d-3-foreign-and-archaic-diction-lands-only-in-the-writing-voice-blocklist)). The readability-editor agent carries the escape clause and the new diction scope inline, so the rewrite pass acts on them ([D-4](artifacts/implementation-decision-log.md#d-4-agent-edit-shape-keeps-the-rubric-at-six)).
+
+The work serves two audiences. Readers of any Han skill's output get prose free of worn figures and pretentious diction. The readability standard's own maintainers get a standard that matches the tempered, exception-bearing form of Orwell's rules that modern evidence supports, without growing the six-point self-check that keeps compliance from decaying.
+
+## User Stories
+
+- **US-1:** As a reader of Han skill output, I want prose free of worn figures of speech and pretentious or archaic diction, so that the writing stays plain and easy to follow.
+- **US-2:** As the readability editor, I want license to break a formatting rule when following it would make the prose read worse, so that mechanical compliance never produces clumsy writing.
+- **US-3:** As a maintainer of the readability standard, I want the new principles to reach the rewrite pass without growing the six-point self-check, so that the standard gains coverage without the compliance decay a longer checklist would cause.
+
+## Constraints and Boundaries
+
+- **Driving constraint:** The research report is validated and its recommendation is committed. The escape-clause gap in particular leaves an editor following the rules mechanically with no license to break one when the result reads badly, the exact failure Orwell's rule 6 exists to prevent.
+- **Out of scope:** Growing the six-point self-check ([D-1](artifacts/implementation-decision-log.md#d-1-escape-clause-placement-and-scoping)); adding a competing word list to `readability-rule.md` ([D-3](artifacts/implementation-decision-log.md#d-3-foreign-and-archaic-diction-lands-only-in-the-writing-voice-blocklist)); editing consuming skills, which read the reference files live ([D-7](artifacts/implementation-decision-log.md#d-7-scoped-doc-consistency-check-and-no-consuming-skill-edits)); copying the escape clause into operator-facing docs (see Deferred).
+- **Watch after ship:** Whether the escape clause is used to excuse a blocklisted word or a dropped fact, and whether the stale-figures principle over-flags the profile's signature analogies.
+
+## Implementation Approach
+
+The four edits touch three files, all owned by `han-communication`. Each edit reuses an existing structure in its target file rather than introducing a new one, which keeps the added prose tight, a deliberate constraint because `readability-rule.md` is read in full by every reader-facing skill in the suite.
+
+The escape clause lands in `readability-rule.md` as a new section between "Fidelity wins" and "The standardized self-check" ([D-1](artifacts/implementation-decision-log.md#d-1-escape-clause-placement-and-scoping)). It is scoped: it governs the drafting properties and rewrite moves, and yields to both hard gates, so it never licenses a blocklisted word or a fidelity loss. This mirrors the standard's existing scoped escapes and the pattern mature plain-language guides use.
+
+The stale-figures principle and the foreign, Latinate, and archaic diction land together in the "Avoided words and phrases" section of `writing-voice.md`, principle first and examples second ([D-2](artifacts/implementation-decision-log.md#d-2-stale-figures-principle-placement-dividing-line-and-carve-out), [D-3](artifacts/implementation-decision-log.md#d-3-foreign-and-archaic-diction-lands-only-in-the-writing-voice-blocklist)). The stale-figures principle reuses the section's existing load-bearing-versus-decorative test as its dividing line and points at the physical-world-analogy carve-out, so a fresh signature analogy stays legal while a worn cliche does not.
+
+The agent edit carries the new principles into the rewrite pass ([D-4](artifacts/implementation-decision-log.md#d-4-agent-edit-shape-keeps-the-rubric-at-six)). This step is required because the editor agent runs its own hardcoded rubric and reads only the rule and the draft, never `writing-voice.md`, so edits to the reference files alone would never reach it. The escape clause joins the agent's fidelity principle as a governing principle, and the diction scope folds into the agent's existing criterion 5. The rubric stays at six criteria, so the "six criteria" count stays true on every surface that echoes it.
+
+### Editor-agent rubric integrity
+
+The one shape decision worth naming is that the new principles enter the agent as a governing principle and a criterion-5 amendment, never as a seventh criterion ([D-4](artifacts/implementation-decision-log.md#d-4-agent-edit-shape-keeps-the-rubric-at-six)). Keeping the rubric at six preserves the keep-it-small design and leaves "They are the whole rubric" literally true.
+
+## Work Units and Sequencing
+
+| #   | Work Unit | Story | Delivers | Depends On | Verification |
+| --- | --------- | ----- | -------- | ---------- | ------------ |
+| 1   | Add the escape-clause section to `readability-rule.md` | US-2, US-3 | The standard states the scoped break-the-rule principle beside "Fidelity wins" ([D-1](artifacts/implementation-decision-log.md#d-1-escape-clause-placement-and-scoping)) | None | The section reads as subordinate to both hard gates; the self-check stays six |
+| 2   | Add the stale-figures principle to `writing-voice.md` | US-1 | A general principle against stale figures, with the load-bearing dividing line and the signature-move carve-out ([D-2](artifacts/implementation-decision-log.md#d-2-stale-figures-principle-placement-dividing-line-and-carve-out)) | None | A worn cliche is flagged; a fresh signature analogy is not |
+| 3   | Add foreign, Latinate, and archaic diction to `writing-voice.md` | US-1 | The named diction category as examples of the replace-first pattern, in the same blocklist section ([D-3](artifacts/implementation-decision-log.md#d-3-foreign-and-archaic-diction-lands-only-in-the-writing-voice-blocklist)) | None | The words live only in the writing-voice blocklist, not in `readability-rule.md` |
+| 4   | Carry the new principles into `readability-editor.md` | US-1, US-2, US-3 | Escape clause beside the fidelity principle; diction scope woven into criterion 5; rubric stays six ([D-4](artifacts/implementation-decision-log.md#d-4-agent-edit-shape-keeps-the-rubric-at-six)) | 1, 2, 3 | "They are the whole rubric" stays true; the rubric still lists six criteria |
+| 5   | Run the han-plugin-builder guidance review over the edited agent | US-3 | A review-pass sign-off on `readability-editor.md` ([D-6](artifacts/implementation-decision-log.md#d-6-guidance-review-prerequisite-for-the-agent-edit)) | 4 | The guidance review returns no unresolved findings |
+| 6   | Run the manual dry-run acceptance check | US-1, US-2 | The edited agent corrects a stale metaphor, "in lieu of," and an archaic word while preserving a load-bearing signature analogy ([D-5](artifacts/implementation-decision-log.md#d-5-manual-dry-run-acceptance-check)) | 4 | The three targets are corrected; the signature analogy survives unchanged |
+| 7   | Run the scoped doc-consistency check | US-3 | Statements the edits make false are corrected; the "six criteria" count claims stay untouched ([D-7](artifacts/implementation-decision-log.md#d-7-scoped-doc-consistency-check-and-no-consuming-skill-edits)) | 4 | No count claim changes; no consuming-skill edits |
+
+## Definition of Done
+
+- [ ] The readability standard states the scoped escape clause between "Fidelity wins" and "The standardized self-check," yielding to both hard gates ([D-1](artifacts/implementation-decision-log.md#d-1-escape-clause-placement-and-scoping)).
+- [ ] The writing-voice profile names the stale-figures principle with its dividing line and carve-out ([D-2](artifacts/implementation-decision-log.md#d-2-stale-figures-principle-placement-dividing-line-and-carve-out)) and the foreign, Latinate, and archaic diction category ([D-3](artifacts/implementation-decision-log.md#d-3-foreign-and-archaic-diction-lands-only-in-the-writing-voice-blocklist)).
+- [ ] The editor agent carries the escape clause as a governing principle and the diction scope in criterion 5, with the rubric still at six criteria and "They are the whole rubric" still true ([D-4](artifacts/implementation-decision-log.md#d-4-agent-edit-shape-keeps-the-rubric-at-six)).
+- [ ] The manual dry run passes: the stale metaphor, "in lieu of," and the archaic word are corrected, and the load-bearing signature analogy survives unchanged ([D-5](artifacts/implementation-decision-log.md#d-5-manual-dry-run-acceptance-check)).
+- [ ] The han-plugin-builder guidance review of the edited agent returns no unresolved findings ([D-6](artifacts/implementation-decision-log.md#d-6-guidance-review-prerequisite-for-the-agent-edit)).
+- [ ] The scoped doc-consistency check leaves every "six criteria" count claim untouched and true, and no consuming skill is edited ([D-7](artifacts/implementation-decision-log.md#d-7-scoped-doc-consistency-check-and-no-consuming-skill-edits)).
+
+## Testing Strategy
+
+The repo has no automated test runner, so verification is a manual dry run plus a guidance review.
+
+- **Observable behaviors to test:** The edited editor agent, run on a sample document, corrects a stale metaphor, "in lieu of," and an archaic word such as "aforementioned," and leaves a load-bearing signature analogy unchanged ([D-5](artifacts/implementation-decision-log.md#d-5-manual-dry-run-acceptance-check)).
+- **Edge cases requiring coverage:** The load-bearing signature analogy is the carve-out case; it must survive to prove the stale-figures principle does not over-flag ([D-2](artifacts/implementation-decision-log.md#d-2-stale-figures-principle-placement-dividing-line-and-carve-out)).
+- **Test doubles posture and levels:** None. The dry run exercises the real agent against a real sample document.
+
+## Risks and Assumptions
+
+### Risks
+
+| ID  | Risk | Impact | Mitigation | Owner |
+| --- | ---- | ------ | ---------- | ----- |
+| R1  | The escape clause is used to excuse a blocklisted word or a dropped fact | The standard's hard gates weaken | Scope the clause to yield to both hard gates and state that scope in the section text ([D-1](artifacts/implementation-decision-log.md#d-1-escape-clause-placement-and-scoping)) | `information-architect` |
+| R2  | The stale-figures principle over-flags the profile's signature physical-world analogies | The signature move is suppressed as a cliche | Reuse the load-bearing-versus-decorative dividing line and point at the carve-out ([D-2](artifacts/implementation-decision-log.md#d-2-stale-figures-principle-placement-dividing-line-and-carve-out)); the dry run's carve-out case verifies it ([D-5](artifacts/implementation-decision-log.md#d-5-manual-dry-run-acceptance-check)) | `information-architect` |
+| R3  | An edit falsifies a "six criteria" count claim on one of the surfaces that echo it | Cross-surface count claims go stale | Keep the rubric at six ([D-4](artifacts/implementation-decision-log.md#d-4-agent-edit-shape-keeps-the-rubric-at-six)); scope the doc-consistency check to leave count claims untouched ([D-7](artifacts/implementation-decision-log.md#d-7-scoped-doc-consistency-check-and-no-consuming-skill-edits)) | `information-architect` |
+
+### Assumptions
+
+| ID  | Assumption | What Changes If Wrong | Status |
+| --- | ---------- | --------------------- | ------ |
+| A1  | The line-110 load-bearing-versus-decorative test generalizes from sports metaphors to physical-world analogies | The dividing line needs its own wording for the carve-out rather than a pointer to it | Verified: `writing-voice.md:110` and `:30-33`; the dry-run carve-out case confirms behavior ([D-5](artifacts/implementation-decision-log.md#d-5-manual-dry-run-acceptance-check)) |
+| A2  | Consuming skills read the reference files live through readability-guidance, so no consumer edit is needed | Consuming skills would need direct edits to see the new principles | Verified: `han-communication/skills/readability-guidance/SKILL.md:32-40` |
+| A3  | The editor agent reads only the rule and the draft, never `writing-voice.md`, so the diction scope must be named inline | The agent edit could inherit the scope from the reference file instead | Verified: `han-communication/agents/readability-editor.md:78` |
+
+## Deferred (YAGNI)
+
+### Escape-clause copy in `docs/readability.md`
+
+- **Why deferred:** Evidence test failed. The cross-plugin summary surface carries a scent line, not copies of the governing principles, and no reader path breaks without the escape clause repeated there.
+- **Reopen when:** An operator relies on `docs/readability.md` as the complete governing-principle list and its absence produces confusion.
+- **Source:** R1, `information-architect` (F12).
+
+### Escape-clause bullet in `han-communication/docs/agents/readability-editor.md`
+
+- **Why deferred:** Evidence test failed. The operator-facing doc is scoped to dispatch guidance and defers internals to the agent definition, so the escape clause does not need to appear there.
+- **Reopen when:** Operators report confusion about the agent overriding a rubric criterion.
+- **Source:** R1, `information-architect` (F13).
+
+## Sources and Plan Records
+
+- **Feature specification:** No source specification file exists. The inputs were the validated research report `docs/research/orwell-six-rules-of-writing.md`, whose O2 option and Recommendation section served as the "what" for this plan.
+- **Decision rationale and rejected alternatives:** [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Team composition and round-by-round history:** [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md)
+
+## Recommendation
+
+Ship as planned. All five open questions were resolved by evidence, no open items block implementation, and the two YAGNI deferrals carry concrete reopen triggers.

--- a/docs/research/orwell-six-rules-of-writing.md
+++ b/docs/research/orwell-six-rules-of-writing.md
@@ -7,15 +7,17 @@ Evidence mode: strict.
 ## Summary
 
 The current readability standard already follows most of Orwell's six rules, and in a form that modern evidence
-supports better than Orwell's own absolute phrasing. Three of his rules are fully or mostly covered today: prefer
-short common words, cut needless words, and write in the active voice. Three are gaps: there is no general rule
-against stale, worn-out figures of speech; there is no guidance on when to replace jargon outright versus define it;
-and the standard never names Orwell's most important rule, the escape clause that says to break any rule rather than
-write something clumsy. The recommendation is to close those three gaps with small, targeted additions to the
-existing guidance files, while keeping the six-point self-check unchanged, because growing the checklist would
-trigger the compliance decay the standard is explicitly designed to avoid. The rule text and the case against
-absolute rules are well corroborated; some details of how mature style guides phrase exceptions rest on single
-sources.
+supports better than Orwell's own absolute phrasing. Four of his rules are fully or mostly covered today: prefer
+short common words, cut needless words, write in the active voice, and replace jargon before defining it. Two are
+confirmed gaps: there is no general rule against stale, worn-out figures of speech, and the standard never names
+Orwell's most important rule, the escape clause that says to break any rule rather than write something clumsy. A
+third, narrower gap also exists: the word guidance never names foreign, Latinate, or archaic stock phrases. The
+recommendation is to close those gaps with small, targeted additions to the existing guidance files and the editor
+agent's instructions, while keeping the six-point self-check unchanged, because growing the checklist would trigger
+the compliance decay the standard is explicitly designed to avoid. Adversarial validation confirmed the two main
+gaps against the files directly, corrected one citation, and narrowed the scope of the third gap. The rule text and
+the case against absolute rules are well corroborated; some details of how mature style guides phrase exceptions
+rest on single sources.
 
 - **Confidence:** Medium
 
@@ -62,9 +64,12 @@ or a threshold, rather than an unqualified "never" (A9, A10, A11).
 
 ### Prior art on applying these rules to AI-generated text
 
-The clearest direct link between Orwell's tradition and AI output is a published "Stop Slop" skill that names
-Orwell's essay as its ancestry and translates it into banned filler phrases, structural tells, and rhythm rules for
-machine prose (A15) [single-source]. Its component claims are independently corroborated: three unrelated sources
+The clearest direct link between Orwell's tradition and AI output comes from a pair of published AI-prose skills:
+"Stop Slop," which bans filler phrases, structural tells, and rhythm patterns in machine prose, and its companion
+"red-pen" (by Rich Tabor), which the Stop Slop author describes as enforcing principles drawn from Orwell's
+"Politics and the English Language" and Butterick's "Practical Typography" (A15) [single-source; validation
+confirmed the Orwell lineage belongs to red-pen, not Stop Slop itself]. The component claims about AI prose are
+independently corroborated: three unrelated sources
 converge on the same lexical markers of AI prose, including overused words such as "delve" and heavy em-dash use,
 and recommend blocklist-style bans as the operational form (A18). One dissenting source rejects rule-based
 approaches entirely in favor of cultivating specificity, and reports that automated AI-writing detectors are
@@ -86,25 +91,36 @@ prior art favors (A19, A20, A21):
 - **Rule 4 (active voice):** covered, and covered better than Orwell phrased it. The standard says "active by
   default" rather than "never passive" (A19, A21), which matches the documented failure modes of the absolute rule
   (A13, A14).
+- **Rule 5, replace-versus-define:** mostly covered, contrary to the initial finding. Validation showed the rule
+  already states a replace-first, define-as-fallback framework in one sentence: "Prefer the common word over the
+  technical synonym. Define a term on first use when it cannot be replaced" (A19), duplicated nearly verbatim in
+  the editor agent (A21). What remains missing is narrower: see the rule 5 gap below.
 
 The standard also already has structural strengths Orwell's list does not address at all: main point first,
 one idea per paragraph, descriptive headings, progressive disclosure, and an absolute fidelity guard (A19).
 
 ### Where the standard has gaps against the rules
 
-Three of Orwell's rules have no explicit counterpart in the current guidance (A19, A20, A21):
+Validation confirmed two real gaps and one narrower one against direct reads of the files (A19, A20, A21):
 
-- **Rule 1 (stale figures of speech):** partial gap. The AI-slop list bans specific worn phrases, which is exactly
-  rule 1 applied to a modern corpus, but there is no general principle against reaching for a stale metaphor or
-  cliche not on the list. The voice profile encourages physical-world analogies as a signature move without
-  distinguishing a fresh, load-bearing analogy from a worn one (A20).
-- **Rule 5 (jargon and foreign phrases):** partial gap. "Define a term on first use when it cannot be replaced"
-  (A19) handles the define case but gives no guidance on when to replace jargon outright, and nothing covers
-  Latinate or foreign stock phrases ("in lieu of," "per se") or archaic formal words ("aforementioned," "herein").
-- **Rule 6 (the escape clause):** the most important gap. The standard has two specific escape hatches, the
-  fidelity-wins override and the soft thirty-word sentence threshold (A19, A21), but never states the general
-  principle: when following a rule would make the sentence read worse, break the rule. Orwell made this the rule
-  that governs the other five, and the mature guides all carry some form of it (A1, A9, A10).
+- **Rule 1 (stale figures of speech):** confirmed gap. The AI-slop list bans specific worn phrases, which is
+  exactly rule 1 applied to a modern corpus, but a search of all three canonical files found no general principle
+  against reaching for a stale metaphor or cliche not on the list. The voice profile encourages physical-world
+  analogies as a signature move without distinguishing a fresh, load-bearing analogy from a worn one (A20). Any
+  fix needs a dividing line, and the voice profile already has one to reuse: its sports-metaphor rule allows a
+  load-bearing analogy and bans a decorative one (A20).
+- **Rule 5 (foreign, Latinate, and archaic diction):** narrower gap than first found. The replace-versus-define
+  framework already exists (see above); what the guidance never names is the specific category of foreign or
+  Latinate stock phrases ("in lieu of," "per se") and archaic formal words ("aforementioned," "herein").
+- **Rule 6 (the escape clause):** the most important gap, confirmed by search. The standard has two specific
+  escape hatches, the fidelity-wins override and the soft thirty-word sentence threshold (A19, A21), but never
+  states the general principle: when following a rule would make the sentence read worse, break the rule. Orwell
+  made this the rule that governs the other five, and the mature guides all carry some form of it (A1, A9, A10).
+
+Validation also surfaced a delivery constraint the gaps analysis alone missed: the readability-editor agent
+carries its own hardcoded six-criterion rubric and states "they are the whole rubric" (A21). Edits to the
+reference files alone would therefore never reach the rewrite pass, which is the standard's highest-leverage
+enforcement path. Any fix has to touch the agent's instructions as well.
 
 One conflict to surface rather than resolve silently: Orwell's rules are phrased as absolutes, and the corroborated
 evidence (A13, A14) says absolutes misfire. Applying Orwell to this standard therefore means adopting what his
@@ -122,18 +138,22 @@ rules protect, in the tempered exception-bearing form the standard already uses,
 - **Rests on:** (A19, A1)
 - **Evidence status:** corroborated (the rule text and the standard's design constraint are both well evidenced)
 
-### O2: Close the gaps with targeted additions to the existing surfaces, self-check unchanged
+### O2: Close the gaps with targeted additions to the existing surfaces, self-check unchanged (as adjusted by validation)
 
-- **What it is:** Three small edits. First, name the escape clause as a general principle in the readability rule,
-  alongside the fidelity guard: when following a rule would make the prose read worse, break the rule. Second,
-  extend the blocklist's guidance with a short general statement against stale figures of speech and pretentious or
-  archaic diction, so the specific banned phrases are examples of a principle rather than an exhaustive list. Third,
-  add a replace-versus-define line to the "Common words" property: replace jargon when an everyday equivalent
-  carries the same meaning; define and keep it when the reader needs the precise term.
+- **What it is:** Three small edits, plus one delivery fix. First, name the escape clause as a general principle in
+  the readability rule, alongside the fidelity guard: when following a rule would make the prose read worse, break
+  the rule. Second, extend the blocklist's guidance with a short general statement against stale figures of speech
+  and pretentious or archaic diction, using the voice profile's existing load-bearing-versus-decorative test as the
+  dividing line so the signature analogies stay legal. Third, add foreign and Latinate stock phrases and archaic
+  formal words to the categories the word guidance names, as examples of the existing replace-first rule rather
+  than a new framework. Finally, update the readability-editor agent's instructions so the rewrite pass weighs the
+  new principles instead of stopping at its hardcoded six-criterion rubric.
 - **Trade-offs:** Nothing new is machine-checkable; these land as drafting guidance and editor judgment rather than
-  self-check gates. That is the same enforcement level the mature guides use for the same rules (A9, A10). Modest
-  risk of the reference files growing over time if additions are not kept tight.
-- **Rests on:** (A1, A9, A10, A13, A14, A19, A20, A21)
+  self-check gates. That is the same enforcement level the mature guides use for the same rules (A9, A10). Edits to
+  the readability rule reach every reader-facing skill in the suite (A23), so the blast radius is wide and the
+  additions must stay tight. A narrower variant, scoping the new principles to the voice profile or the agent only,
+  would shrink the blast radius but would not reach skills that self-check without a rewrite pass.
+- **Rests on:** (A1, A9, A10, A13, A14, A19, A20, A21, A23)
 - **Evidence status:** corroborated (rule text, absolute-rule failure modes, and current codebase state are all
   corroborated; the specific phrasing patterns of exceptions in individual guides carry single-source caveats)
 
@@ -149,20 +169,109 @@ rules protect, in the tempered exception-bearing form the standard already uses,
 
 ## Recommendation
 
-- **Recommendation:** O2. Close the three gaps with targeted additions to `readability-rule.md` and
-  `writing-voice.md`, and keep the six-point self-check exactly as it is.
+- **Recommendation:** O2 as adjusted by validation. Close the gaps with targeted additions to
+  `readability-rule.md` and `writing-voice.md`, extend the readability-editor agent's instructions so the rewrite
+  pass sees the new principles, scope the jargon edit down to naming foreign, Latinate, and archaic diction, and
+  keep the six-point self-check exactly as it is.
 - **Evidence basis:** The verbatim rule text and its intent are corroborated across independent mirrors and
   restatements (A1, A2, A7). The current state of the standard, including which rules it already covers and which
-  it lacks, is codebase evidence (A19, A20, A21). The case for tempered, exception-bearing phrasing over Orwell's
-  absolutes is corroborated from two independent directions (A13, A14) and matches the operational pattern of the
-  government plain-language guides (A9, A10). Single-source elements: the Economist's framing of the rules (A8),
-  the specific numeric thresholds (A11), and the specific exception clause at plainlanguage.gov (A9); none of these
-  is load-bearing for the recommendation, which stands on the corroborated rule text, the corroborated critique of
-  absolutes, and the codebase gaps.
+  it lacks, is codebase evidence verified twice, once by exploration and once adversarially (A19, A20, A21). The
+  case for tempered, exception-bearing phrasing over Orwell's absolutes is corroborated from two independent
+  directions (A13, A14) and matches the operational pattern of the government plain-language guides (A9, A10).
+  Single-source elements: the Economist's framing of the rules (A8), the specific numeric thresholds (A11), and
+  the specific exception clause at plainlanguage.gov (A9); none of these is load-bearing for the recommendation,
+  which stands on the corroborated rule text, the corroborated critique of absolutes, and the codebase gaps.
 
 ## Validation
 
-_Pending adversarial validation._
+### V1: The replace-versus-define jargon gap was overstated
+
+- **Strategy:** Challenge the Evidence
+- **Investigation:** Direct read of the readability rule and the editor agent's rubric.
+- **Result:** Partially Refuted. The rule already states a replace-first, define-as-fallback framework ("Prefer the
+  common word over the technical synonym. Define a term on first use when it cannot be replaced"), duplicated in
+  the agent. The real gap is narrower: foreign, Latinate, and archaic diction is never named.
+- **Impact:** The rule 5 finding and O2's third edit were rescoped from "add a framework" to "name the missing
+  categories as examples of the existing rule."
+
+### V2: The escape-clause and stale-figures gaps are real
+
+- **Strategy:** Challenge the Evidence
+- **Investigation:** Searched all three canonical files for any general break-the-rule principle or any stale-figure
+  or cliche guidance. Both searches returned nothing beyond the two narrow escape hatches already cited.
+- **Result:** Confirmed.
+- **Impact:** The two load-bearing gaps in the recommendation stand.
+
+### V3: The Stop Slop citation misattributed the Orwell lineage
+
+- **Strategy:** Challenge the Evidence-Gathering Integrity
+- **Investigation:** Fetched the Stop Slop page directly. The Orwell and Butterick lineage is stated for a sibling
+  skill, "red-pen" by Rich Tabor, which the Stop Slop author lists as a companion, not for Stop Slop itself.
+- **Result:** Refuted as originally cited.
+- **Impact:** The prior-art paragraph was corrected. The claim was not load-bearing for the recommendation.
+
+### V4: The Language Log critiques are fairly represented
+
+- **Strategy:** Challenge the Evidence
+- **Investigation:** Fetched both posts and compared their content against the report's claims.
+- **Result:** Confirmed, including the report's own shared-venue caveat.
+- **Impact:** The "absolutes misfire" evidence chain holds.
+
+### V5: The fix as first scoped would never reach the rewrite pass
+
+- **Strategy:** Challenge the Recommendation
+- **Investigation:** Read the readability-editor agent. Its rubric is a separately authored copy of the six
+  criteria and closes with "they are the whole rubric," so principles added only to the reference files would be
+  invisible to the synthesis-skill rewrite pass.
+- **Result:** Confirmed.
+- **Impact:** O2 now includes updating the agent's instructions as a required part of the fix.
+
+### V6: A lower-blast-radius option was missing from the framing
+
+- **Strategy:** Challenge the Options Framing
+- **Investigation:** Traced the sourcing path: the readability rule is read in full by every reader-facing skill in
+  the suite, so editing it has suite-wide reach. Scoping the new principles to the voice profile or the agent alone
+  was never framed as its own option.
+- **Result:** Partially Refuted (framing gap).
+- **Impact:** O2's trade-offs now name the blast radius and the narrower variant, so the implementer can choose the
+  surface deliberately.
+
+### V7: The stale-figures principle needs a dividing line
+
+- **Strategy:** Challenge the Recommendation
+- **Investigation:** The voice profile names specific analogies as a signature move and reuses them as closing
+  devices. A bare "avoid stale figures" principle gives an editor no way to tell a signature analogy from a cliche.
+- **Result:** Confirmed as an open ambiguity.
+- **Impact:** O2 now specifies reusing the voice profile's existing load-bearing-versus-decorative test as the
+  dividing line.
+
+### V8: The primary Orwell text could not be re-fetched during validation
+
+- **Strategy:** Challenge the Evidence-Gathering Integrity
+- **Investigation:** The mirror hosting the essay returned an access error during validation, so the verbatim rule
+  text rests on the research pass's fetch plus cross-mirror agreement, not an independent re-fetch.
+- **Result:** Partially Refuted (low-severity provenance gap). The essay is public-domain, widely reproduced, and
+  its wording is not in dispute.
+- **Impact:** No change to the recommendation; noted as a residual risk.
+
+### Adjustments Made
+
+Validation changed the report in four ways: the rule 5 gap was narrowed and the matching O2 edit rescoped (V1);
+the Stop Slop citation was corrected to attribute the Orwell lineage to red-pen (V3); updating the
+readability-editor agent's instructions became a required part of O2 (V5); and O2's trade-offs now name the blast
+radius of editing the shared rule file and the narrower alternative surface (V6), plus the dividing line for the
+stale-figures principle (V7). The recommendation survived in adjusted form.
+
+### Confidence Assessment
+
+- **Confidence:** Medium
+- **Remaining Risks:** Several single-source artifacts were spot-checked for reachability only, not full-text
+  accuracy (A8, A9's exception clause, A11, A16). The critique side of the Orwell literature is better evidenced
+  than the defence side, because two candidate defence sources were paywalled or blocked during research; this
+  asymmetry did not drive the recommendation, which keeps rather than abandons Orwell's substance, but it is
+  unresolved. Whether the agent-instruction edit should extend the rubric itself or sit beside it is a design call
+  for implementation, not settled here. No dry run of the self-check or rewrite behavior against a document with a
+  stale metaphor or unresolved jargon was performed.
 
 ## Sources
 
@@ -182,7 +291,7 @@ _Pending adversarial validation._
 | A12 | Strunk & White, "omit needless words" | https://faculty.washington.edu/heagerty/Courses/b572/public/StrunkWhite.pdf | 2026-07-21 | web | The canonical absolute cut-words imperative, parallel to Orwell's rule 3 | corroborated by A1 |
 | A13 | Pullum, "50 Years of Stupid Grammar Advice" | https://www.chronicle.com/article/whos-afraid-of-strunk-and-white/ | 2026-07-21 | web | Strunk & White misidentify the passive in three of four of their own examples | corroborated by A14 |
 | A14 | Pinker on the passive voice | https://www.unz.com/isteve/pinker-on-the-passive-voice/ | 2026-07-21 | web | The passive has legitimate uses (agent unimportant or distracting) an absolute ban forecloses | corroborated by A13 |
-| A15 | "Stop Slop" AI-slop skill | https://gauravtiwari.org/stop-slop-ai-slop/ | 2026-07-21 | web | Rule set for AI prose naming Orwell's essay as its ancestry; banned phrases plus structural tells | single source (caveated) |
+| A15 | "Stop Slop" AI-slop skill (and companion "red-pen") | https://gauravtiwari.org/stop-slop-ai-slop/ | 2026-07-21 | web | Rule sets for AI prose; the companion red-pen skill carries the stated Orwell lineage (corrected per V3) | single source (caveated) |
 | A16 | "The Field Guide to AI Slop" | https://www.ignorance.ai/p/the-field-guide-to-ai-slop | 2026-07-21 | web | Rejects rule-based fixes in favor of cultivated specificity; AI detectors unreliable | single source (caveated); contradicts A15's approach |
 | A17 | markup.ai enterprise AI writing rules | https://markup.ai/blog/rules-for-ai-to-write-successful-content/ | 2026-07-21 | web | Enterprise AI-writing governance is compliance-focused, with no Orwell/plain-language lineage | single source (caveated) |
 | A18 | Converging AI-slop lexical tells (three sources) | https://aipulsr.com/blog/why-ai-writing-drowns-in-em-dashes-and-how-to-stop-it | 2026-07-21 | web | Three independent pieces converge on the same overused words and em-dash overuse in AI prose | corroborated (three independent sources) |

--- a/docs/research/orwell-six-rules-of-writing.md
+++ b/docs/research/orwell-six-rules-of-writing.md
@@ -1,0 +1,235 @@
+# Research: Orwell's Six Rules of Writing, Applied to the han-communication Guidance
+
+Question: what do George Orwell's six rules of writing actually say, and how should they be applied to the
+han-communication readability standard to produce output that is easier for humans to read and understand?
+Evidence mode: strict.
+
+## Summary
+
+The current readability standard already follows most of Orwell's six rules, and in a form that modern evidence
+supports better than Orwell's own absolute phrasing. Three of his rules are fully or mostly covered today: prefer
+short common words, cut needless words, and write in the active voice. Three are gaps: there is no general rule
+against stale, worn-out figures of speech; there is no guidance on when to replace jargon outright versus define it;
+and the standard never names Orwell's most important rule, the escape clause that says to break any rule rather than
+write something clumsy. The recommendation is to close those three gaps with small, targeted additions to the
+existing guidance files, while keeping the six-point self-check unchanged, because growing the checklist would
+trigger the compliance decay the standard is explicitly designed to avoid. The rule text and the case against
+absolute rules are well corroborated; some details of how mature style guides phrase exceptions rest on single
+sources.
+
+- **Confidence:** Medium
+
+## Research Results
+
+### What the six rules say, and what they were for
+
+Orwell published the six rules in his 1946 essay "Politics and the English Language." Verbatim, they are: (1) "Never
+use a metaphor, simile, or other figure of speech which you are used to seeing in print." (2) "Never use a long word
+where a short one will do." (3) "If it is possible to cut a word out, always cut it out." (4) "Never use the passive
+where you can use the active." (5) "Never use a foreign phrase, a scientific word, or a jargon word if you can think
+of an everyday English equivalent." (6) "Break any of these rules sooner than say anything outright barbarous."
+(A1, A2, A7)
+
+The rules answer a diagnosis. Orwell cataloged four habits of bad writing: dying metaphors (stale figures used
+without regard to their meaning), verbal false limbs (padded verb phrases that dodge a plain verb), pretentious
+diction (Latinate vocabulary that lends a false air of authority), and meaningless words (terms used so loosely they
+no longer denote anything checkable) (A1, A2). His framing question for every sentence is "What am I trying to
+say?", and rule 6 subordinates the first five mechanical rules to that goal: they are heuristics in service of
+clarity, not laws (A1).
+
+### The rules have known failure modes when read as absolutes
+
+Linguists have documented where the rules break as literal commands. Two Language Log authors independently note
+that rule 1, read literally, would forbid virtually all fluent prose, and that Orwell breaks rule 4 in his own
+essay's opening sentence with the passive "it is generally assumed" (A3, A4; both posts share a venue, so they are
+one intellectual lineage rather than two). Pullum separately showed that Strunk and White's parallel anti-passive
+rule misidentifies the passive voice in three of its own four worked examples, evidence that absolute grammatical
+bans get misapplied by the people enforcing them (A13). Pinker adds that the passive has legitimate uses the active
+cannot replicate, such as omitting an agent the reader does not need (A14). A further critique argues plain style is
+not itself proof of honesty, since disarming plainness can also be used to obscure (A5) [single-source]. None of
+this discredits the rules as directional preferences; it discredits them as bans without exceptions.
+
+### How mature style guides operationalize the same preferences
+
+The guides that inherit Orwell's preferences temper them. The Economist Style Guide opens with Orwell's rules but
+treats them as a philosophical frame, not a pass/fail test (A8) [single-source]. The US federal plain-language
+guidance prefers active voice and names a specific narrow exception for it (A9; the exception clause is
+[single-source]). GOV.UK mandates plain English with a 15-to-25-word sentence guideline and active voice, with
+contextual escape valves elsewhere in the guide (A10). One downstream checklist converts the same guidance into
+measurable thresholds, such as an average sentence under twenty words and active voice above fifty percent (A11)
+[single-source]. The pattern across guides: state the directional preference, then attach either a named exception
+or a threshold, rather than an unqualified "never" (A9, A10, A11).
+
+### Prior art on applying these rules to AI-generated text
+
+The clearest direct link between Orwell's tradition and AI output is a published "Stop Slop" skill that names
+Orwell's essay as its ancestry and translates it into banned filler phrases, structural tells, and rhythm rules for
+machine prose (A15) [single-source]. Its component claims are independently corroborated: three unrelated sources
+converge on the same lexical markers of AI prose, including overused words such as "delve" and heavy em-dash use,
+and recommend blocklist-style bans as the operational form (A18). One dissenting source rejects rule-based
+approaches entirely in favor of cultivating specificity, and reports that automated AI-writing detectors are
+unreliable (A16) [single-source]; this is a live disagreement, not a settled question. No widely recognized,
+authoritative AI writing style guide that adapts Orwell's rules end to end was found; that absence is a finding,
+not an oversight (A15, A16, A17).
+
+### Where the han-communication standard already matches the rules
+
+The codebase evidence shows the standard covers Orwell's rules 2 through 4 today, in the tempered form the
+prior art favors (A19, A20, A21):
+
+- **Rule 2 (short common words):** covered. The "Common words" property says to prefer the common word over the
+  technical synonym and define an irreplaceable term on first use (A19).
+- **Rule 3 (cut needless words):** mostly covered. The blocklist bans specific filler, hedging, and AI-slop phrases
+  (A20), and the voice profile forbids performative hedging. There is no single general "cut every needless word"
+  statement, but the readability-editor's short-sentence and one-idea-per-paragraph rules do the same work in
+  practice (A21).
+- **Rule 4 (active voice):** covered, and covered better than Orwell phrased it. The standard says "active by
+  default" rather than "never passive" (A19, A21), which matches the documented failure modes of the absolute rule
+  (A13, A14).
+
+The standard also already has structural strengths Orwell's list does not address at all: main point first,
+one idea per paragraph, descriptive headings, progressive disclosure, and an absolute fidelity guard (A19).
+
+### Where the standard has gaps against the rules
+
+Three of Orwell's rules have no explicit counterpart in the current guidance (A19, A20, A21):
+
+- **Rule 1 (stale figures of speech):** partial gap. The AI-slop list bans specific worn phrases, which is exactly
+  rule 1 applied to a modern corpus, but there is no general principle against reaching for a stale metaphor or
+  cliche not on the list. The voice profile encourages physical-world analogies as a signature move without
+  distinguishing a fresh, load-bearing analogy from a worn one (A20).
+- **Rule 5 (jargon and foreign phrases):** partial gap. "Define a term on first use when it cannot be replaced"
+  (A19) handles the define case but gives no guidance on when to replace jargon outright, and nothing covers
+  Latinate or foreign stock phrases ("in lieu of," "per se") or archaic formal words ("aforementioned," "herein").
+- **Rule 6 (the escape clause):** the most important gap. The standard has two specific escape hatches, the
+  fidelity-wins override and the soft thirty-word sentence threshold (A19, A21), but never states the general
+  principle: when following a rule would make the sentence read worse, break the rule. Orwell made this the rule
+  that governs the other five, and the mature guides all carry some form of it (A1, A9, A10).
+
+One conflict to surface rather than resolve silently: Orwell's rules are phrased as absolutes, and the corroborated
+evidence (A13, A14) says absolutes misfire. Applying Orwell to this standard therefore means adopting what his
+rules protect, in the tempered exception-bearing form the standard already uses, not adopting his "never" phrasing.
+
+## Options to Consider
+
+### O1: Add the missing rules as new self-check criteria
+
+- **What it is:** Extend the standardized six-point self-check with new criteria for stale metaphors, jargon
+  substitution, and the escape clause, making them enforced checks on every deliverable.
+- **Trade-offs:** Directly contradicts the standard's own design principle that the check "is kept small on purpose
+  so it applies as one focused pass rather than decaying under its own weight" (A19). Stale-metaphor detection is
+  also a judgment call, not the yes/no criterion the self-check requires. Highest enforcement, highest decay risk.
+- **Rests on:** (A19, A1)
+- **Evidence status:** corroborated (the rule text and the standard's design constraint are both well evidenced)
+
+### O2: Close the gaps with targeted additions to the existing surfaces, self-check unchanged
+
+- **What it is:** Three small edits. First, name the escape clause as a general principle in the readability rule,
+  alongside the fidelity guard: when following a rule would make the prose read worse, break the rule. Second,
+  extend the blocklist's guidance with a short general statement against stale figures of speech and pretentious or
+  archaic diction, so the specific banned phrases are examples of a principle rather than an exhaustive list. Third,
+  add a replace-versus-define line to the "Common words" property: replace jargon when an everyday equivalent
+  carries the same meaning; define and keep it when the reader needs the precise term.
+- **Trade-offs:** Nothing new is machine-checkable; these land as drafting guidance and editor judgment rather than
+  self-check gates. That is the same enforcement level the mature guides use for the same rules (A9, A10). Modest
+  risk of the reference files growing over time if additions are not kept tight.
+- **Rests on:** (A1, A9, A10, A13, A14, A19, A20, A21)
+- **Evidence status:** corroborated (rule text, absolute-rule failure modes, and current codebase state are all
+  corroborated; the specific phrasing patterns of exceptions in individual guides carry single-source caveats)
+
+### O3: Change nothing; document the lineage only
+
+- **What it is:** Treat the current standard as already Orwell-compliant in substance and record the mapping in a
+  doc, without editing the guidance.
+- **Trade-offs:** Cheapest and zero decay risk, but leaves the three real gaps open. The escape-clause gap in
+  particular means an editor following the rules mechanically has no license to break one when the result reads
+  badly, which is the exact failure Orwell's rule 6 exists to prevent (A1).
+- **Rests on:** (A19, A20, A21, A1)
+- **Evidence status:** corroborated
+
+## Recommendation
+
+- **Recommendation:** O2. Close the three gaps with targeted additions to `readability-rule.md` and
+  `writing-voice.md`, and keep the six-point self-check exactly as it is.
+- **Evidence basis:** The verbatim rule text and its intent are corroborated across independent mirrors and
+  restatements (A1, A2, A7). The current state of the standard, including which rules it already covers and which
+  it lacks, is codebase evidence (A19, A20, A21). The case for tempered, exception-bearing phrasing over Orwell's
+  absolutes is corroborated from two independent directions (A13, A14) and matches the operational pattern of the
+  government plain-language guides (A9, A10). Single-source elements: the Economist's framing of the rules (A8),
+  the specific numeric thresholds (A11), and the specific exception clause at plainlanguage.gov (A9); none of these
+  is load-bearing for the recommendation, which stands on the corroborated rule text, the corroborated critique of
+  absolutes, and the codebase gaps.
+
+## Validation
+
+_Pending adversarial validation._
+
+## Sources
+
+| ID  | Source | Link / location | Retrieved | Trust class | Summary (one line) | Evidence status |
+| --- | ------ | --------------- | --------- | ----------- | ------------------ | --------------- |
+| A1  | Orwell, "Politics and the English Language" (full text mirror) | https://americanliterature.com/author/george-orwell/essay/politics-and-the-english-language | 2026-07-21 | web | Verbatim six rules, the four bad-writing habits, and the "What am I trying to say?" framing | corroborated by A2, A7 |
+| A2  | Wikipedia: Politics and the English Language | https://en.wikipedia.org/wiki/Politics_and_the_English_Language | 2026-07-21 | web | Essay summary; notes the Pullum critique and the essay's pedagogical longevity | corroborated by A1, A3 |
+| A3  | Language Log: Pullum on Orwell | https://languagelog.ldc.upenn.edu/nll/?p=551 | 2026-07-21 | web | Pullum: rule 1 is unfollowable literally; the essay conflates style with honesty | corroborated by A4 (shared venue) |
+| A4  | Language Log: "Orwell's Liar" (Beaver) | https://languagelog.ldc.upenn.edu/nll/?p=992 | 2026-07-21 | web | Orwell breaks rule 4 in his own opening sentence; the decline premise is unsupported | corroborated by A3 (shared venue) |
+| A5  | New Statesman: "Don't be beguiled by Orwell" | https://www.newstatesman.com/culture/2013/02/don%E2%80%99t-be-beguiled-orwell-using-plain-and-clear-language-not-always-moral-virtue | 2026-07-21 | web | Plain style can obscure as well as reveal; plainness is not proof of honesty | single source (caveated) |
+| A6  | Pullum on prescriptive advice as "sacred scripture" | https://www.npr.org/2009/04/16/103171738/a-half-century-of-stupid-grammar-advice | 2026-07-21 | web | Reported framing of Orwell/Strunk fetishization in composition teaching | single source (caveated, not verified against primary) |
+| A7  | Open Culture and Duke restatements of the six rules | https://sites.duke.edu/scientificwriting/orwells-6-rules/ | 2026-07-21 | web | Independent restatements confirming the rule wording; the rules travel into technical-writing pedagogy | corroborated by A1 |
+| A8  | The Economist Style Guide's use of Orwell | https://writingcooperative.com/5-tips-on-writing-from-the-economist-style-guide-28a7ff736ade | 2026-07-21 | web | The Economist opens its guide with Orwell's rules as a philosophical frame | single source (caveated) |
+| A9  | plainlanguage.gov active-voice guidance | https://github.com/GSA/plainlanguage.gov/blob/main/_pages/guidelines/conversational/use-active-voice.md | 2026-07-21 | web | Active-voice preference with a named narrow exception (law as actor) | preference corroborated by A10; exception clause single source |
+| A10 | GOV.UK content style guide | https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/ | 2026-07-21 | web | Plain English mandatory; 15-25 word sentences; active voice; contextual escape valves | corroborated by A9 |
+| A11 | AuditBuffet plain-language checklist | https://auditbuffet.com/patterns/ab-001617 | 2026-07-21 | web | Converts plain-language rules into numeric thresholds (sentence length, percent active) | single source (caveated) |
+| A12 | Strunk & White, "omit needless words" | https://faculty.washington.edu/heagerty/Courses/b572/public/StrunkWhite.pdf | 2026-07-21 | web | The canonical absolute cut-words imperative, parallel to Orwell's rule 3 | corroborated by A1 |
+| A13 | Pullum, "50 Years of Stupid Grammar Advice" | https://www.chronicle.com/article/whos-afraid-of-strunk-and-white/ | 2026-07-21 | web | Strunk & White misidentify the passive in three of four of their own examples | corroborated by A14 |
+| A14 | Pinker on the passive voice | https://www.unz.com/isteve/pinker-on-the-passive-voice/ | 2026-07-21 | web | The passive has legitimate uses (agent unimportant or distracting) an absolute ban forecloses | corroborated by A13 |
+| A15 | "Stop Slop" AI-slop skill | https://gauravtiwari.org/stop-slop-ai-slop/ | 2026-07-21 | web | Rule set for AI prose naming Orwell's essay as its ancestry; banned phrases plus structural tells | single source (caveated) |
+| A16 | "The Field Guide to AI Slop" | https://www.ignorance.ai/p/the-field-guide-to-ai-slop | 2026-07-21 | web | Rejects rule-based fixes in favor of cultivated specificity; AI detectors unreliable | single source (caveated); contradicts A15's approach |
+| A17 | markup.ai enterprise AI writing rules | https://markup.ai/blog/rules-for-ai-to-write-successful-content/ | 2026-07-21 | web | Enterprise AI-writing governance is compliance-focused, with no Orwell/plain-language lineage | single source (caveated) |
+| A18 | Converging AI-slop lexical tells (three sources) | https://aipulsr.com/blog/why-ai-writing-drowns-in-em-dashes-and-how-to-stop-it | 2026-07-21 | web | Three independent pieces converge on the same overused words and em-dash overuse in AI prose | corroborated (three independent sources) |
+| A19 | Han readability rule | han-communication/references/readability-rule.md | n/a | codebase | The nine output properties, length guidance, fidelity guard, and six-point self-check | codebase (current-state anchor) |
+| A20 | Han writing-voice profile | han-communication/references/writing-voice.md | n/a | codebase | Voice attributes, the vocabulary blocklist, and the AI-slop list | codebase (current-state anchor) |
+| A21 | readability-editor agent | han-communication/agents/readability-editor.md | n/a | codebase | The six-criterion rewrite rubric, prose-only scope, and fidelity override | codebase (current-state anchor) |
+| A22 | readability-guidance skill | han-communication/skills/readability-guidance/SKILL.md | n/a | codebase | The inline cross-plugin sourcing mechanism for the standard | codebase (current-state anchor) |
+| A23 | Cross-plugin readability doc | docs/readability.md | n/a | codebase | Staged application design principle and the consumer-skill table | codebase (current-state anchor) |
+
+### A1: Orwell, "Politics and the English Language" — recommendation-bearing
+
+- **Link / location:** https://americanliterature.com/author/george-orwell/essay/politics-and-the-english-language
+- **Retrieved:** 2026-07-21
+- **Trust class:** web
+- **Summary:** The primary text. Supplies the six rules verbatim, the four-part diagnosis of bad writing that
+  motivates them, the "What am I trying to say?" framing, and rule 6's explicit subordination of the mechanical
+  rules to clarity. The Orwell Foundation's own hosting failed to fetch, so the text rests on two independent
+  mirrors that agree word for word.
+- **Evidence status:** corroborated by A2, A7
+
+### A13: Pullum, "50 Years of Stupid Grammar Advice" — recommendation-bearing
+
+- **Link / location:** https://www.chronicle.com/article/whos-afraid-of-strunk-and-white/
+- **Retrieved:** 2026-07-21
+- **Trust class:** web
+- **Summary:** Documents that Strunk and White's own worked examples misidentify the passive voice three times out
+  of four. This is the strongest concrete evidence that absolute grammatical bans get misapplied in practice, which
+  is why the recommendation keeps the standard's "active by default" phrasing instead of adopting Orwell's "never."
+- **Evidence status:** corroborated by A14
+
+### A19: Han readability rule — recommendation-bearing
+
+- **Link / location:** han-communication/references/readability-rule.md
+- **Retrieved:** n/a
+- **Trust class:** codebase
+- **Summary:** The current-state anchor. Defines the nine output properties (including "Common words" and "Short,
+  active sentences"), the soft thirty-word threshold, the fidelity-wins override, and the six-point self-check with
+  its explicit keep-it-small design principle. The recommendation's shape (targeted additions, self-check
+  unchanged) follows directly from this file's own stated constraint against instruction stacking.
+- **Evidence status:** codebase (current-state anchor)
+
+### A20: Han writing-voice profile — recommendation-bearing
+
+- **Link / location:** han-communication/references/writing-voice.md
+- **Retrieved:** n/a
+- **Trust class:** codebase
+- **Summary:** Carries the authoritative vocabulary blocklist ("Avoided words and phrases" plus "AI slop to
+  avoid") and the physical-world-analogy signature move. The blocklist is where the stale-figure and
+  pretentious-diction guidance would land, turning the enumerated bans into examples of a named principle.
+- **Evidence status:** codebase (current-state anchor)

--- a/docs/research/orwell-six-rules-of-writing.md
+++ b/docs/research/orwell-six-rules-of-writing.md
@@ -1,23 +1,27 @@
 # Research: Orwell's Six Rules of Writing, Applied to the han-communication Guidance
 
-Question: what do George Orwell's six rules of writing actually say, and how should they be applied to the
+Question: what do George Orwell's six rules of writing say, and how should they be applied to the
 han-communication readability standard to produce output that is easier for humans to read and understand?
 Evidence mode: strict.
 
 ## Summary
 
-The current readability standard already follows most of Orwell's six rules, and in a form that modern evidence
-supports better than Orwell's own absolute phrasing. Four of his rules are fully or mostly covered today: prefer
-short common words, cut needless words, write in the active voice, and replace jargon before defining it. Two are
-confirmed gaps: there is no general rule against stale, worn-out figures of speech, and the standard never names
-Orwell's most important rule, the escape clause that says to break any rule rather than write something clumsy. A
-third, narrower gap also exists: the word guidance never names foreign, Latinate, or archaic stock phrases. The
-recommendation is to close those gaps with small, targeted additions to the existing guidance files and the editor
-agent's instructions, while keeping the six-point self-check unchanged, because growing the checklist would trigger
-the compliance decay the standard is explicitly designed to avoid. Adversarial validation confirmed the two main
-gaps against the files directly, corrected one citation, and narrowed the scope of the third gap. The rule text and
-the case against absolute rules are well corroborated; some details of how mature style guides phrase exceptions
-rest on single sources.
+The current readability standard already follows most of Orwell's six rules, and does so in a form that modern
+evidence supports better than Orwell's own absolute phrasing. Four of his rules are fully or mostly covered today:
+prefer short common words, cut needless words, write in the active voice, and replace jargon before defining it.
+
+Two real gaps remain. First, there is no general rule against stale, worn-out figures of speech. Second, the
+standard never names Orwell's most important rule: the escape clause that says to break any rule rather than write
+something clumsy. A third, narrower gap also exists: the word guidance never names foreign, Latinate, or archaic
+stock phrases.
+
+The recommendation closes these gaps with small, targeted additions to the existing guidance files and the editor
+agent's instructions. The six-point self-check stays unchanged, because growing the checklist would trigger the
+compliance decay the standard is explicitly designed to avoid.
+
+Adversarial validation confirmed the two main gaps against the files directly, corrected one citation, and narrowed
+the scope of the third gap. The rule text and the case against absolute rules are well corroborated. Some details of
+how mature style guides phrase exceptions rest on single sources.
 
 - **Confidence:** Medium
 
@@ -32,26 +36,28 @@ where you can use the active." (5) "Never use a foreign phrase, a scientific wor
 of an everyday English equivalent." (6) "Break any of these rules sooner than say anything outright barbarous."
 (A1, A2, A7)
 
-The rules answer a diagnosis. Orwell cataloged four habits of bad writing: dying metaphors (stale figures used
-without regard to their meaning), verbal false limbs (padded verb phrases that dodge a plain verb), pretentious
-diction (Latinate vocabulary that lends a false air of authority), and meaningless words (terms used so loosely they
-no longer denote anything checkable) (A1, A2). His framing question for every sentence is "What am I trying to
-say?", and rule 6 subordinates the first five mechanical rules to that goal: they are heuristics in service of
+The rules answer a diagnosis. Orwell cataloged four habits of bad writing. Dying metaphors are stale figures used
+without regard to their meaning. Verbal false limbs are padded verb phrases that dodge a plain verb. Pretentious
+diction is Latinate vocabulary that lends a false air of authority. Meaningless words are terms used so loosely they
+no longer denote anything checkable (A1, A2). His framing question for every sentence is "What am I trying to
+say?" Rule 6 subordinates the first five mechanical rules to that goal: they are heuristics in service of
 clarity, not laws (A1).
 
 ### The rules have known failure modes when read as absolutes
 
-Linguists have documented where the rules break as literal commands. Two Language Log authors independently note
-that rule 1, read literally, would forbid virtually all fluent prose, and that Orwell breaks rule 4 in his own
-essay's opening sentence with the passive "it is generally assumed" (A3, A4; both posts share a venue, so they are
-one intellectual lineage rather than two). Pullum separately showed that Strunk and White's parallel anti-passive
-rule misidentifies the passive voice in three of its own four worked examples, evidence that absolute grammatical
-bans get misapplied by the people enforcing them (A13). Pinker adds that the passive has legitimate uses the active
-cannot replicate, such as omitting an agent the reader does not need (A14). A further critique argues plain style is
-not itself proof of honesty, since disarming plainness can also be used to obscure (A5) [single-source]. None of
-this discredits the rules as directional preferences; it discredits them as bans without exceptions.
+Linguists have documented where the rules break as literal commands. None of this discredits the rules as
+directional preferences; it discredits them only as bans without exceptions.
 
-### How mature style guides operationalize the same preferences
+Two Language Log authors independently make two points. Read literally, rule 1 would forbid virtually all fluent
+prose. Orwell also breaks rule 4 in his own essay's opening sentence, using the passive phrase "it is generally
+assumed" (A3, A4; both posts share a venue, so they are one intellectual lineage rather than two). Pullum separately
+showed that Strunk and White's parallel anti-passive rule misidentifies the passive voice in three of its own four
+worked examples, which is evidence that absolute grammatical bans get misapplied by the people enforcing them (A13).
+Pinker adds that the passive has legitimate uses the active cannot replicate, such as omitting an agent the reader
+does not need (A14). A further critique argues plain style is not itself proof of honesty, since disarming plainness
+can also be used to obscure (A5) [single-source].
+
+### How mature style guides apply the same preferences
 
 The guides that inherit Orwell's preferences temper them. The Economist Style Guide opens with Orwell's rules but
 treats them as a philosophical frame, not a pass/fail test (A8) [single-source]. The US federal plain-language
@@ -62,30 +68,29 @@ measurable thresholds, such as an average sentence under twenty words and active
 [single-source]. The pattern across guides: state the directional preference, then attach either a named exception
 or a threshold, rather than an unqualified "never" (A9, A10, A11).
 
-### Prior art on applying these rules to AI-generated text
+### Earlier work on applying these rules to AI-generated text
 
-The clearest direct link between Orwell's tradition and AI output comes from a pair of published AI-prose skills:
-"Stop Slop," which bans filler phrases, structural tells, and rhythm patterns in machine prose, and its companion
-"red-pen" (by Rich Tabor), which the Stop Slop author describes as enforcing principles drawn from Orwell's
-"Politics and the English Language" and Butterick's "Practical Typography" (A15) [single-source; validation
-confirmed the Orwell lineage belongs to red-pen, not Stop Slop itself]. The component claims about AI prose are
-independently corroborated: three unrelated sources
-converge on the same lexical markers of AI prose, including overused words such as "delve" and heavy em-dash use,
-and recommend blocklist-style bans as the operational form (A18). One dissenting source rejects rule-based
-approaches entirely in favor of cultivating specificity, and reports that automated AI-writing detectors are
-unreliable (A16) [single-source]; this is a live disagreement, not a settled question. No widely recognized,
-authoritative AI writing style guide that adapts Orwell's rules end to end was found; that absence is a finding,
-not an oversight (A15, A16, A17).
+The clearest direct link between Orwell's tradition and AI output comes from a pair of published AI-prose skills.
+"Stop Slop" bans filler phrases, structural tells, and rhythm patterns in machine prose. Its companion, "red-pen"
+(by Rich Tabor), enforces principles the Stop Slop author traces to Orwell's "Politics and the English Language" and
+Butterick's "Practical Typography" (A15) [single-source; validation confirmed the Orwell lineage belongs to
+red-pen, not Stop Slop itself]. The component claims about AI prose are independently corroborated. Three unrelated
+sources converge on the same lexical markers of AI prose, including overused words such as "delve" and heavy
+em-dash use. They recommend blocklist-style bans as the operational form (A18). One dissenting source rejects
+rule-based approaches entirely in favor of cultivating specificity, and reports that automated AI-writing detectors
+are unreliable (A16) [single-source]. This is a live disagreement, not a settled question. No widely recognized,
+authoritative AI writing style guide adapts Orwell's rules end to end. That absence is itself a finding, not an
+oversight (A15, A16, A17).
 
 ### Where the han-communication standard already matches the rules
 
 The codebase evidence shows the standard covers Orwell's rules 2 through 4 today, in the tempered form the
-prior art favors (A19, A20, A21):
+earlier work favors (A19, A20, A21):
 
 - **Rule 2 (short common words):** covered. The "Common words" property says to prefer the common word over the
   technical synonym and define an irreplaceable term on first use (A19).
 - **Rule 3 (cut needless words):** mostly covered. The blocklist bans specific filler, hedging, and AI-slop phrases
-  (A20), and the voice profile forbids performative hedging. There is no single general "cut every needless word"
+  (A20). The voice profile also forbids performative hedging. There is no single general "cut every needless word"
   statement, but the readability-editor's short-sentence and one-idea-per-paragraph rules do the same work in
   practice (A21).
 - **Rule 4 (active voice):** covered, and covered better than Orwell phrased it. The standard says "active by
@@ -103,26 +108,26 @@ one idea per paragraph, descriptive headings, progressive disclosure, and an abs
 
 Validation confirmed two real gaps and one narrower one against direct reads of the files (A19, A20, A21):
 
-- **Rule 1 (stale figures of speech):** confirmed gap. The AI-slop list bans specific worn phrases, which is
-  exactly rule 1 applied to a modern corpus, but a search of all three canonical files found no general principle
-  against reaching for a stale metaphor or cliche not on the list. The voice profile encourages physical-world
-  analogies as a signature move without distinguishing a fresh, load-bearing analogy from a worn one (A20). Any
-  fix needs a dividing line, and the voice profile already has one to reuse: its sports-metaphor rule allows a
-  load-bearing analogy and bans a decorative one (A20).
+- **Rule 1 (stale figures of speech):** confirmed gap. The AI-slop list bans specific worn phrases. That is exactly
+  rule 1 applied to a modern corpus. But a search of all three canonical files found no general principle against
+  reaching for a stale metaphor or cliche not on the list. The voice profile encourages physical-world analogies as
+  a signature move without distinguishing a fresh, load-bearing analogy from a worn one (A20). Any fix needs a
+  dividing line. The voice profile already has one to reuse: its sports-metaphor rule allows a load-bearing analogy
+  and bans a decorative one (A20).
 - **Rule 5 (foreign, Latinate, and archaic diction):** narrower gap than first found. The replace-versus-define
-  framework already exists (see above); what the guidance never names is the specific category of foreign or
+  framework already exists (see above). What the guidance never names is the specific category of foreign or
   Latinate stock phrases ("in lieu of," "per se") and archaic formal words ("aforementioned," "herein").
 - **Rule 6 (the escape clause):** the most important gap, confirmed by search. The standard has two specific
-  escape hatches, the fidelity-wins override and the soft thirty-word sentence threshold (A19, A21), but never
+  escape hatches: the fidelity-wins override and the soft thirty-word sentence threshold (A19, A21). But it never
   states the general principle: when following a rule would make the sentence read worse, break the rule. Orwell
   made this the rule that governs the other five, and the mature guides all carry some form of it (A1, A9, A10).
 
 Validation also surfaced a delivery constraint the gaps analysis alone missed: the readability-editor agent
 carries its own hardcoded six-criterion rubric and states "they are the whole rubric" (A21). Edits to the
-reference files alone would therefore never reach the rewrite pass, which is the standard's highest-leverage
+reference files alone would therefore never reach the rewrite pass, which is the standard's most effective
 enforcement path. Any fix has to touch the agent's instructions as well.
 
-One conflict to surface rather than resolve silently: Orwell's rules are phrased as absolutes, and the corroborated
+One conflict to surface rather than resolve silently: Orwell's rules are phrased as absolutes. The corroborated
 evidence (A13, A14) says absolutes misfire. Applying Orwell to this standard therefore means adopting what his
 rules protect, in the tempered exception-bearing form the standard already uses, not adopting his "never" phrasing.
 
@@ -143,16 +148,17 @@ rules protect, in the tempered exception-bearing form the standard already uses,
 - **What it is:** Three small edits, plus one delivery fix. First, name the escape clause as a general principle in
   the readability rule, alongside the fidelity guard: when following a rule would make the prose read worse, break
   the rule. Second, extend the blocklist's guidance with a short general statement against stale figures of speech
-  and pretentious or archaic diction, using the voice profile's existing load-bearing-versus-decorative test as the
-  dividing line so the signature analogies stay legal. Third, add foreign and Latinate stock phrases and archaic
+  and pretentious or archaic diction. Use the voice profile's existing load-bearing-versus-decorative test as the
+  dividing line, so the signature analogies stay legal. Third, add foreign and Latinate stock phrases and archaic
   formal words to the categories the word guidance names, as examples of the existing replace-first rule rather
   than a new framework. Finally, update the readability-editor agent's instructions so the rewrite pass weighs the
   new principles instead of stopping at its hardcoded six-criterion rubric.
-- **Trade-offs:** Nothing new is machine-checkable; these land as drafting guidance and editor judgment rather than
-  self-check gates. That is the same enforcement level the mature guides use for the same rules (A9, A10). Edits to
-  the readability rule reach every reader-facing skill in the suite (A23), so the blast radius is wide and the
-  additions must stay tight. A narrower variant, scoping the new principles to the voice profile or the agent only,
-  would shrink the blast radius but would not reach skills that self-check without a rewrite pass.
+- **Trade-offs:** Nothing new here is machine-checkable. These land as drafting guidance and editor judgment rather
+  than self-check gates. That is the same enforcement level the mature guides use for the same rules (A9, A10).
+  Edits to the readability rule reach every reader-facing skill in the suite (A23). That means the blast radius is
+  wide, so the additions must stay tight. A narrower variant would scope the new principles to the voice profile or
+  the agent only. That would shrink the blast radius, but it would not reach skills that self-check without a
+  rewrite pass.
 - **Rests on:** (A1, A9, A10, A13, A14, A19, A20, A21, A23)
 - **Evidence status:** corroborated (rule text, absolute-rule failure modes, and current codebase state are all
   corroborated; the specific phrasing patterns of exceptions in individual guides carry single-source caveats)
@@ -169,18 +175,19 @@ rules protect, in the tempered exception-bearing form the standard already uses,
 
 ## Recommendation
 
-- **Recommendation:** O2 as adjusted by validation. Close the gaps with targeted additions to
-  `readability-rule.md` and `writing-voice.md`, extend the readability-editor agent's instructions so the rewrite
-  pass sees the new principles, scope the jargon edit down to naming foreign, Latinate, and archaic diction, and
-  keep the six-point self-check exactly as it is.
+- **Recommendation:** O2 as adjusted by validation: close the gaps with targeted additions to `readability-rule.md`
+  and `writing-voice.md`. Extend the readability-editor agent's instructions so the rewrite pass sees the new
+  principles. Scope the jargon edit down to naming foreign, Latinate, and archaic diction. Keep the six-point
+  self-check exactly as it is.
 - **Evidence basis:** The verbatim rule text and its intent are corroborated across independent mirrors and
   restatements (A1, A2, A7). The current state of the standard, including which rules it already covers and which
   it lacks, is codebase evidence verified twice, once by exploration and once adversarially (A19, A20, A21). The
   case for tempered, exception-bearing phrasing over Orwell's absolutes is corroborated from two independent
-  directions (A13, A14) and matches the operational pattern of the government plain-language guides (A9, A10).
-  Single-source elements: the Economist's framing of the rules (A8), the specific numeric thresholds (A11), and
-  the specific exception clause at plainlanguage.gov (A9); none of these is load-bearing for the recommendation,
-  which stands on the corroborated rule text, the corroborated critique of absolutes, and the codebase gaps.
+  directions (A13, A14). It also matches the operational pattern of the government plain-language guides (A9, A10).
+  Single-source elements include the Economist's framing of the rules (A8), the specific numeric thresholds (A11),
+  and the specific exception clause at plainlanguage.gov (A9). None of these is load-bearing for the
+  recommendation, which stands on the corroborated rule text, the corroborated critique of absolutes, and the
+  codebase gaps.
 
 ## Validation
 
@@ -208,7 +215,7 @@ rules protect, in the tempered exception-bearing form the standard already uses,
 - **Investigation:** Fetched the Stop Slop page directly. The Orwell and Butterick lineage is stated for a sibling
   skill, "red-pen" by Rich Tabor, which the Stop Slop author lists as a companion, not for Stop Slop itself.
 - **Result:** Refuted as originally cited.
-- **Impact:** The prior-art paragraph was corrected. The claim was not load-bearing for the recommendation.
+- **Impact:** The earlier-work paragraph was corrected. The claim was not load-bearing for the recommendation.
 
 ### V4: The Language Log critiques are fairly represented
 
@@ -221,8 +228,8 @@ rules protect, in the tempered exception-bearing form the standard already uses,
 
 - **Strategy:** Challenge the Recommendation
 - **Investigation:** Read the readability-editor agent. Its rubric is a separately authored copy of the six
-  criteria and closes with "they are the whole rubric," so principles added only to the reference files would be
-  invisible to the synthesis-skill rewrite pass.
+  criteria and closes with "they are the whole rubric." Principles added only to the reference files would
+  therefore be invisible to the synthesis-skill rewrite pass.
 - **Result:** Confirmed.
 - **Impact:** O2 now includes updating the agent's instructions as a required part of the fix.
 
@@ -256,19 +263,19 @@ rules protect, in the tempered exception-bearing form the standard already uses,
 
 ### Adjustments Made
 
-Validation changed the report in four ways: the rule 5 gap was narrowed and the matching O2 edit rescoped (V1);
-the Stop Slop citation was corrected to attribute the Orwell lineage to red-pen (V3); updating the
-readability-editor agent's instructions became a required part of O2 (V5); and O2's trade-offs now name the blast
-radius of editing the shared rule file and the narrower alternative surface (V6), plus the dividing line for the
-stale-figures principle (V7). The recommendation survived in adjusted form.
+Validation changed the report in four ways. First, the rule 5 gap was narrowed and the matching O2 edit rescoped
+(V1). Second, the Stop Slop citation was corrected to attribute the Orwell lineage to red-pen (V3). Third, updating
+the readability-editor agent's instructions became a required part of O2 (V5). Fourth, O2's trade-offs now name the
+blast radius of editing the shared rule file and the narrower alternative surface (V6), plus the dividing line for
+the stale-figures principle (V7). The recommendation survived in adjusted form.
 
 ### Confidence Assessment
 
 - **Confidence:** Medium
 - **Remaining Risks:** Several single-source artifacts were spot-checked for reachability only, not full-text
   accuracy (A8, A9's exception clause, A11, A16). The critique side of the Orwell literature is better evidenced
-  than the defence side, because two candidate defence sources were paywalled or blocked during research; this
-  asymmetry did not drive the recommendation, which keeps rather than abandons Orwell's substance, but it is
+  than the defence side, because two candidate defence sources were paywalled or blocked during research. This
+  asymmetry did not drive the recommendation, which keeps rather than abandons Orwell's substance. Still, it is
   unresolved. Whether the agent-instruction edit should extend the rubric itself or sit beside it is a design call
   for implementation, not settled here. No dry run of the self-check or rewrite behavior against a document with a
   stale metaphor or unresolved jargon was performed.
@@ -301,7 +308,7 @@ stale-figures principle (V7). The recommendation survived in adjusted form.
 | A22 | readability-guidance skill | han-communication/skills/readability-guidance/SKILL.md | n/a | codebase | The inline cross-plugin sourcing mechanism for the standard | codebase (current-state anchor) |
 | A23 | Cross-plugin readability doc | docs/readability.md | n/a | codebase | Staged application design principle and the consumer-skill table | codebase (current-state anchor) |
 
-### A1: Orwell, "Politics and the English Language" — recommendation-bearing
+### A1: Orwell, "Politics and the English Language" (recommendation-bearing)
 
 - **Link / location:** https://americanliterature.com/author/george-orwell/essay/politics-and-the-english-language
 - **Retrieved:** 2026-07-21
@@ -312,7 +319,7 @@ stale-figures principle (V7). The recommendation survived in adjusted form.
   mirrors that agree word for word.
 - **Evidence status:** corroborated by A2, A7
 
-### A13: Pullum, "50 Years of Stupid Grammar Advice" — recommendation-bearing
+### A13: Pullum, "50 Years of Stupid Grammar Advice" (recommendation-bearing)
 
 - **Link / location:** https://www.chronicle.com/article/whos-afraid-of-strunk-and-white/
 - **Retrieved:** 2026-07-21
@@ -322,7 +329,7 @@ stale-figures principle (V7). The recommendation survived in adjusted form.
   is why the recommendation keeps the standard's "active by default" phrasing instead of adopting Orwell's "never."
 - **Evidence status:** corroborated by A14
 
-### A19: Han readability rule — recommendation-bearing
+### A19: Han readability rule (recommendation-bearing)
 
 - **Link / location:** han-communication/references/readability-rule.md
 - **Retrieved:** n/a
@@ -333,7 +340,7 @@ stale-figures principle (V7). The recommendation survived in adjusted form.
   unchanged) follows directly from this file's own stated constraint against instruction stacking.
 - **Evidence status:** codebase (current-state anchor)
 
-### A20: Han writing-voice profile — recommendation-bearing
+### A20: Han writing-voice profile (recommendation-bearing)
 
 - **Link / location:** han-communication/references/writing-voice.md
 - **Retrieved:** n/a

--- a/han-communication/agents/readability-editor.md
+++ b/han-communication/agents/readability-editor.md
@@ -32,6 +32,11 @@ in three of ten windows" to "was sometimes slow," or "only when X and Y both hol
 failure, not a simplification. When a readability change would blur a fact, keep the fact and find another way to make
 the sentence read.
 
+**Break a rule before writing something clumsy.** When applying a rubric criterion would make a passage read worse — a
+split that strips the connective tissue, a reordering that buries a step of reasoning — leave the version that reads
+better. This license covers the readability moves only. It never excuses a word from the vocabulary blocklist and never
+excuses a fidelity loss; criterion 5's blocklist and the fidelity principle above stay absolute.
+
 ## Prose only
 
 You rewrite **prose regions only**. Leave these byte-for-byte unchanged:
@@ -67,7 +72,9 @@ Audit and rewrite against these six criteria. They are the whole rubric.
    hurt by splitting.
 5. **Common words, no blocklisted words** — prefer the common word over the technical synonym; define an unavoidable
    term on first use. Remove every word on the vocabulary blocklist (the writing-voice profile's "Avoided words and
-   phrases" and "AI slop to avoid" lists). Keep domain terms the reader genuinely needs.
+   phrases" and "AI slop to avoid" lists). Replace stale figures of speech and foreign, Latinate, or archaic diction
+   ("in lieu of," "aforementioned") with plain equivalents, but keep a fresh analogy that is load-bearing for the
+   explanation. Keep domain terms the reader genuinely needs.
 6. **Progressive disclosure** — the core idea comes before its qualifications, edge cases, and supporting evidence.
    Reorder within a section when the detail arrives before the point it supports. Pull implementation and technical
    references (symbol names, file paths, flags) out of the prose where the reader does not need them to follow the

--- a/han-communication/references/readability-rule.md
+++ b/han-communication/references/readability-rule.md
@@ -94,6 +94,17 @@ quantity, named entity, and stated condition or qualifier survives with its prec
 in three of ten windows" to "was sometimes slow," or "only when X and Y both hold" to "generally," is a fidelity
 failure, not a simplification. The standard governs how the content is said, never whether a required fact appears.
 
+## Break a rule before writing something clumsy
+
+When following one of the drafting properties above, or making a rewrite move to satisfy one, would make the prose read
+worse, break the rule. The properties exist to make the deliverable easier to read. A rule applied mechanically can do
+the opposite: splitting a sentence that read well, or reordering a paragraph into a muddle. In that case the better
+prose wins.
+
+The escape is scoped. It covers the drafting properties and rewrite moves only, and it yields to both hard gates: it
+never licenses a word from the vocabulary blocklist, and it never licenses a fidelity loss. Self-check criterion 5 and
+"Fidelity wins" stay absolute.
+
 ## The standardized self-check
 
 After the draft exists, run this self-check as a discrete pass over the prose regions. It evaluates concrete,

--- a/han-communication/references/writing-voice.md
+++ b/han-communication/references/writing-voice.md
@@ -108,6 +108,15 @@ Based on what's conspicuously absent across the samples:
 - No "showcase" as a verb. Prefers "show", "demonstrate", "illustrate".
 - No "robust" as a vague positive.
 - No sports metaphors as decoration — the running-distance metaphor appears as actual load-bearing analogy, not flavor.
+- No stale figures of speech. A metaphor or simile worn familiar from overuse ("low-hanging fruit", "the tip of the
+  iceberg", "a double-edged sword") gets cut or replaced with a fresh image. The dividing line is the same
+  load-bearing-versus-decorative test as the sports-metaphor rule above: a fresh physical-world analogy that carries
+  the explanation — the signature move described under core voice attributes — stays legal; a worn figure doing
+  decoration goes.
+- No foreign or Latinate stock phrases. Not "in lieu of" but "instead of"; not "per se" but a plain restatement of the
+  point.
+- No archaic formal words. Not "aforementioned" but "that" or the thing's own name; not "herein" but "here" or "in this
+  document".
 - No "actually" - this is rude, and indicates that the reader was wrong
 - No "just" - this assumes the information is easy to understand or follow, and can make readers feel insulted for not
   understanding


### PR DESCRIPTION
## Summary

**This PR teaches Han's shared writing standard to catch stale figures of speech and clumsy stock phrasing, and to break its own rules when following them would read worse, so that every skill's prose output stays vivid without turning wooden.**

## Behavior changes

Every Han skill that produces prose reads its writing rules live from two shared files in `han-communication`. `readability-rule.md` holds the drafting-and-rewrite standard, and `writing-voice.md` holds the voice profile with its blocklist. This PR edits those two files, so the change reaches every consuming skill at once without touching any skill itself. The one exception is the `readability-editor` agent: it runs a hardcoded rubric instead of reading those files, so this PR weaves the same rules into its rubric directly.

Two things change for anyone whose prose runs through the standard. First, the voice profile now flags three kinds of tired language: worn-out figures of speech, foreign or Latinate stock phrases like "in lieu of" and "per se", and archaic formal words like "aforementioned" and "herein". The figures-of-speech rule draws a line between decorative clichés (out) and load-bearing physical-world analogies (kept), so Han's own signature style stays legal.

Second, the standard gains an explicit escape clause: when following a drafting rule would produce clumsy prose, break the rule. That clause yields to the two hard gates it cannot override, so it never licenses a blocklisted word or a loss of fidelity to the source meaning.

The rest of the branch is the paper trail behind those edits: a research report comparing Orwell's six rules of writing against the existing standard, plus the planning artifacts that turned the report's findings into the four targeted edits. The six-point self-check and the editor agent's six rubric criteria are unchanged, so every count claim across the docs stays accurate.
