### PR TITLE
feat(han-coding): list the context used, with direct links, in code-overview output

### DIFF
--- a/han-coding/docs/skills/code-overview.md
+++ b/han-coding/docs/skills/code-overview.md
@@ -15,8 +15,9 @@ to use the skill. For what the skill does internally, read the skill definition 
   working on or reviewing it.
 - **When to use it.** You have landed in code you do not know, or a PR you are about to review, and you want a fast
   orientation before you start.
-- **What you get back.** A scratch overview file (written outside the repository) with a purpose statement, Mermaid flow
-  charts, the directly-related context, and where to start, all at minimal technical depth.
+- **What you get back.** A scratch overview file (written outside the repository) with a purpose statement, a linked
+  list of the context the overview drew on, Mermaid flow charts, the directly-related context, and where to start, all
+  at minimal technical depth.
 - **Size-aware.** The skill classifies the target as small / medium / large, defaults to small, and scales how many
   `codebase-explorer` agents it dispatches. Pass the size as the first positional argument to override
   (`/code-overview medium`). See [Sizing](../../../docs/sizing.md).
@@ -93,11 +94,17 @@ not maintained; it is a point-in-time orientation aid.
 The document follows one structure per mode, under a shared grammar. It opens with a title and a short intro paragraph
 naming what is being examined (not a metadata block), then leads with the why and lets every later section flow from it:
 
-- **Code mode:** _Why it exists_ (the problem solved or goal served, then briefly what it is) → _Main flow_ (a Mermaid
-  chart with a scope label, read as how the code delivers on the why) → _Context and uses_ → _Where to start_.
-- **PR mode:** _Why this change exists_ (the need that motivated it, then the bottom line of what it does) → _Changes by
-  intent_ (grouped by the outcome, the why, each group delivers) → _How the change flows_ (a Mermaid chart with a scope
-  label) → _What to watch when reviewing_ (navigational only).
+- **Code mode:** _Why it exists_ (the problem solved or goal served, then briefly what it is) → _Context used_ (the
+  sources the overview drew on) → _Main flow_ (a Mermaid chart with a scope label, read as how the code delivers on the
+  why) → _Context and uses_ → _Where to start_.
+- **PR mode:** _Why this change exists_ (the need that motivated it, then the bottom line of what it does) → _Context
+  used_ → _Changes by intent_ (grouped by the outcome, the why, each group delivers) → _How the change flows_ (a Mermaid
+  chart with a scope label) → _What to watch when reviewing_ (navigational only).
+
+The _Context used_ section, placed directly after the lead why section, lists every source the overview drew on. Each
+source with an address is a direct link — a repository file by path, a pull request, issue, or commit by URL — so you
+can walk the same evidence the overview was built from. A source with no address (an uncommitted diff, the branch's
+commit messages, context supplied in conversation) is stated in one plain sentence instead.
 
 In PR mode, when the pull request has screenshots, the overview embeds them inline next to the text they illustrate, so
 you do not have to switch back to the PR to see them.

--- a/han-coding/skills/code-overview/SKILL.md
+++ b/han-coding/skills/code-overview/SKILL.md
@@ -67,6 +67,11 @@ Read these before doing anything. They constrain every step below.
   counts, or any other diff-stat figure — not in the intro, not in a section, not anywhere. BECAUSE these numbers go
   stale the instant the PR is updated and add no understanding; describe what changed and why, never how big the diff
   is.
+- **Every overview cites its context.** The overview lists every source it drew on in a `Context used` section placed
+  directly after the lead why section — linked directly when the source has an address (a repository file path, a PR /
+  issue / commit URL), stated in one plain sentence when it does not (an uncommitted diff, the branch's commit messages,
+  context supplied in conversation). BECAUSE the reader should be able to walk the same evidence the overview was built
+  from, and a fabricated or broken link poisons that trust — never invent a URL or link a path that does not exist.
 - **Ephemeral, not documentation.** The overview is written to a scratch file outside the repository and is never
   committed into the repository's documentation tree. BECAUSE durable feature and system docs are
   `project-documentation`'s job; this skill is an understand-now orientation aid.
@@ -158,6 +163,12 @@ here.
 
 Identify the set of files the change touches; that set scopes the exploration in Step 4.
 
+**Start the context ledger.** From this step on, record every context source consulted — the files and directories read,
+the PR reference and its URL, the commit range and log, CLAUDE.md or project-discovery.md, and any material the user
+supplied in conversation — noting for each whether it has a direct address (a repository file path, a PR / issue /
+commit URL) or not (an uncommitted diff, the branch's commit messages, conversational context). Step 5 renders this
+ledger into the overview's `Context used` section, so an unrecorded source here is a missing citation there.
+
 ## Step 4: Dispatch Exploration Scaled to Size
 
 Dispatch `han-core:codebase-explorer` agents to discover the surrounding code and context — **the evidence of why the
@@ -174,9 +185,12 @@ Each brief must contain: the resolved target (and, in PR mode, the changed-file 
 3); the project-context conventions from Step 1, or a note that surrounding-code inference applies; and the instruction
 to report **the evidence of why the code exists** — the problem it solves or goal it serves, drawn from commit messages,
 PR/issue intent, code comments, naming, and tests — alongside entry points, directly-related context, uses, and the main
-flow, as concrete, file-grounded findings. Instruct each explorer to **report what it found, not to assess quality** —
-this skill raises no findings — and, where the why is not stated anywhere in the evidence, to say so rather than infer
-one.
+flow, as concrete, file-grounded findings. Instruct each explorer to **list the files and sources its findings rest
+on** (paths, commits, PR or issue references) so the skill can fold them into the context ledger from Step 3. Instruct
+each explorer to **report what it found, not to assess quality** — this skill raises no findings — and, where the why is
+not stated anywhere in the evidence, to say so rather than infer one.
+
+When the wave returns, merge each explorer's reported sources into the context ledger, deduplicated.
 
 Wait for the whole wave to return before synthesizing. If the target proves too large to cover fully at the chosen size,
 the explorers cover the highest-signal areas; carry that into the coverage note in Step 5.
@@ -205,17 +219,27 @@ evidence does not support.
 
 **Code mode** renders, in order: the title and intro paragraph; a coverage note **only if** coverage was partial; **Why
 it exists** (the problem the code solves or goal it serves, then briefly what it is and why it works the way it does —
-all flowing from the why); **Main flow** (a Mermaid chart with a one-line scope label, read as how the code delivers on
-the why); **Context and uses** (context and uses kept distinguishable, framed as what it depends on to meet the need and
-where that need is served from); **Where to start** (the concrete entry points the reader opens first).
+all flowing from the why); **Context used** (the context ledger, rendered per the rules below); **Main flow** (a Mermaid
+chart with a one-line scope label, read as how the code delivers on the why); **Context and uses** (context and uses
+kept distinguishable, framed as what it depends on to meet the need and where that need is served from); **Where to
+start** (the concrete entry points the reader opens first).
 
 **PR mode** renders, in order: the same title and intro paragraph; the same conditional coverage note; **Why this change
-exists** (the problem the change solves or goal it advances, then briefly the bottom line of what it does); **Changes by
-intent** (grouped by the reader-visible outcome each group delivers — the why each group serves — not by file, layer, or
-author motivation; a single logical change is one narrative with no grouping header); **How the change flows** (a
-Mermaid chart with a scope label, placed after the grouped changes BECAUSE the reviewer must know what changed before
-that chart is meaningful); **What to watch when reviewing** (navigational only — where the change is hardest to follow
-and why; never a quality or risk judgment).
+exists** (the problem the change solves or goal it advances, then briefly the bottom line of what it does); **Context
+used** (the context ledger, rendered per the rules below); **Changes by intent** (grouped by the reader-visible outcome
+each group delivers — the why each group serves — not by file, layer, or author motivation; a single logical change is
+one narrative with no grouping header); **How the change flows** (a Mermaid chart with a scope label, placed after the
+grouped changes BECAUSE the reviewer must know what changed before that chart is meaningful); **What to watch when
+reviewing** (navigational only — where the change is hardest to follow and why; never a quality or risk judgment).
+
+**Render the `Context used` section from the context ledger** built in Steps 3 and 4, directly after the lead why
+section in both modes. One line per source, each with a short note on what it contributed. Link every source that has a
+direct address: a repository file or directory as a Markdown link whose target is its absolute path (the scratch file
+lives outside the repository, so a relative path would not resolve); a pull request, issue, or commit as its URL (in PR
+mode with a remote, prefer the remote's file URLs at the PR's head so the links work for a reader outside this machine).
+A source with no address — the uncommitted diff, the branch's commit messages, context the user supplied in conversation
+— gets one plain sentence stating what the context was. Never fabricate a URL or link a path that does not exist;
+deduplicate the list and keep it a reference list, not prose.
 
 **Place any captured screenshots inline next to the text they illustrate** — embedded as `![caption](url)` directly
 under the Changes-by-intent item or the flow step they depict, BECAUSE a visual next to its description spares the
@@ -249,7 +273,9 @@ and the resolved target (and, in PR mode, the changed-file set) so it knows what
   inferred; does the code actually do what _Why it exists_ / _Why this change exists_ says; does the **Main flow** /
   **How the change flows** chart match the real control flow, in the right order, with no invented or missing steps; do
   the named **Where to start** entry points exist and are they the right ones; does each **Changes by intent** grouping
-  describe what that change actually does and the why it claims to serve. Surface every claim that is unsupported,
+  describe what that change actually does and the why it claims to serve; does every entry in **Context used** point at
+  a source that exists (the file path resolves, the PR / issue / commit reference is real) — a fabricated or broken link
+  is an inaccuracy like any other. Surface every claim that is unsupported,
   overstated, contradicted by the code, or hallucinated — the why most of all, since it is the load-bearing claim —
   citing the file, line, or commit that disproves it. **Validate the accuracy of the description only — do not assess
   the code's quality and do not raise findings about the code itself.** Return a list of inaccurate or unsupported
@@ -267,10 +293,11 @@ readability rewrite, not two overlapping reviews.
   default reader (a capable reader who did not do this work and lacks the author's context), preserving every fact. Pass
   it the scratch-file path; the editor reads han-communication's own canonical rule, so pass no rule path. It operates
   on **prose regions only**: it does not touch the Mermaid chart bodies, code fences, or the embedded screenshot markup,
-  and it leaves every named file, symbol, and entry point exact. It applies the rewrite to the scratch file in place and
-  returns a rubric verdict and a fact-preservation ledger. Tell it: **rewrite the overview document for readability only
-  — do not review the underlying code, and do not raise findings about it.** This skill makes no quality judgment about
-  the code; the validator guards truth, the editor guards clarity, and neither crosses into evaluating the work itself.
+  and it leaves every named file, symbol, entry point, and `Context used` link target exact. It applies the rewrite to
+  the scratch file in place and returns a rubric verdict and a fact-preservation ledger. Tell it: **rewrite the
+  overview document for readability only — do not review the underlying code, and do not raise findings about it.**
+  This skill makes no quality judgment about the code; the validator guards truth, the editor guards clarity, and
+  neither crosses into evaluating the work itself.
 
 Keep the spec-content discipline through both passes: the result is still an orientation aid with no quality findings,
 led by the why with everything flowing from it, minimal technical detail in the why/flow/context sections, and concrete

--- a/han-coding/skills/code-overview/references/overview-template.md
+++ b/han-coding/skills/code-overview/references/overview-template.md
@@ -24,6 +24,13 @@ exactly as written.
   need. Every section after it (flow, context, handoff) exists to give the reader the context to understand that why.
   Never invent a business rationale the evidence does not support; when the why can only be inferred, mark it as
   inferred.
+- **List the context used, directly after the lead why section.** The `Context used` section names every source the
+  overview drew on — the files and directories read, the pull request or issue, the commit history consulted, the
+  project-context docs, and any material the user supplied. Link each source directly when it has an address: repository
+  files link by path, and a pull request, issue, or commit links by URL. When a source has no address to link to (an
+  uncommitted diff, the branch's commit messages, context supplied in conversation), state in one plain sentence what
+  the context was. Never fabricate a URL or link to a path that does not exist. This section is a reference list, not
+  prose — one line per source, with a short note on what it contributed.
 - **Progressive disclosure, anchored on the why.** The most important understanding comes first, and that is _why the
   code exists_ — the problem it solves or goal it serves. Detail unfolds beneath it, every section flowing from and
   serving that why. A reader who stops after the lead section still knows why the target exists and what need it meets.
@@ -62,6 +69,15 @@ date, or size as metadata fields; weave whatever is worth saying into this sente
 solution to a need, not technical mechanics — and why it works the way it does. Then, briefly, what it is, so the reader
 has a concrete referent. The single most important orientation fact is the why; if the why can only be inferred from the
 code and its intent, say so rather than inventing a rationale.}
+
+## Context used
+
+<!-- One line per source the overview drew on. Link directly when the source has an address (a repository file path, a
+PR / issue / commit URL); when it does not, state plainly what the context was. Never fabricate a link. -->
+
+- [{source name}]({file path or URL}) — {one line on what it contributed}.
+- {Plain statement of a source with no address — e.g. "The uncommitted changes in the working tree" — and what it
+  contributed}.
 
 ## Main flow
 
@@ -115,6 +131,16 @@ for the business or a user — the need that motivated it, as a solution to that
 need, not technical mechanics. Then, briefly, the bottom line of what it does. If
 the why can only be inferred from intent (commit messages, PR/issue text), say so
 rather than inventing one.}
+
+## Context used
+
+<!-- One line per source the overview drew on. Link directly when the source has
+an address (the PR URL, an issue, a repository file path); when it does not,
+state plainly what the context was. Never fabricate a link. -->
+
+- [{source name}]({file path or URL}) — {one line on what it contributed}.
+- {Plain statement of a source with no address — e.g. "The branch's commit
+  messages" or "The uncommitted diff" — and what it contributed}.
 
 ## Changes by intent
 


### PR DESCRIPTION
## What this does

The `/code-overview` skill now cites its sources. Every overview renders a **Context used** section directly after the lead why section (`Why it exists` / `Why this change exists`), listing every source the overview drew on, one line per source with a short note on what it contributed.

- Sources with an address link directly: repository files by path, and a pull request, issue, or commit by URL.
- Sources with no address to link to (an uncommitted diff, the branch's commit messages, context supplied in conversation) are stated in one plain sentence instead.
- Fabricated or broken links are treated as inaccuracies: the adversarial-validator pass now checks that every listed source exists, and the readability-editor pass leaves link targets exact.

## How it works

- **SKILL.md** — a new operating principle (every overview cites its context), a context ledger started in Step 3 and fed by the Step 4 explorers, rendering rules in Step 5 (absolute paths for local files since the scratch file lives outside the repository; remote file URLs when a remote PR is in scope), and the Step 7 validator/editor updates.
- **references/overview-template.md** — the `Context used` section added to both mode templates plus a shared rule describing it.
- **docs/skills/code-overview.md** — the long-form doc's structure lists and TL;DR updated to match.

## Placement note

"After the initial summary" is read as after the lead why section, which is the document's summarizing lead (the intro is only one or two sentences naming the target). This keeps the skill's lead-with-the-why principle intact while putting the source list ahead of the flow and detail sections.

## Note on this branch

The branch also carries a pre-existing commit (`a132c37`, the han-core restructure investigation doc) that predates this change.