### PR TITLE
feature: han-config for project-specific configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ han-plugin-builder skill:
 │   └── docs/           # In-plugin long-form docs: docs/skills/{name}.md
 ├── docs/               # Operator-facing documentation (cross-plugin surfaces; long-form docs now live in each plugin)
 │   ├── concepts.md
+│   ├── configuration.md   # The .han/config.md project-local configuration guide (canonical annotated example)
 │   ├── quickstart.md
 │   ├── sizing.md
 │   ├── yagni.md
@@ -201,6 +202,15 @@ such as Claude, shnould be referenced here.
   Read before changing any file under `han-core/`, `han-github/`, or `docs/`.
 - **[CHANGELOG.md](./CHANGELOG.md).** Version history. Check when a behavior or skill name in user-supplied context
   doesn't match what's on disk. May be a pre-2.0 rename or a removed feature.
+
+### Project-local configuration
+
+- **[docs/configuration.md](./docs/configuration.md).** The operator guide for `.han/config.md`, the optional file a
+  consuming project carries to set an output base directory and extra agents for Han skills. Holds the single canonical
+  annotated schema example.
+- **[han-core/references/config-rule.md](./han-core/references/config-rule.md).** The canonical interpretation contract
+  (schema tokens, precedence, containment, pool-join, degradation) every participating skill applies. Vendored
+  byte-identical into every skill-carrying plugin's `references/`; edit the canonical copy and re-sync the others.
 
 ### Writing voice
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -200,6 +200,14 @@ skills as machine input, are out of scope.
 Read the full [Readability](./readability.md) reference for the required properties, the staged application, the scope
 table, and the fidelity guard.
 
+## Project-local configuration
+
+A project can carry one optional file, `.han/config.md`, that every Han skill reads on every run. It sets a base
+directory for the skills' markdown deliverables and names extra agents for the dispatching skills to consider. A
+project without the file sees no change, and a broken file degrades quietly to defaults with a one-line note. Read the
+full [Configuration](./configuration.md) reference for the file's schema, the precedence chain, and the degradation
+contract.
+
 ## When would you invoke an agent directly?
 
 Most of the time you will not. A skill calling an agent is the typical flow.
@@ -268,6 +276,7 @@ Skim the indexes after you read this page. Pick the one skill you need right now
 - **Want to know what survives a review?** → [YAGNI](./yagni.md).
 - **Want to know how confident to be in what survives?** → [Evidence](./evidence.md).
 - **Want to know how skill output is kept readable?** → [Readability](./readability.md).
+- **Want to adjust where skills write and which agents they consider?** → [Configuration](./configuration.md).
 - **Writing your own skill or agent?** → [Contributing](../CONTRIBUTING.md).
 
 ## Related reading

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,111 @@
+# Project-Local Configuration
+
+A project that uses Han can carry one optional file, `.han/config.md`, to adjust how Han skills behave in that project.
+The file controls two things: where skills write their markdown deliverables, and which extra agents dispatching skills
+consider. Every Han skill reads the file on every run, so the overrides take effect without depending on the model
+remembering to look. A project without the file sees no change of any kind.
+
+> See also: [Plugin landing page](../README.md) · [Concepts](./concepts.md) · [Quickstart](./quickstart.md) ·
+> [All skills](./skills/README.md) · [All agents](./agents/README.md)
+
+## TL;DR
+
+- **You write the file; Han cannot.** Han cannot ship or seed a project-level config from the plugin side. You create
+  `.han/config.md` by hand in a `.han/` folder at your project root, and it travels through version control like any
+  other file. The annotated example below is the canonical source to author from.
+- **Two overrides ship.** `output-directory` sets one base directory for every skill's markdown deliverables.
+  `## Extra Agents` names project-defined or third-party agents that Han's dispatching skills consider alongside their
+  built-in rosters.
+- **A bad config can never fail a skill run.** The worst it can do is be ignored, with a one-line note naming what was
+  ignored. A missing or empty file changes nothing and says nothing.
+- **The interpretation contract lives in
+  [`han-core/references/config-rule.md`](../han-core/references/config-rule.md).** Every skill applies that one rule
+  file (vendored byte-identical into each plugin), so one config file resolves identically across the whole suite.
+  This page is the operator-facing guide.
+
+## The file, annotated
+
+Create `.han/config.md` in the directory you run Han skills from. This is the one canonical example; both settings are
+optional, and everything unrecognized is ignored.
+
+```markdown
+---
+# Base directory for Han's markdown deliverables, relative to this project's
+# root. Each skill keeps its own folder and file structure beneath it, and
+# creates the directory on first write. Must stay inside the project: absolute
+# paths and paths escaping upward are refused.
+output-directory: docs/han
+---
+
+## Extra Agents
+
+One agent per line. Qualified `plugin:agent` form or bare name, matched
+case-insensitively against the agents available in the session.
+
+- my-plugin:payments-domain-expert
+- accessibility-reviewer
+```
+
+## What each override does
+
+### `output-directory`
+
+Skills that write markdown deliverables (plans, reports, documentation) write them under this base directory instead of
+their default locations, keeping their own folder structure beneath it. A skill that writes nothing ignores the setting
+silently. The value must be a relative path that stays inside the project; an absolute path or a `..` escape is
+refused with a one-line note, and the skill falls back to its default location.
+
+### `## Extra Agents`
+
+Skills that select among candidate agents (for example [`/code-review`](../han-coding/docs/skills/code-review.md),
+[`/research`](../han-research/docs/skills/research.md), or
+[`/plan-implementation`](../han-planning/docs/skills/plan-implementation.md)) add these agents to their candidate pool.
+The extras compete under the same signal-based selection and the same size caps as the skill's own roster — a selected
+extra agent can take a slot a default specialist would otherwise have filled, and that displacement is intended. An
+entry that duplicates an agent already in the pool has no effect. An entry that does not resolve to a dispatchable
+agent (a misspelling, a skill name) is skipped with a one-line note. The override selects among agents that already
+exist in the session; it does not define new agents.
+
+## Precedence
+
+Each single-value setting resolves through a fixed chain; the first source that supplies a value wins:
+
+1. Explicit input — what you tell the skill directly, or an explicit path a wrapper skill passes.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+So the config file beats CLAUDE.md, silently. The extra-agents list adds rather than replaces: agents you name
+explicitly are always considered, and the config's entries join them as candidates.
+
+## Where the file is discovered
+
+Skills look for `.han/config.md` only in the directory they run from — the same place they already look for CLAUDE.md
+and the project-discovery file. In a monorepo, each package can carry its own config; running a skill from a directory
+without one behaves as if the file were absent, even when another directory in the repo has one.
+
+## When something is wrong
+
+A configuration problem degrades to defaults; it never blocks or fails the run. You hear about a problem under one
+rule: a one-line note appears only when content that attempts a recognized override cannot be used — malformed
+frontmatter, an unrecognized setting name, a blank value, an out-of-bounds `output-directory`, or an unresolvable agent
+name. Content the suite has no use for (plain prose in the file) is passed over silently, and when everything applies
+cleanly the skills say nothing about the config at all.
+
+## Keeping the file visible
+
+Because the config silently outranks CLAUDE.md, [`/project-discovery`](../han-core/docs/skills/project-discovery.md)
+keeps it visible: when `.han/config.md` exists it offers to add a one-line pointer to it in your CLAUDE.md, and when
+the file is gone but a pointer remains it offers to remove the stale line. Both only with your consent.
+
+Keep the file small. Its whole content is read on every skill run, so everything in it costs context on every run.
+
+## Related reading
+
+- [`han-core/references/config-rule.md`](../han-core/references/config-rule.md). The canonical interpretation contract
+  every skill applies.
+- [Concepts](./concepts.md). How skills, agents, sizing, and the other cross-suite mechanics fit together.
+- [Quickstart](./quickstart.md). Which skill to start with, including project setup in Path D.
+- [`/project-discovery`](../han-core/docs/skills/project-discovery.md). The skill that keeps the CLAUDE.md pointer to
+  this file honest.

--- a/docs/plans/fix-config-probe-exit-code/investigation.md
+++ b/docs/plans/fix-config-probe-exit-code/investigation.md
@@ -1,0 +1,267 @@
+# Investigation: `.han/config.md` probe fails skill invocation when the file is absent
+
+A probe command shipped without an exit-0 guard, so it aborts every Han skill run in a project that has no `.han/config.md` file. The fix guards that command in all 39 SKILL.md files. Read the summary below, then approve the Planned Fix or push back.
+
+## What's broken and how to fix it
+
+- **Root Cause:** The probe command `cat .han/config.md 2>/dev/null` exits with status 1 when the file does not exist, and Claude Code's skill loader fails any `!`-backtick pattern whose command exits nonzero, so every skill run in a project without the config file aborts before the skill body loads (E1, E2, E10).
+- **Fix:** Replace the probe line in all 39 SKILL.md files with `cat .han/config.md 2>/dev/null || echo ""`, the loader's own recommended guard idiom. This makes the command always exit 0 and still produce empty output when the file is absent, exactly the "probe returns nothing, no config present" state the config rule already defines (E6, E10).
+- **Why Correct:** Both halves of the fixed command are on the loader's documented auto-approve allowlist, and the `2>/dev/null || echo` shape is the guard already proven by fifteen-plus working probes across the suite (E4, E10). Validation rejected the originally proposed `|| true` form, because `true` appears nowhere on that allowlist and the form is untested against the loader (V1).
+- **Validation Outcome:** The adversarial validator confirmed the root cause, the 39-file scope, and the byte-identical claim (V3, V4). It refuted the first-draft `|| true` fix form (V1), which was replaced with the allowlisted `|| echo ""` form, and it confirmed the pre-commit hooks leave the line untouched (V6).
+- **Remaining Risks:** An unreadable-but-present config degrades silently instead of with the contract's one-line note (V2); the fix should get one live spot-run in a config-less project before release; the repo-internal `han-release` skill carries two same-class unguarded `jq` probes worth a follow-up (V8). See the Confidence Assessment.
+
+## Problem Statement
+
+Running any Han skill in a project that has no `.han/config.md` throws an error and the skill does not execute. The reported reproduction ran `/han-planning:plan-a-feature` in a consuming project and got:
+
+```
+Error: Shell command failed for pattern "!`cat .han/config.md 2>/dev/null`":
+```
+
+The expected behavior is the opposite, and it is written into the feature's own contract: a missing config file means "no config present," the skill behaves exactly as it does without the feature, and nothing is said about it (E6). The config file is optional by design, so the absent-file state is the normal state for most projects.
+
+Every one of the 39 Han skills carries this probe line (E3), so the bug blocks the entire suite in any project that has not created the optional file. That makes it a release blocker for the `han-config` branch.
+
+## Why the probe fails
+
+### Root Cause
+
+`cat` on a missing file exits with status 1, even when stderr is redirected. Claude Code's skill loader treats a nonzero exit from a `!`-backtick context probe as a hard failure of the skill invocation. The probe line shipped without the exit-0 guard that the loader's guidance recommends and that every other probe in the suite carries.
+
+### The three-link failure chain
+
+Each link in the chain is backed by evidence.
+
+First, the command itself. `2>/dev/null` suppresses the "No such file or directory" message but does not change the exit status. Reproduced directly in this repo, where no `.han/config.md` exists: the bare command exits 1 (E1).
+
+Second, the loader. Claude Code runs `!`-backtick probes at skill load, before the skill body is read, and fails the load when a probe's command exits nonzero. The error text in the reproduction matches this failure mode exactly, naming the probe pattern verbatim (E2).
+
+The repo's own probe-authoring guidance separates this from the loader's other failure mode. A command that is not auto-approvable is rejected with a different message (`Shell command permission check failed ... requires approval`), so the reported error belongs to the execution-failure family, not the permission family (E10). The permission explanation is independently ruled out: `readability-guidance` carries the same probe with no Bash grant at all in its allowed-tools, and its probe succeeds whenever the file exists (V3).
+
+Third, the convention gap. Every other probe across all 39 SKILL.md files is exit-0-safe by construction: `find` exits 0 whether or not it matches, tool checks use `which ... || echo "not installed"`, git-state probes use `... || echo unknown`, and one probe pipes through `head`, which always exits 0 (E4). The loader guidance names this exact guard (`2>/dev/null || echo <sentinel>`) as the recommended compound for "any command that exits non-zero when its subject is absent" (E10).
+
+The `.han/config.md` probe is the only one with no guard. It was added across the suite in commits `172ce8d` and `5ca6f3b` on the `han-config` branch (E5). The prose written next to it in those same commits ("When it returns nothing, no project config is present and nothing changes") states the intended silent behavior, but the chosen command cannot deliver it: the run dies in the loader before that prose is ever read.
+
+The bug never surfaced during the branch's own verification because the completeness check was a structural grep, and the manual spot-runs against an absent config had not been run yet.
+
+## Planned Fix
+
+### Chosen fix and rejected alternatives
+
+The fix changes the probe line in all 39 SKILL.md files to `cat .han/config.md 2>/dev/null || echo ""`. It also spot-verifies one skill against the live loader before sweeping the rest, and refreshes the one live doc that quotes the old command text.
+
+The team weighed three candidate forms, and validation changed the choice.
+
+- **`|| echo ""` (chosen).** Both parts (`cat`, `echo`) are on the loader's documented auto-approve allowlist. The `2>/dev/null || echo` compound is the guidance's recommended guard, already proven by fifteen-plus shipped probes (E4, E10). The fallback output is a blank line, so on absence the probe still "returns nothing": the exact absence signal the config rule and all 39 pointer paragraphs already describe (E6). No other file changes.
+- **`|| true` (first draft, rejected).** Correct in a bare shell (E1), but `true` appears nowhere on the loader's enumerated allowlist, no live SKILL.md uses it, and the form was never tested against the loader itself. It risked trading the exit-status failure for an untested permission rejection (V1).
+- **`|| echo "none"` and `test -f ... && cat ...` (rejected).** A visible sentinel lands in a slot the skills treat as file content, breaking the "probe returns nothing" absence contract and colliding with legitimate content (E8). The `test -f` form adds a check no other probe uses, does not help the unreadable-file case (`test -f` passes on a permission-denied file), and `test` is likewise not on the enumerated allowlist (E8, V7).
+
+### Files to change
+
+#### Spot verification first: one SKILL.md against the live loader
+
+- **Change:** Apply the new probe line to a single skill. Then invoke that skill in a project (or scratch directory) with no `.han/config.md` and confirm the skill loads with no error and an empty probe value. Also invoke it with the file present and confirm the content is injected.
+- **Evidence:** (V1): the first-draft fix failed validation precisely because the form was never run against the loader. This gate keeps the same mistake from shipping twice.
+- **Details:** Any cheap skill works; `han-communication:readability-guidance` is a good candidate because its allowed-tools has no Bash grant, making it the strictest permission case (V3).
+
+#### All 39 `*/skills/*/SKILL.md` files (complete list in E3)
+
+- **Change:** Replace the probe line, identically in every file:
+
+  ```markdown
+  - .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
+  ```
+
+- **Evidence:** (E1) the guard forces exit 0; (E10) both parts and the compound shape are loader-approved; (E3) enumerates the full fix surface; (E4) shows the guard matches the suite's proven convention.
+- **Standards:** The probe-hardening convention and the loader guidance's recommended guard (Coding Standards Reference below); the config-rule contract that absence means empty output (E6).
+- **Details:** Apply this as a mechanical, byte-identical replacement across the 39 files (a scripted, `grep`-verified pass, mirroring how the line was introduced), so no file diverges. No pointer paragraphs, `config-rule.md` copies, or allowed-tools lists change. None of the 12 vendored rule copies, `docs/configuration.md`, `CLAUDE.md`, or any README quotes the command text (E7, V5), and the pointer paragraphs' "when the probe returns nothing" phrasing already matches the fixed behavior (V9). Verify completion with the same greps used on the branch: 39 files matching the new probe text, 0 matching the old.
+
+#### `docs/research/han-config-extensibility.md`
+
+- **Change:** Update the one inline example at line 105 that quotes the old command, so the report's illustration matches the shipped probe.
+- **Evidence:** (E8, V5): this is the only file outside the frozen `docs/plans/` history that quotes the command verbatim.
+- **Details:** Replace the quoted `` !`cat .han/config.md 2>/dev/null` `` with `` !`cat .han/config.md 2>/dev/null || echo ""` ``. One-line edit.
+
+## Evidence Summary
+
+### E1: The bare probe exits 1 on absence, a guarded probe exits 0
+
+- **Source:** Shell reproduction in this repo (no `.han/` present) and in an empty scratch directory.
+- **Finding:**
+  ```
+  cat .han/config.md 2>/dev/null; echo "exit=$?"
+  exit=1
+  (cat .han/config.md 2>/dev/null || true); echo "exit-with-fallback=$?"
+  exit-with-fallback=0
+  ```
+- **Relevance:** Direct mechanical cause: `2>/dev/null` redirects only the error text, not the exit status, and an `||` fallback forces exit 0. (This shell-level check motivated the first-draft `|| true` form; the shipped form swaps the fallback to the allowlisted `echo ""` for the loader-approval reasons in E10/V1, with identical exit behavior.)
+
+### E2: Claude Code fails a `!`-pattern on nonzero exit, matching the reported error verbatim
+
+- **Source:** Reported error screenshot from a consuming-project run of `/han-planning:plan-a-feature`.
+- **Finding:**
+  ```
+  Error: Shell command failed for pattern "!`cat .han/config.md 2>/dev/null`":
+  ```
+- **Relevance:** The loader names the exact probe pattern and fails the skill invocation before the skill body runs, tying the symptom to the probe's exit status rather than to anything in the skill's own steps. The wording also distinguishes it from the loader's permission-rejection message (E10).
+
+### E3: All 39 SKILL.md files carry the identical probe line, the complete fix surface
+
+- **Source:** `grep -rln "cat .han/config.md" --include="SKILL.md"` → 39 matches; line-level uniqueness check found exactly one variant (V4).
+- **Finding:** `han-coding` (9): `coding-standard:19`, `architectural-analysis:21`, `investigate:19`, `code-review:21`, `automated-test-planning:41`, `code-overview:25`, `tdd:24`, `manual-test-planning:17`, `refactor:24`. `han-atlassian` (6): `work-items-to-jira:24`, `markdown-to-confluence:21`, `project-documentation-to-confluence:20`, `plan-a-feature-to-confluence:21`, `investigate-to-confluence:19`, `code-overview-to-confluence:20`. `han-planning` (5): `plan-implementation:17`, `plan-work-items:19`, `iterative-plan-review:18`, `plan-a-phased-build:18`, `plan-a-feature:19`. `han-github` (3): `update-pr-description:27`, `post-code-review-to-pr:27`, `work-items-to-issues:16`. `han-research` (3): `research:24`, `issue-triage:17`, `gap-analysis:19`. `han-documentation` (3): `architectural-decision-record:41`, `runbook:50`, `project-documentation:20`. `han-plugin-builder` (3): `guidance:16`, `skill-builder:15`, `agent-builder:15`. `han-communication` (2): `readability-guidance:15`, `edit-for-readability:19`. `han-reporting` (2): `stakeholder-summary:17`, `html-summary:15`. `han-core` (1): `project-discovery:18`. `han-linear` (1): `work-items-to-linear:24`. `han-feedback` (1): `han-feedback:15`.
+- **Relevance:** The line is byte-identical everywhere, so the fix is one mechanical replacement across 39 files, and any file left behind diverges in behavior.
+
+### E4: Every other probe in the suite guarantees exit 0; this is the sole unguarded one
+
+- **Source:** Exhaustive sweep of all `!`-backtick probes across `*/skills/*/SKILL.md` (68 probe lines examined), e.g. `han-coding/skills/tdd/SKILL.md:20-21`, `han-core/skills/project-discovery/SKILL.md:14-17`, `han-coding/skills/refactor/SKILL.md:21`, `han-github/skills/post-code-review-to-pr/SKILL.md:16-26`.
+- **Finding:**
+  ```
+  - git installed: !`which git 2>/dev/null || echo "not installed"`
+  - current branch: !`git branch --show-current 2>/dev/null || echo unknown`
+  - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
+  - working tree: !`git status --porcelain 2>/dev/null | head -5`
+  ```
+- **Relevance:** The repo already has a load-bearing hardening convention: 15+ `|| echo` guards, `find` for every file-presence check, and pipeline-through-`head`. The failing probe is the one place the convention was not applied. The suite never uses bare `cat` for optional files anywhere else.
+
+### E5: The probe was introduced by commits `172ce8d` and `5ca6f3b` on branch `han-config`
+
+- **Source:** `git log -S 'cat .han/config.md 2>/dev/null' --all`; `git show 172ce8d`.
+- **Finding:** `172ce8d feat(config): read .han/config.md from every skill with a Project Context block` added the line to the 24 skills with existing blocks. `5ca6f3b feat(config): add a minimal config-only Project Context block to skills that had none` extended it to the other 15. The commits' own adjacent prose states "When it returns nothing, no project config is present and nothing changes."
+- **Relevance:** Pinpoints the regression's origin and shows the intent (silent absence) was documented at the moment the command that contradicts it shipped.
+
+### E6: The canonical config rule requires exactly the behavior the fix restores
+
+- **Source:** `han-core/references/config-rule.md:34-35` and its 11 md5-identical vendored copies.
+- **Finding:**
+  ```
+  When the probe returns nothing, no config is present: behave exactly as the skill does without this rule, with no note.
+  ...
+  A bad config can never fail a skill run; the worst it can do is be ignored.
+  ```
+- **Relevance:** The contract defines absence as empty probe output and forbids config-related failures outright. The current probe violates the second line at a level above the skill: the invocation aborts. The `|| echo ""` fix satisfies both lines with no contract change.
+
+### E7: No live doc outside the SKILL.md files quotes the command, except one research report
+
+- **Source:** Verbatim-text search across `CLAUDE.md`, `README.md`, every `*/README.md`, `docs/configuration.md`, all 12 `config-rule.md` copies, and the `han-plugin-builder` guidance tree; re-verified during validation (V5).
+- **Finding:** Zero matches in all of those surfaces; the rule files describe the probe's behavior ("the inline probe in its `## Project Context` block") without quoting its command text. The one live exception is `docs/research/han-config-extensibility.md:105`.
+- **Relevance:** The fix surface stays small: 39 probe lines plus the one research-report example. Nothing else goes stale.
+
+### E8: Candidate-fix comparison across the four forms
+
+- **Source:** Analysis against E4's convention, E6's contract, and E10's loader allowlist; refined by validation findings V1 and V7.
+- **Finding:** (a) `|| echo ""`: exit 0, blank-line output on absence; both parts allowlisted; matches the documented guard idiom; contract-compliant. (b) `|| true`: exit 0 and empty output in a shell, but `true` is absent from the loader's enumerated allowlist and no live probe uses it, so it is untested against the mechanism that produces the bug. (c) `|| echo "none"`: exit 0 but the probe then never returns nothing; the sentinel lands in a slot the skills treat as file content, so absence detection breaks and `none` becomes indistinguishable from a one-word config. (d) `test -f ... && cat ... || true`: correct output but a shape no other probe uses; `test -f` still passes on a permission-denied file so it does not help the unreadable case; `test` is also not on the enumerated allowlist.
+- **Relevance:** Grounds the "Chosen fix and rejected alternatives" choice: (a) is the only form that is loader-documented, convention-proven, and contract-compliant at once.
+
+### E9: One same-class latent probe exists outside the shipped plugins
+
+- **Source:** `.claude/skills/han-release/SKILL.md:37,39`: `jq -r ... 2>/dev/null` probes.
+- **Finding:** `jq` exits nonzero on missing or invalid input even with stderr suppressed, the same failure class. `jq` is not on the loader allowlist, but the skill declares `Bash(jq *)`, so only the exit-status half of the failure class applies.
+- **Relevance:** Out of scope for this fix: the file is repo-internal maintenance tooling, not shipped to consuming projects. The validator flagged its inputs as fragile: `marketplace.json` is hand-edited during every release, exactly when a transiently malformed file would fail the probe (V8). A follow-up fix (adding the same guard) is recommended rather than leaving this as a footnote.
+
+### E10: The loader's documented allowlist and recommended guard idiom
+
+- **Source:** `han-plugin-builder/skills/guidance/references/skill-building-guidance/context-injection-commands.md:49-59` and `:106-111`; `troubleshooting.md:353`.
+- **Finding:**
+  ```
+  The loader ships a fixed allowlist that already covers most inspection tools, including `cat`, `ls`, `head`,
+  `tail`, `wc`, `grep`, `find` (without the dangerous predicates below), `which`, `echo`, `date`, and the
+  read-only `git` and `gh` subcommands ...
+  Pipes and `&&` / `;` / `||` chains are not forbidden. The loader splits them and checks each part ...
+  One compound form is not only allowed but recommended: the trailing `2>/dev/null || echo <sentinel>` guard.
+  ```
+  The troubleshooting guidance documents a distinct error string for permission rejections (`Shell command permission check failed ... requires approval`) versus the execution failure reported here (`Shell command failed for pattern`).
+- **Relevance:** Confirms the two-part mechanism: each chain part is classified, and nonzero exit fails the load. It confirms the reported error is the execution family and names the exact guard the fix adopts. `true` is absent from every enumeration in the file, which is what disqualified the first-draft fix (V1).
+
+## Validation Results
+
+An adversarial-validator pass attacked the evidence, the root cause, and the first-draft fix. It confirmed the diagnosis and the scope, and it refuted the first-draft fix form, which was replaced before this plan was finalized.
+
+### Counter-Evidence Investigated
+
+#### V1: The first-draft `|| true` form was never tested against the actual loader
+
+- **Hypothesis:** `|| true` might not be a construct the context-injection loader auto-approves, trading the exit-status failure for an untested permission rejection.
+- **Investigation:** Read the loader guidance (`context-injection-commands.md:49-54,106-111`): its fixed allowlist enumerates `cat`, `echo`, and friends but never `true`, and its only recommended guard is `2>/dev/null || echo <sentinel>`. Grepped every live SKILL.md: zero uses of `|| true` (it appears only in `.sh` scripts that run through the Bash tool, a different permission layer). E1's reproduction proves shell exit semantics only, not loader classification.
+- **Result:** Partially Refuted: the root cause stands, but the first-draft fix form rested on an untested assumption.
+- **Impact:** The fix form changed to `|| echo ""` (both parts allowlisted, idiom documented and production-proven), and a one-skill live spot-verification step was added ahead of the 39-file sweep. See Adjustments Made.
+
+#### V2: The guard collapses "config absent" and "config unreadable" into the same silent path
+
+- **Hypothesis:** Forcing exit 0 hides genuinely broken states (a permission-denied file, or `.han/config.md` existing as a directory) which the contract says should get a one-line note.
+- **Investigation:** Read the degradation section of `config-rule.md`: "a file unreadable as text: ignore the unusable portion ... and note what was ignored" is a distinct promise from the silent absent-file path. `cat` exits nonzero identically for missing, permission-denied, and directory targets, so the probe cannot distinguish them.
+- **Result:** Confirmed as a real, accepted gap: an unreadable-but-present file behaves as absent, without the promised note. Failing the run (the only alternative available at probe level) is worse under the contract's top line ("a bad config can never fail a skill run").
+- **Impact:** No code change; the summary at the top and the Confidence Assessment section state the risk plainly instead of calling the risk list empty.
+
+#### V3: Permission denial as an alternate root cause
+
+- **Hypothesis:** The error might come from the probe command lacking an allowed-tools grant, in which case no `||` guard would help.
+- **Investigation:** `cat` is explicitly on the loader's fixed allowlist and needs no grant (E10). The strongest counter-example: `readability-guidance`'s allowed-tools is `Read` alone (no Bash entry of any kind), yet it carries the same probe, which succeeds whenever the file exists. Permission rejections also produce a different documented error string than the one reported.
+- **Result:** Refuted as an alternative cause; exit status stands as the mechanism.
+- **Impact:** Confirms the fix needs no allowed-tools changes in any of the 39 files.
+
+#### V4: The 39-file count and byte-identical claim
+
+- **Hypothesis:** The file list might be incomplete or the line might vary (whitespace, CRLF, quoting) across files, breaking a mechanical replacement.
+- **Investigation:** Re-ran the count independently (39) and reduced all matching lines to unique variants: exactly one. Spot-checked five cited line numbers against the live files; all matched.
+- **Result:** Confirmed.
+- **Impact:** None; the mechanical single-pattern replacement is safe.
+
+#### V5: Other files quoting the command text
+
+- **Hypothesis:** More live files than the one research report might quote the command and go stale.
+- **Investigation:** Repo-wide verbatim search excluding SKILL.md files: one live hit (`docs/research/han-config-extensibility.md:105`) plus hits only inside `docs/plans/`, which the repo's own `docs/plans/CLAUDE.md` freezes. Confirmed `docs/research/` is excluded from Prettier and pre-commit hooks but not from manual editing, so it is correctly in scope.
+- **Result:** Confirmed.
+- **Impact:** None; the two-target fix surface stands.
+
+#### V6: Pre-commit or Prettier hooks mangling the fixed line
+
+- **Hypothesis:** The repo's formatting hooks might rewrite the probe line and break it after the fix lands.
+- **Investigation:** `.prettierignore` excludes all `*.md` (with a comment explaining markdown is the product), and every whitespace/EOL hook in `.pre-commit-config.yaml` excludes `.md`. Reproduced directly: ran Prettier over a scratch file carrying the guarded probe line; output unchanged.
+- **Result:** Confirmed safe (a failure mode the first draft never checked).
+- **Impact:** None.
+
+#### V7: The `test -f` alternate as a better fix
+
+- **Hypothesis:** `test -f .han/config.md && cat .han/config.md || true` might handle the unreadable-file gap the chosen form accepts.
+- **Investigation:** Traced the semantics: `test -f` passes on a permission-denied file (it checks existence and type, not readability), so the unreadable case degrades identically; on a missing file the behavior is identical to the simpler form; `test` is also not on the enumerated allowlist.
+- **Result:** Confirmed: no functional advantage, extra nonconventional shape, same loader-approval risk.
+- **Impact:** None; the rejection in E8(d) stands.
+
+#### V8: The `han-release` jq probes as a recurrence of the same bug class
+
+- **Hypothesis:** Scoping the `.claude/skills/han-release/SKILL.md:37,39` jq probes out understates their risk.
+- **Investigation:** Confirmed the probes are unguarded and that their input, `marketplace.json`, is hand-edited during every release, exactly the moment a transient syntax error would fail the probe. The file is repo-internal, so consuming projects are unaffected.
+- **Result:** Partially Refuted on risk framing (the facts stood): same regression class, likely to recur.
+- **Impact:** Recorded as a recommended follow-up (add the same guard to those two probes) rather than a footnote; still outside this fix's scope.
+
+#### V9: Pointer-paragraph prose conflicting with empty-output absence
+
+- **Hypothesis:** Some of the 39 files' pointer paragraphs might describe absence in a way a blank-line probe output contradicts.
+- **Investigation:** Inspected the pointer text in all 39 files: every one uses "When the `.han/config.md` probe returns content ... When it returns nothing, no project config is present" (or project-discovery's consistent variant). No file expects an error, a sentinel, or any non-empty absence signal.
+- **Result:** Confirmed.
+- **Impact:** None; no pointer paragraph changes.
+
+### Adjustments Made
+
+- **Fix form replaced (V1):** `|| true` → `|| echo ""` throughout the plan, and the E8 comparison was reworked around the loader allowlist evidence (new E10).
+- **Spot-verification gate added (V1):** one SKILL.md is verified against the live loader in a config-less project before the 39-file sweep.
+- **Risk reporting corrected (V2):** the summary at the top now names the unreadable-file silent degradation instead of claiming no material risks.
+- **Evidence strengthened (V3):** the zero-Bash-grant `readability-guidance` counter-example and the distinct permission-error string were added to the root-cause analysis.
+- **Follow-up elevated (V8):** the `han-release` jq probes moved from a footnote to a named recommended follow-up in E9 and Remaining Risks.
+
+### Confidence Assessment
+
+- **Confidence:** High
+- **Remaining Risks:**
+  - The chosen form still awaits its one live loader spot-run (the verification gate under Files to change). Its components and shape are documented as auto-approvable and proven by 15+ shipped probes, so the residual risk is small.
+  - An unreadable-but-present config file degrades silently instead of with the contract's one-line note (V2), accepted since the only probe-level alternative is failing the run.
+  - The `han-release` jq probes (E9, V8) share the failure class and should get the same guard in a follow-up.
+  - A `.han/config.md` that is a directory or symlink loop behaves as absent, consistent with V2's accepted trade.
+
+## Coding Standards Reference
+
+| Standard                                                                                        | Source                                                                                              | Applies To                             |
+| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| Context probes must be auto-approvable and exit-0-safe; the recommended guard is `2>/dev/null \|\| echo <sentinel>` | `han-plugin-builder/skills/guidance/references/skill-building-guidance/context-injection-commands.md:49-59,106-111` | The replacement probe line             |
+| Absence is signaled by empty probe output, never a visible sentinel string                       | `han-core/references/config-rule.md:34-35` (and 11 vendored copies)                                  | Choice of `\|\| echo ""` over a sentinel |
+| Suite-wide lines stay byte-identical across files; verify with a grep completeness check         | Branch precedent: commits `172ce8d`/`5ca6f3b` and the branch's completeness check                    | The 39-file replacement pass           |

--- a/docs/plans/han-project-config/artifacts/.discovery-notes.md
+++ b/docs/plans/han-project-config/artifacts/.discovery-notes.md
@@ -1,0 +1,83 @@
+# Discovery Notes: Project-Local Han Configuration (implementation planning)
+
+Structured project-context summary for the specialist team. Read this first; do not re-grep for what is already here.
+
+## Tech stack
+
+This repository IS the deliverable: a suite of Claude Code plugins written entirely in markdown (SKILL.md files with
+YAML frontmatter, agent .md definitions, reference .md files) plus a few shell scripts under `scripts/` folders in
+some skills. There is no application runtime, no build system, no automated test suite. "Implementation" for this
+feature means editing SKILL.md prompt text, adding reference files, and updating documentation surfaces. Verification
+is by manual skill runs and review, not automated tests.
+
+## Skill inventory relevant to the feature
+
+- 39 SKILL.md files exist across the plugins (`*/skills/*/SKILL.md`). The spec's D4 says "26 with a Project Context
+  block, 15 without" — the current tree shows **24 with** and **15 without** (counts drift; the plan should avoid
+  hardcoded totals per repo convention and enumerate at execution time).
+- Skills WITH a `## Project Context` block (the inline `!`-probe pattern): all of han-coding (7), han-documentation
+  (3), han-planning (5), han-research (3), han-github's update-pr-description and post-code-review-to-pr,
+  han-core/project-discovery, han-feedback/han-feedback, han-reporting/stakeholder-summary.
+- Skills WITHOUT: all 6 han-atlassian skills, han-coding/manual-test-planning, both han-communication skills,
+  han-linear/work-items-to-linear, han-github/work-items-to-issues, all 3 han-plugin-builder skills,
+  han-reporting/html-summary.
+- Agent-dispatching skills (roster tables / candidate pools): code-review, architectural-analysis, investigate
+  (han-coding); plan-a-feature, plan-implementation, iterative-plan-review, plan-work-items (han-planning); research,
+  gap-analysis (han-research); han-feedback; investigate-to-confluence (wrapper).
+- Markdown-deliverable-writing skills: the planning skills (multi-file plan folders under `docs/plans/` or
+  `docs/features/`), research/gap-analysis/issue-triage (reports), documentation skills, coding-standard,
+  automated/manual-test-planning, code-overview (scratch), stakeholder-summary, html-summary, runbook, ADR.
+
+## Existing conventions the implementation must slot into
+
+- **Probe pattern:** `## Project Context` blocks use inline `!`-backtick commands resolved from the working
+  directory, e.g. `han-coding/skills/code-review/SKILL.md:16-20`:
+  `- CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f``. The config read is committed (T1) to use the same
+  pattern, e.g. `cat .han/config.md 2>/dev/null`.
+- **Fallback-chain wording:** `han-coding/skills/code-review/SKILL.md:86-89` shows the in-step resolution prose:
+  "read CLAUDE.md's `## Project Discovery` section ... fall back to project-discovery.md; fall back to Glob
+  defaults ... Continue without any keys that remain unfound." The config file slots in ahead of these per D6.
+- **Roster/size-band convention:** dispatching skills carry roster tables with size-band caps (e.g.
+  `han-research/skills/research/SKILL.md:139-169`, `han-planning/skills/plan-implementation/SKILL.md` Step 3).
+  Extra agents join these pools under existing caps (D5).
+- **Canonical-vs-vendored references:** han-core/references/ holds canonical `yagni-rule.md` + `evidence-rule.md`;
+  han-documentation, han-research, han-planning, han-coding each vendor copies in their own `references/`.
+  han-communication owns `readability-rule.md` + `writing-voice.md` with NO vendored copies (cross-plugin sourcing
+  via a skill). Both precedents exist for where shared config-resolution guidance could live.
+- **project-discovery skill:** `han-core/skills/project-discovery/SKILL.md` already writes a `## Project Discovery`
+  section directly into AGENTS.md or CLAUDE.md with dedup/replace logic (steps: choose target, check existing
+  section, build from `references/template.md`, write, verify). The D10 pointer offer extends this skill.
+
+## Documentation surfaces per repo conventions (CLAUDE.md)
+
+Every changed skill's long-form doc lives at `{plugin}/docs/skills/{name}.md`; plugin READMEs carry scent lines;
+`docs/skills/README.md` is the alphabetized index; `docs/workflows.md` maps chains; `docs/choosing-a-han-plugin.md`
+indexes plugins. A new cross-suite convention (`.han/config.md`) plausibly needs an operator-facing doc under
+`docs/` and mentions in skill docs. The `han-update-documentation` skill exists for doc sweeps.
+
+## Plan precedent
+
+`docs/plans/han-communication-plugin/feature-implementation-plan.md` (+ `artifacts/`) is the closest format
+precedent: a prior plan-implementation output in this repo covering a cross-plugin change. `docs/plans/` holds ~20
+plan folders.
+
+## ADRs and coding standards
+
+- No `docs/adr/` or `docs/coding-standards/` directories exist. Gap: no formal ADRs; decisions live in plan folders'
+  decision logs. The plugin-authoring rules live in `han-plugin-builder/skills/guidance/references/` (notably
+  `plugin-entity-taxonomy.md`, loaded via CLAUDE.md) — skill edits must comply with that guidance.
+- Repo conventions from CLAUDE.md: one canonical source per concept; indexes stay complete, not counted (no
+  hardcoded totals); writing voice per `han-communication/references/writing-voice.md`; YAGNI applies to docs.
+
+## Recent activity
+
+Branch `han-config` carries the research report and this spec (5 commits). Recent main-branch work: readability
+standard rollout across skills (touching most SKILL.md files), han-communication plugin extraction, context-footprint
+reduction. High churn on SKILL.md files suite-wide — the config feature touches the same files.
+
+## Gaps (searched for, not found)
+
+- No automated test harness for skills (no CI running skills). Verification is manual.
+- No ADR directory, no coding-standards directory.
+- No existing `.han/` convention anywhere in the tree (`.han` appears only in this plan folder's spec/research).
+- No plugin.json `user-configuration` usage anywhere in the repo (relevant to OI-1).

--- a/docs/plans/han-project-config/artifacts/.round-1-specialist-outputs.md
+++ b/docs/plans/han-project-config/artifacts/.round-1-specialist-outputs.md
@@ -1,0 +1,204 @@
+# Round 1 verbatim specialist outputs: Project-Local Han Configuration implementation planning
+
+Working file for PM synthesis. Contains the verbatim output of each Round 1 agent.
+
+---
+
+## structural-analyst (verbatim)
+
+**S1: The probe line must be inline per SKILL.md; only the surrounding process prose is a factoring candidate**
+
+- **Dimension:** Boundaries / Abstraction
+- **File(s):** `han-coding/skills/code-review/SKILL.md:16-20`; T1 (`docs/plans/han-project-config/artifacts/feature-technical-notes.md:11-13`)
+- **Finding:** The existing `## Project Context` block uses inline `!`-backtick commands (e.g. `- CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f``) that Claude Code executes from the invoking skill's own working directory at prompt-assembly time, before any step runs. T1 commits the config read to the identical mechanism (`cat .han/config.md 2>/dev/null`). A `!`-probe line cannot be moved into a shared reference file and still execute — SKILL.md frontmatter/body probes are evaluated in place, not by dereferencing an include. So the probe line itself (one bullet per skill) is structurally forced to be inline in each of the 39 files.
+- **Impact:** Only the *interpretation* of the probed content — precedence (D6), degradation/note rules (D9, D14), and the D5 extra-agent pool-join rule — is a legitimate factoring candidate. The probe line is not. Any plan that proposes "factor the whole config-resolution feature into one file skills link to" needs to still land one new bullet inside each SKILL.md's `## Project Context` block (or a new one), not zero.
+
+**S2: D4's "every skill participates" collides with three plugins' "depends on nothing" design, and CONTRIBUTING.md documents the exact carve-out that must now be reopened**
+
+- **Dimension:** Coupling / Dependency Direction
+- **File(s):** `han-feedback/.claude-plugin/plugin.json`, `han-linear/.claude-plugin/plugin.json`, `han-plugin-builder/.claude-plugin/plugin.json` (none declare a `dependencies` array); `CONTRIBUTING.md:202-205`
+- **Finding:** `CONTRIBUTING.md:202-205` states the existing rule for wiring cross-plugin shared prose into a skill: *"Declare the dependency on `han-communication` ... If the skill's plugin does not already depend on `han-communication`, add the direct dependency edge to its `plugin.json`... (`han-linear` and `han-feedback` host no prose-producing skill, so they carry no edge.)"* That carve-out is the reason these plugins currently have zero Han-plugin dependencies — confirmed by their `plugin.json` files carrying no `dependencies` key at all. `han-plugin-builder` likewise depends on nothing (per `CLAUDE.md`'s repository-layout section: "depends on nothing and is also deliberately _not_ bundled by the `han` meta-plugin"). D4 (`decision-log.md:76-96`) requires every skill, including `han-feedback/han-feedback`, `han-linear/work-items-to-linear`, and all three `han-plugin-builder` skills, to read `.han/config.md` and apply D6/D9/D14. If the config-resolution rules are shared via a cross-plugin skill invocation (the `readability-guidance` pattern), these three plugins must each gain a new dependency edge — reopening the exact carve-out CONTRIBUTING.md documents, and contradicting the "depends on nothing" design stated for them in `CLAUDE.md`.
+- **Impact:** This is a real, evidence-backed tension the implementation plan must resolve explicitly, not a hypothetical. The two ways out are structurally different: (a) add a new dependency edge to three plugin manifests (a cross-cutting architectural change with its own review burden and a stale CONTRIBUTING.md line to fix), or (b) avoid cross-plugin skill invocation for this feature and use full per-plugin vendoring instead (see S3), which needs no new dependency edges. Given D4 forces universal participation and these three plugins are explicitly meant to stay dependency-free, vendoring is the layout that does not force a manifest change; recommend it over the skill-invocation pattern for this feature specifically (unlike readability, which _did_ get the dependency-edge treatment because CONTRIBUTING.md's carve-out no longer applied).
+
+**S3: Two existing precedents diverge on drift risk; the config-resolution rules should use full per-plugin vendoring (yagni-rule.md pattern), not single-canonical-plus-invocation (readability-rule.md pattern) — with the vendoring footprint roughly 2.4x the existing worst case**
+
+- **Dimension:** Duplication / Abstraction
+- **File(s):** `han-core/references/yagni-rule.md`, `han-documentation/references/yagni-rule.md`, `han-research/references/yagni-rule.md`, `han-planning/references/yagni-rule.md`, `han-coding/references/yagni-rule.md` (5 identical copies, confirmed by matching md5); `han-communication/references/readability-rule.md` (1 canonical copy, sourced cross-plugin via `han-communication:readability-guidance`, no vendored copies anywhere)
+- **Finding:** The yagni-rule precedent vendors identical copies into 5 plugins with no automated sync tool — the only vendoring script in the repo (`han-plugin-builder/skills/guidance/scripts/init-guidance.sh`) copies plugin-builder's own guidance into *external consuming repos*, not between Han's own plugins. Keeping the 5 yagni-rule.md copies identical today is a manual-diligence convention, not a mechanism. Per S2, the config-resolution rules cannot use the readability-rule pattern without forcing new dependency edges onto `han-feedback`, `han-linear`, and `han-plugin-builder`. That leaves vendoring as the structurally available option — but vendoring config-resolution guidance touches all 12 plugins that carry any SKILL.md (`han-communication`, `han-core`, `han-documentation`, `han-research`, `han-planning`, `han-coding`, `han-github`, `han-reporting`, `han-feedback`, `han-atlassian`, `han-linear`, `han-plugin-builder`), each of which already has (or would gain) its own `references/` directory.
+- **Impact:** 12 vendored copies is materially more drift-prone than the existing 5-copy precedent, with no existing tooling to catch divergence. The plan should either (a) accept the drift risk and add a documentation-sweep or `code-review`/`architectural-analysis`-adjacent check that diffs vendored copies (new machinery, needs its own YAGNI justification), or (b) keep the vendored file intentionally small and mechanical (the precedence order, the note format, the D5 pool-join sentence) so an eyeball diff during any future edit is cheap — closer to how `yagni-rule.md` (Gate 1/Gate 2, ~40 lines) stays synced by convention. Recommend (b): the file should be short enough that "one canonical copy, twelve vendored" is not much heavier in practice than "one canonical, five vendored" was.
+
+**S4: Canonical ownership of the `.han/config.md` schema belongs in han-core/references/, one file, cited by all 39 skills — not restated per skill**
+
+- **Dimension:** Boundaries / Abstraction
+- **File(s):** `han-core/references/` (existing home for `yagni-rule.md`, `evidence-rule.md`); T1 (`feature-technical-notes.md:9-15`)
+- **Finding:** T1 commits the schema shape (frontmatter scalar keys + named markdown section for the extra-agents list) but explicitly defers "exact key names, section headings, and agent-name matching rules" to implementation planning. `han-core` is already the suite's home for cross-cutting behavioral rules consumed suite-wide (`yagni-rule.md`, `evidence-rule.md`), and per `CLAUDE.md`'s repository layout, `han-core` "owns... the canonical rule files." A single `han-core/references/config-schema.md` (or similarly named file) pinning the exact frontmatter key names, the extra-agents section heading, and the agent-name resolution rule is the one canonical source; every plugin's vendored copy (per S3) is a byte-identical mechanical copy of that file, not an independent restatement.
+- **Impact:** Without one pinned canonical source, 12 vendored copies risk drifting on the actual key names (e.g., one copy says `output-directory:`, another says `output_dir:`), which would silently break cross-project config files depending on which plugin's skill happens to read them. This is the highest-value single artifact in the implementation plan.
+
+**S5: The 24 existing `## Project Context` blocks get one new bullet; the 15 skills without one need only a minimal config-only block, not the full existing block — evidence bounds the addition**
+
+- **Dimension:** Boundaries
+- **File(s):** `han-coding/skills/code-review/SKILL.md:16-20` (existing block, 3 bullets: git installed, CLAUDE.md, project-discovery.md); `han-atlassian/skills/markdown-to-confluence/SKILL.md` (no block; publishes an existing file, discovers nothing about the project)
+- **Finding:** The existing `## Project Context` blocks probe for CLAUDE.md, project-discovery.md, and skill-specific signals (git, size hints) because those skills' *own* resolution logic (D6's discovery-source tiers) needs them. The 15 skills without a block today — all 6 `han-atlassian` skills, `han-coding/manual-test-planning`, both `han-communication` skills, `han-linear/work-items-to-linear`, `han-github/work-items-to-issues`, all 3 `han-plugin-builder` skills, `han-reporting/html-summary` — mostly don't resolve CLAUDE.md or project-discovery.md context today because their work doesn't need it (e.g., `markdown-to-confluence` only needs a file path and a Confluence location the user supplies). D4 requires only that they add the config *read*, not the full discovery chain, since D6's "config file" tier is one link in a chain most of these skills never walked before.
+- **Impact:** Giving all 15 skills the full existing block (git/CLAUDE.md/project-discovery.md bullets) would add probes these skills have no use for and no D6 tier to consult them against — an unjustified addition per the YAGNI evidence test (no named need for `han-linear/work-items-to-linear` to probe for CLAUDE.md). The correct per-skill addition is a minimal block carrying only the `.han/config.md` probe line, e.g. `- .han/config.md: !`cat .han/config.md 2>/dev/null``, added as a new `## Project Context` heading in these 15 files. This keeps the 15-skill change small and auditable and avoids scope creep into D6's CLAUDE.md/discovery-file tiers for skills that never used them.
+
+**S6: D5's extra-agent pool-join text is a per-skill addition to existing roster tables, not a new abstraction — but it touches ~10 files with slightly different roster shapes**
+
+- **Dimension:** Duplication / Coupling
+- **File(s):** `han-research/skills/research/SKILL.md:139-169` (roster table + band caps); discovery notes list the ~10 dispatching skills (`code-review`, `architectural-analysis`, `investigate` in han-coding; `plan-a-feature`, `plan-implementation`, `iterative-plan-review`, `plan-work-items` in han-planning; `research`, `gap-analysis` in han-research; `han-feedback`; `investigate-to-confluence`)
+- **Finding:** Each dispatching skill's roster table is shaped differently — `research`'s table has an "Angle / Add when / Min band" structure with size-band agent counts (`research/SKILL.md:143-148`), while other skills likely use different column sets. D5 (`decision-log.md:98-130`) is one behavioral rule ("extra agents join the candidate pool under existing caps, compete under signal-based selection, duplicates collapse, unresolvable entries are skipped with a note") that must be restated once per skill because each skill's dispatch step has its own prose describing how its pool is assembled — there is no single shared "dispatch" module these skills all delegate to.
+- **Impact:** This is structural duplication that already exists in the roster/band-cap machinery (each dispatching skill hand-rolls its own roster logic) — D5 inherits that pre-existing duplication rather than creating new duplication. A shared reference file for D5's rule text is a legitimate factoring candidate (same S3 vendoring treatment), but the actual pool-join *mechanics* (where in each skill's Step 4/5 the extra agents get spliced into the table) must be hand-edited per skill because the roster shapes differ. Do not attempt to unify the ~10 roster tables into one shared format as part of this feature — that is unrelated, larger surgery with no evidence behind it (YAGNI candidate; reopening trigger: a future feature that needs one canonical roster-table format across dispatching skills).
+
+**S7: D10's CLAUDE.md pointer offer fits as a new step in `project-discovery/SKILL.md` between the existing write step and verification, reusing its existing consent/dedup pattern**
+
+- **Dimension:** Boundaries
+- **File(s):** `han-core/skills/project-discovery/SKILL.md:72-97` (Step 4: write, with dedup/contradiction-consent logic), `:99-106` (Step 5: verification)
+- **Finding:** `project-discovery/SKILL.md` already has the exact shape D10 needs: Step 1 builds a dedup baseline against the target file's existing content; Step 4 writes/replaces a section with dedup applied and uses `AskUserQuestion` for a contradiction the user must resolve (`:84-86`). D10's pointer offer ("offer to add a one-line pointer... never add a second pointer when any reference is already present... offer to remove a stale pointer") is the same shape: check for the file's presence (new probe: `.han/config.md`), check for an existing pointer/reference in the target file (extension of the Step 1 dedup baseline), and use the same `AskUserQuestion`-gated consent already established in Step 4.
+- **Impact:** The natural insertion point is a new step after Step 4 (write discovery) and before Step 5 (verification) — call it "Step 4.5" or renumber — rather than folding pointer logic into Step 4 itself, since the pointer's target section (beside `## Project Discovery`, not inside it) and its independent presence/absence lifecycle (file can exist without the section ever having been written, and vice versa) make it a distinct concern from the Project Discovery section's own dedup. No new skill or reference file is needed for this; it is prose added directly to `project-discovery/SKILL.md`'s existing step sequence, which the YAGNI evidence test supports (D10, a named decision, is the only evidence needed — no separate abstraction is justified).
+
+**S8: T1 contradiction check — none found; T1's committed mechanics are consistent with the repo's actual probe and reference-file precedents**
+
+- **Dimension:** Dependency Direction
+- **File(s):** T1 (`feature-technical-notes.md:11-13`)
+- **Finding:** T1's inline `!`-probe commitment matches the actual mechanism in `han-coding/skills/code-review/SKILL.md:16-20` exactly (verified directly, not just cited by T1). No divergence found between T1's stated mechanics and what the codebase does.
+- **Impact:** None — noted as a negative result. T1 is safe to treat as committed without renegotiation.
+
+**Structural summary:** Key concerns: (1) D4's universal participation vs the zero-dependency design of han-feedback / han-linear / han-plugin-builder — decides whether the plan touches 3 plugin.json files or stays in vendored .md files (recommend vendoring). (2) Canonical-vs-vendored scales the yagni-rule drift pattern from 5 to 12 copies with no sync tooling — keep the vendored file short and mechanical rather than adding sync machinery. (3) The 15 no-block skills get a minimal config-only block. Well-structured: the probe/fallback convention is proven at scale; project-discovery's consent/dedup shape fits D10 with no new abstraction.
+
+---
+
+## junior-developer (verbatim)
+
+### Confirmed counts (enumerate at execution, do not hardcode)
+
+Grep matches the discovery notes, not the decision log: **24 skills with a `## Project Context` block, 15 without, 39 total**. `D4` in `decision-log.md` still says "26 with … 15 without." Per repo convention (CLAUDE.md "indexes stay complete, not counted"), the plan should enumerate participating skills by globbing `*/skills/*/SKILL.md` at execution time and never inherit the stale 26. The 15 "without" set is confirmed: all 6 han-atlassian, han-coding/manual-test-planning, both han-communication, han-github/work-items-to-issues, han-linear/work-items-to-linear, all 3 han-plugin-builder, han-reporting/html-summary.
+
+### JD-001 — "Every skill participates" collides with the plugin dependency graph. Where can shared config-resolution guidance live? (Blocks decision)
+
+- **Evidence:** `D4` mandates all skills read the file. `T1` only specifies the *read* (`cat .han/config.md 2>/dev/null` via the inline probe) — it is silent on where the *interpretation* prose lives (degradation table D9, precedence chain D6, containment D14). CLAUDE.md project map states han-communication "depends on nothing," han-linear "depends on no other Han plugin," and han-plugin-builder "depends on nothing." No shared context/config reference file exists today.
+- **The problem:** The config read is one line, but the *behavior* behind it is multi-paragraph and must be applied identically by every participating skill. Two hosting patterns exist as precedent: canonical-in-han-core + vendored copies (yagni-rule.md), and canonical-in-han-communication sourced cross-plugin via a skill (readability-rule.md). **But no single plugin can host guidance that all 39 skills reference by dependency:** han-communication, han-linear, and the 3 han-plugin-builder skills sit on plugins that depend on nothing.
+- **Recommendation:** Keep the inline probe line in each file (matches T1), and put the *degradation/precedence/containment* prose in **one canonical reference**, hosted by whichever is cheaper — vendoring copies (yagni-rule precedent) avoids the dependency-graph change entirely and is the lower-risk option for the five dependency-free skills. A single canonical reference passes the evidence test: named dependency = D9+D6+D14 behavior that must be byte-identical across files, and the simpler-version (pure inline duplication) demonstrably falls short against documented SKILL.md churn.
+- **Specialist to consult:** system-architect (cross-plugin dependency topology). [Not needed — resolved by convergent R1 evidence.]
+
+### JD-002 — The extra-agents edit is not a uniform block; each dispatching skill has a bespoke roster structure
+
+- **Evidence:** `research/SKILL.md:137-159` structures dispatch as "synthesis spine + signal-selected angle table + caps-by-band"; `code-review/SKILL.md` handles agents at Step 7 with a 30-item finding cap; `plan-implementation` uses a Step 3 roster.
+- **The problem:** Unlike the config *read* (a uniform probe line), the extra-agents *join* has no shared shape to paste. Each of the ~11 dispatching skills expresses its roster differently, so the edit is a bespoke insertion into each unique structure. The plan should treat these as a separate, non-uniform work pass, not fold them into the "add a probe block" pass. If the plan estimates the extra-agents work as "add one line to N files," it will under-scope.
+
+### JD-003 — Wrapper skills (han-atlassian) that invoke other skills share a working directory: the output-directory base relocates the wrapped skill's "temporary" file
+
+- **Evidence:** `investigate-to-confluence/SKILL.md:22-23,55` invokes `han-coding:investigate` via the Skill tool "to a temporary file," then publishes to Confluence. D15 pins discovery to the working directory; a wrapper and its wrapped skill run in the same directory, so both read the same `.han/config.md`. Spec Primary Flow step 6 says a skill that produces no markdown output ignores the output directory.
+- **The problem:** The wrapper produces no local markdown deliverable, so it ignores the output base — fine. But the *wrapped* `investigate` skill *does* write markdown and, once it participates (D4), will honor the base directory, relocating the "temporary" file the wrapper expects. All 6 han-atlassian skills are wrappers, and all 6 are in the "gaining a block" set. The person editing must decide whether wrapper temp-file handoffs honor the base or bypass it.
+
+### JD-004 — "Outside the project" (D14 containment) has no operational definition a model can apply from prompt text
+
+- **Evidence:** D14 refuses an output base that "points outside the project" and resolves "relative to the project root the skill runs in." D15 deliberately pins discovery to "the directory it runs in" with no repo-root walk, and F4 records that "project root was never defined behaviorally." code-review even has a git-absent Mode C (`code-review/SKILL.md:93-94`), so a git-derived root isn't guaranteed.
+- **The problem:** The containment guard needs a concrete, model-followable rule. The plan owes a concrete test — e.g., "reject absolute paths and any value containing `..`; resolve the value relative to the current working directory." That is expressible and closes the gap without a repo-root concept.
+
+### JD-005 — T1 leaves the config schema's concrete tokens open; the plan must close them
+
+- **Evidence:** `T1` commits the "frontmatter-plus-named-sections split" but states "Exact key names, section headings, and agent-name matching rules are finalized during implementation planning." F8: "Exact name-matching rules are implementation detail left to plan-implementation."
+- **The problem:** The plan must close: (1) the frontmatter key for the output base, (2) the exact heading of the extra-agents section, (3) agent-name matching — bare name vs qualified `plugin:agent`, case sensitivity. The roster tables use fully-qualified names like `han-research:research-analyst` (`research/SKILL.md:141`), so the matching rule should accept qualified names; the plan should state it once so all skills match identically. These tokens must be fixed once and reused verbatim.
+
+### JD-006 — Verification approach for a 39-file, no-harness edit is unspecified
+
+- **Recommendation (YAGNI-checked):** A cheap grep-based structural check — every participating `SKILL.md` contains the `.han/config.md` probe line and the pointer to the canonical resolution guidance — plus a manual spot-run of one representative skill per category (a deliverable-writer, a dispatcher, a wrapper, a no-op-config skill). **Not** recommending: any new CI, runner, or fixture project — that fails the evidence test today (reopen trigger: a regression from config drift is actually observed).
+
+### JD-007 — OI-1 is a gating pre-step the sequencing must honor as step 0
+
+- **Evidence:** Spec Open Items OI-1: the live-install check "must run during implementation planning, before the implementation plan is approved," and "a negative result … reopens the feature's foundational decision (D1)."
+- **Why it matters:** The plan must schedule OI-1 as its first activity and gate approval on it. [Resolved: the check ran during R1; claim held; D1 stands.]
+
+### JD-008 — The one-line-note rule (D9) is a subtle model-judgment boundary; state it once, canonically
+
+- **Evidence:** D9 / spec Edge Cases: a note appears "only when content that attempts a recognized override cannot be used," silent for "prose the suite has no use for," recurring per run. F6 records this boundary was "fuzzy" and needed a crisp rule.
+- **The problem:** "Attempted-recognized-override vs mere-prose" is a discrimination each participating skill must make identically. Restating it in ~24-39 files invites the exact drift F6 fixed once. This is the strongest argument for the single canonical resolution reference: the note rule and the edge-case table should be stated once and referenced, not paraphrased per skill.
+
+**T# contradiction check:** No contradiction with `T1`.
+
+### Sequencing recommendation (YAGNI-checked)
+
+1. **OI-1 live-install check** (gating) — before anything else. [Done.]
+2. **Fix the schema + canonical resolution guidance** in one place — one file lands the tokens, the precedence chain, the degradation table, the note rule.
+3. **Extend the 24 skills that already have `## Project Context`** — add the probe line + pointer to the canonical guidance.
+4. **Add a block to the 15 skills without one** — watch the dependency-free skills.
+5. **Separate pass for the ~11 dispatching skills** — bespoke roster insertions.
+6. **project-discovery pointer offer + stale-cleanup (D10) and docs surfaces** last.
+7. **Grep-based completeness check + representative spot-runs.**
+
+Reopen trigger for adding tooling: an observed config-drift regression after landing.
+
+---
+
+## information-architect (verbatim)
+
+### IA-001 — The canonical operator doc for `.han/config.md` must be created, and it belongs at repo-root `docs/`
+
+- **Evidence:** No config doc exists anywhere in the tree. The four cross-suite mechanics each have a repo-root doc (`docs/sizing.md`, `docs/yagni.md`, `docs/evidence.md`, `docs/readability.md`), each introduced in `docs/concepts.md:126-201` and its "Where to go next" list (`docs/concepts.md:261-271`). `.han/config.md` is not a skill, agent, or plugin, so it does not fit the `{plugin}/docs/skills/*.md` or plugin-README canonical slots; the repo-root `docs/` concept-doc slot is its structural match. Because Han cannot seed the file (`feature-specification.md:133-135`), an engineer with no canonical doc has no correct source to author from and will guess the frontmatter key — landing in D9's silent-degradation path.
+- **Severity:** Blocks comprehension.
+- **Recommendation:** Add one deliverable: a new repo-root operator concept doc (proposed `docs/configuration.md`) as the *single canonical* home. It must contain: what the file is and who writes it; the two v1 overrides (D7); the precedence chain in plain terms (D6); the degradation contract (D9); the working-directory / monorepo rule (D15); and **the one annotated schema example**. Sequence it *after* the plan finalizes T1's key names — the example cannot be authored before the schema is pinned.
+
+### IA-002 — The schema example must appear once (canonical), not be scattered across skill docs or READMEs
+
+- **Evidence:** T1 fixes the shape but leaves key names open, so any copy duplicated across 39 skills will drift. The repo already enforces single-source for its shared rules. D4 makes all ~39 skills participants, which is 39 opportunities for a pasted example to fall out of sync.
+- **Recommendation:** Put the full annotated example only in `docs/configuration.md`. Every other surface that mentions the file carries a one-sentence scent plus a link — never a second copy. State this as an explicit plan constraint.
+
+### IA-003 — The skill-side config-resolution contract needs one named canonical home; the plan must choose it and forbid 39 inline restatements
+
+- **Evidence:** The read mechanism is necessarily inline per skill. But the *contract* — precedence (D6), degradation and the one-line-note rule (D9), agent-name matching / working-directory rule (D15) — is shared across every participating skill.
+- **Recommendation:** Name one canonical config-resolution reference (the `han-core/references/` + vendored-copies precedent is the closest fit). Skills' inline probe blocks carry only the probe line; the precedence, degradation, and matching rules live in the referenced file. Do not restate them inline in each skill.
+
+### IA-004 — `docs/concepts.md` must gain a scent entry for the config convention
+
+- **Evidence:** `concepts.md` is the repo's stated orientation page (`docs/concepts.md:1-4`), enumerating every cross-suite behavior. A behavior every skill honors on every run that is *absent* from this page is invisible to anyone orienting through it.
+- **Recommendation:** Add a short "Configuration" subsection (parallel to, but lighter than, the four mechanic sections) plus one "Where to go next" link. Scent + link only — concepts.md must not restate the schema. Minimal viable version: a single "Where to go next" bullet is the floor; do not ship with zero mention.
+
+### IA-005 — `han-core/docs/skills/project-discovery.md` is now incomplete: it omits the D10 config pointer behavior
+
+- **Evidence:** D10 adds real behavior to project-discovery. The long-form doc describes project-discovery as writing *only* the `## Project Discovery` section ("Key concepts" `project-discovery.md:21-36`, the 3-step and 5-step process `:62-68`, `:107-118`, "What you get back" `:76-84`) — no config pointer.
+- **Recommendation:** Include as explicit deliverables: (1) `han-core/skills/project-discovery/SKILL.md` (the pointer offer/removal — committed by D10) and (2) its long-form doc, adding the pointer behavior to "Key concepts," the process steps, and "What you get back." Cross-link to `docs/configuration.md`. This is the one skill whose *documented behavior* materially changes; not covered by IA-006's YAGNI cut.
+
+### IA-006 — Do NOT touch all ~39 participating skill long-form docs (YAGNI candidate)
+
+- **Evidence:** The four existing cross-suite mechanics set the precedent: per-skill docs do *not* each re-document the mechanic — they rely on the canonical `docs/*.md`. No named audience task requires the same sentence in 39 places.
+- **Category: YAGNI candidate** for any blanket "add a config note to every skill doc" plan step. **Reopen trigger:** a specific skill whose config interaction is genuinely non-obvious. Recommendation: touch skill docs only where an existing "reads project context" statement already appears and would now be wrong without a link; enumerate those at execution time.
+
+### IA-007 — `docs/quickstart.md` Path D is the natural insertion point for a config pointer, but only a scent link
+
+- **Evidence:** Path D "Set up a project for everything else" (`docs/quickstart.md:113-129`) is the project-setup path and already lists `/project-discovery` as step 1.
+- **Recommendation:** Add one bullet/pointer in Path D linking to `docs/configuration.md`. No full authoring walkthrough. Track-and-improve, not must-block.
+
+### IA-008 — Register the new convention in the repo `CLAUDE.md` map
+
+- **Evidence:** `CLAUDE.md` enumerates the `docs/` tree and states doc conventions. Contributors need to know `docs/configuration.md` is canonical for the config file and where the config-resolution contract lives.
+- **Recommendation:** Add `docs/configuration.md` to the `docs/` listing in `CLAUDE.md` and a one-line Conventions note naming the canonical home of the config-resolution contract. Minimal edit; keep counts out.
+
+### IA-009 — Explicit YAGNI cuts: surfaces that do NOT need updating
+
+- **`docs/choosing-a-han-plugin.md`** — the config file is not a plugin and does not change any install choice. YAGNI candidate. Reopen when: the config becomes plugin-scoped or install-gated.
+- **`docs/workflows.md`** — the config adds no chain step. YAGNI candidate. Reopen when: a workflow's documented output path becomes wrong in a way that misleads a chain reader.
+- **The four mechanic docs** — orthogonal; no change.
+- **README table** — a mention is defensible as a scent link but not required; track, do not block.
+
+### Sequencing and contingency notes
+
+- Doc example is downstream of schema finalization: finalize T1 schema → author the single canonical example → add scent links.
+- All doc artifacts assume `.han/config.md` per D1, contingent on OI-1 — gate doc deliverables behind OI-1's resolution. [OI-1 resolved: D1 stands.]
+- No T# contradictions found.
+
+### Priority
+
+- **Must-fix-now:** IA-001, IA-002, IA-003, IA-005.
+- **Track-and-improve:** IA-004, IA-007, IA-008.
+- **Prevents over-work:** IA-006, IA-009.
+
+---
+
+## OI-1 live check (Claude Code documentation agent, condensed verbatim)
+
+Verdict on the claim "a plugin cannot ship or seed a project-scoped, version-controlled, per-repo configuration; plugin-root CLAUDE.md is not loaded as project context; plugin user-configuration is user-scoped only":
+
+- **Plugin-root CLAUDE.md not loaded as project context: CONFIRMED.** Official docs (code.claude.com/docs/en/plugins-reference): "A CLAUDE.md file at the plugin root is not loaded as project context. Plugins contribute context through skills, agents, and hooks rather than CLAUDE.md."
+- **Plugin user-configuration is user-scoped: CONFIRMED.** Docs (v2.1.207+): "entries in a project's `.claude/settings.json` or `.claude/settings.local.json` are ignored" for user-configuration. A plugin's own `settings.json` supports only the `agent` and `subagentStatusLine` keys and is not seeded into consuming repos. Local inspection corroborated: Han's plugin enablement and settings live at user scope (`~/.claude-testdouble/settings.json`); the Han repo's `.claude/` has no settings.json.
+- **One nuance:** a plugin can be *installed at project scope* (`--scope project` writes `enabledPlugins` to the repo's `.claude/settings.json`). This governs plugin *activation* per-repo, not delivery of per-repo override *values* — it gives Han no way to ship or seed an output-directory or extra-agents value.
+
+**Disposition for this plan:** the load-bearing constraint behind D1 holds. The consuming project must carry the configuration; `.han/config.md` stands. OI-1 is closed as confirmed during implementation planning, before plan approval, as the spec required.

--- a/docs/plans/han-project-config/artifacts/decision-log.md
+++ b/docs/plans/han-project-config/artifacts/decision-log.md
@@ -3,7 +3,7 @@
 ## Trivial decisions
 
 - D11: Absent or empty config file means today's behavior — a project without `.han/config.md` sees no change and no
-  note. — Referenced in spec: Outcome; Alternate Flows and States.
+  note. — Referenced in spec: Outcome; Alternate Flows and States; Edge Cases and Failure Modes.
 - D12: Settings that do not apply to the running skill are ignored without comment (considered a per-skill "setting not
   used here" note; rejected because it would add noise to every run in a configured project). — Referenced in spec:
   Primary Flow.
@@ -12,17 +12,18 @@
 
 ## Full decisions
 
-### D1: One dedicated markdown file at the project root
+### D1: One dedicated markdown file carried by the consuming project
 
 - **Question:** Where does a consuming project's Han configuration live?
-- **Decision:** In a single dedicated file, `.han/config.md`, at the consuming project's root. The project creates and
-  owns it; Han cannot ship or seed it from the plugin side.
+- **Decision:** In a single dedicated file, `.han/config.md` — one file inside a `.han/` folder at the project root.
+  The project creates and owns it; Han cannot ship or seed it from the plugin side.
 - **Rationale:** A dedicated file gives Han full ownership of the schema and keeps the override surface out of the
   team's shared narrative files. The plugin cannot carry it: a CLAUDE.md at a plugin's root is not loaded as project
   context, and the plugin manifest's user-configuration mechanism is user-scoped only, so neither can deliver a
   per-repo, version-controlled override.
 - **Evidence:** Research report `docs/research/han-config-extensibility.md` (provided; recommendation O1). The
-  cannot-ship constraint is research source A13 (web, single-source, flagged for an empirical check — see spec OI-1).
+  cannot-ship constraint is research source A13 (web, single-source, flagged for an empirical check — see spec OI-1,
+  sharpened by F13: a negative check result reopens this decision).
 - **Rejected alternatives:**
   - A `.claude/rules/han.md` rules file (research O2) — rejected because rules content is ambient guidance with a
     documented soft-compliance ceiling, occupies context in every session, and no skill can verify it loaded.
@@ -32,9 +33,9 @@
   - JSON configuration (research O4) — rejected because the overrides are mostly content a model interprets, and the
     surveyed evidence shows JSON degrading into prose stuffed inside strings for that use; see D2.
 - **Linked technical notes:** T1
-- **Driven by findings:** —
-- **Dependent decisions:** D2, D3, D8, D10
-- **Referenced in spec:** Primary Flow; Coordinations; Out of Scope.
+- **Driven by findings:** F13, F14
+- **Dependent decisions:** D2, D3, D8, D10, D15
+- **Referenced in spec:** Primary Flow; Coordinations; Out of Scope; Open Items.
 
 ### D2: Markdown with a structured header block, not JSON
 
@@ -69,7 +70,7 @@
     verify the content loaded (research A2, A15).
 - **Linked technical notes:** —
 - **Driven by findings:** —
-- **Dependent decisions:** D4, D6
+- **Dependent decisions:** D4, D6, D15
 - **Referenced in spec:** Actors and Triggers; Primary Flow; Coordinations.
 
 ### D4: Every Han skill participates
@@ -80,15 +81,17 @@
   of this feature.
 - **Rationale:** User chose full coverage over the research's narrower proposal. Uniform participation means an
   engineer never has to remember which skills honor the config; combined with D12 (inapplicable settings silently
-  ignored), full coverage costs nothing in noise.
+  ignored), full coverage costs nothing in noise. The review team challenged this as a YAGNI candidate (F10),
+  recommending the research's narrower 26-skill scope; the decision stands on the user's explicit choice, made with
+  that trade-off presented.
 - **Evidence:** User input, overriding the research report's V2 scoping proposal.
 - **Rejected alternatives:**
-  - Only the 26 skills that already resolve project context (the research's recommendation) — rejected by the user in
-    favor of a uniform contract.
+  - Only the 26 skills that already resolve project context (the research's recommendation, re-raised by F10) —
+    rejected by the user in favor of a uniform contract.
   - A pilot subset of agent-dispatching skills — rejected by the user; partial coverage makes the feature harder to
     explain and trust.
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F10
 - **Dependent decisions:** D12
 - **Referenced in spec:** Primary Flow.
 
@@ -96,12 +99,20 @@
 
 - **Question:** How do project-supplied extra agents interact with a skill's hardcoded roster, signal-based selection,
   and size-band caps?
-- **Decision:** Config-named agents join the candidate pool and compete under the same signal-based selection and the
-  same size-band caps as the skill's own roster. A name that does not resolve to an agent available in the session is
-  skipped with a one-line note, and dispatch proceeds.
+- **Decision:** The configuration carries one global list of extra agents. For any dispatching skill, those agents join
+  the candidate pool and compete under the same signal-based selection and the same size-band caps as the skill's own
+  roster — which means a selected extra agent can displace a default specialist, silently and by design. An entry that
+  duplicates an agent already in the pool has no effect (one candidate, counted once). An entry that does not resolve
+  to a dispatchable agent — a misspelling, a skill name, the running skill itself — is skipped with a one-line note,
+  and dispatch proceeds.
 - **Rationale:** Joining the pool covers the stated need (project-defined agents get considered) without changing any
-  skill's selection logic or cost profile. Roster validation keeps a typo or stale name from silently breaking
-  dispatch.
+  skill's selection logic or cost profile. A global list is the strictly simpler version of per-skill grouping:
+  signal-based selection already filters agents irrelevant to a skill's domain, so grouping is deferred until a real
+  mis-selection is reported. Validation is against session availability rather than each skill's own roster — the
+  stricter per-roster reading of the research's wording would make project agents impossible by definition, since they
+  are never on a built-in roster; the looser reading is the one that serves the feature's purpose, and signal selection
+  plus caps supply the discipline the research's validation asked for. Displacement under the cap is the accepted
+  meaning of "compete": the user chose capped competition over cap-exempt addition.
 - **Evidence:** User input. Roster mechanics: codebase, research A20 (`plan-implementation`, `code-review`, `research`
   SKILL.md roster tables). Validation requirement: research validation finding V9.
 - **Rejected alternatives:**
@@ -109,35 +120,44 @@
     project-supplied agents.
   - Extra agents exempt from caps, always dispatched — rejected because it changes every configured run's cost and
     undermines the size-band discipline.
-- **Linked technical notes:** —
-- **Driven by findings:** —
+  - Per-skill grouping of extra agents (raised by T1's first draft and F2) — deferred as the larger version; see the
+    spec's Deferred section.
+  - Validating entries against each skill's own hardcoded roster (the strict reading of V9) — rejected because project
+    agents are by definition not on any built-in roster; session-availability is the check that can actually pass.
+- **Linked technical notes:** T1
+- **Driven by findings:** F2, F3, F8, F16
 - **Dependent decisions:** —
 - **Referenced in spec:** Outcome; Primary Flow; Edge Cases and Failure Modes; Out of Scope.
 
 ### D6: Precedence: explicit input, config file, discovery sources, defaults
 
 - **Question:** When sources disagree, which value wins?
-- **Decision:** Explicit user input first, then `.han/config.md`, then CLAUDE.md's `## Project Discovery` section, then
-  `project-discovery.md`, then the skill's built-in defaults. Conflicts resolve silently in that order.
+- **Decision:** For single-value settings: explicit user input first, then `.han/config.md`, then CLAUDE.md's
+  `## Project Discovery` section, then `project-discovery.md`, then the skill's built-in defaults. Conflicts resolve
+  silently in that order. For the list-shaped extra-agents setting, precedence works by addition: agents the user names
+  explicitly are always considered, and the configuration's entries join them as candidates rather than being replaced
+  by them.
 - **Rationale:** A dedicated configuration file the engineer wrote on purpose should beat generic discovery output. The
   known trade-off — a value visible in CLAUDE.md silently outranked by a file the team may forget — is mitigated by the
-  CLAUDE.md pointer (D10). The research labels this order a design proposal to validate in use, not a derived fact.
+  CLAUDE.md pointer (D10) and tracked for post-ship validation (OI-2). Replacement semantics make no sense for a list
+  whose whole purpose is adding candidates, so the chain applies as written only to single values (F12). The research
+  labels this order a design proposal to validate in use, not a derived fact.
 - **Evidence:** User input, accepting the research report's proposed order (flagged as a design proposal in validation
-  finding V4).
+  finding V4). Explicit-naming-always-considered matches the suite's existing dispatch convention (research A20).
 - **Rejected alternatives:**
   - CLAUDE.md outranks the config file — rejected because it makes the dedicated config unable to override the very
     sources it exists to override.
   - Surfacing every conflict to the user instead of resolving it — rejected because it turns a routine resolution step
     into a recurring interruption.
 - **Linked technical notes:** —
-- **Driven by findings:** —
-- **Dependent decisions:** D10
-- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes.
+- **Driven by findings:** F11, F12
+- **Dependent decisions:** D10, D14
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes; Open Items.
 
 ### D7: v1 override set: output directory and extra agents only
 
 - **Question:** Which overrides does the file support at launch?
-- **Decision:** Exactly two: the output directory for skill-written markdown deliverables, and the extra agents for
+- **Decision:** Exactly two: the base directory for skill-written markdown deliverables, and the extra agents for
   dispatching skills to consider.
 - **Rationale:** These are the two user-described needs the research was commissioned against. Every additional
   override class fails the YAGNI evidence test today; the file format (D2) leaves room to add more when evidence
@@ -148,53 +168,66 @@
     reopening trigger (see the spec's Deferred section).
 - **Linked technical notes:** T1
 - **Driven by findings:** —
-- **Dependent decisions:** —
+- **Dependent decisions:** D14
 - **Referenced in spec:** Outcome.
 
 ### D8: One file in v1, not a folder
 
-- **Question:** Is the configuration one file or a `.han/` folder of per-concern files?
-- **Decision:** One file, `.han/config.md`, in v1.
-- **Rationale:** A deliberate simplification to avoid speculative structure, not a claim that one file is superior on
-  the merits. The research names the migration cost of splitting later and accepts it; the reopening trigger is
-  recorded in the spec's Deferred section.
-- **Evidence:** Research report recommendation and validation finding V8 (which reframed the single file as a v1
-  simplification after noting a folder would mirror Han's per-artifact probe convention more closely).
+- **Question:** Is the configuration one file, or several per-concern files inside `.han/`?
+- **Decision:** One file, `.han/config.md`, in v1. The `.han/` folder exists only to hold it; "not a folder" means no
+  additional per-concern files inside that folder.
+- **Rationale:** A deliberate simplification to avoid speculative structure — explicitly not a claim that one file is
+  superior on the merits, since the research noted a folder would mirror Han's own per-artifact probe convention more
+  closely. Splitting later carries a named migration cost: existing projects' config files would need to be split and
+  moved. The reopening trigger is recorded in the spec's Deferred section.
+- **Evidence:** Research report recommendation and validation finding V8.
 - **Rejected alternatives:**
-  - A folder of per-concern files — rejected for v1 because there are only two override classes to hold; deferred, not
-    discarded.
+  - Several per-concern files inside `.han/` — rejected for v1 because there are only two override classes to hold;
+    deferred, not discarded.
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F14, F15
 - **Dependent decisions:** —
 - **Referenced in spec:** Deferred (YAGNI).
 
 ### D9: Graceful degradation: a bad config can never break a skill
 
-- **Question:** What happens when the file is malformed, names unknown settings, or lists agents that do not exist?
-- **Decision:** A configuration problem can never fail a skill run. Unusable content is ignored, the affected settings
-  fall through to the rest of the precedence chain, and the user sees a one-line note naming what was ignored.
-  Content that applies cleanly produces no note at all.
-- **Rationale:** The config is an optional convenience; letting it block work would make it a liability. The one-line
-  note keeps degradation visible without turning it into an interruption.
+- **Question:** What happens when the file is malformed, names unknown settings, carries unusable values, or lists
+  agents that do not exist?
+- **Decision:** A configuration problem can never fail a skill run. Unusable content — a malformed header, an
+  unrecognized setting name, a blank or unusable value, a non-text file — is ignored, the affected settings fall
+  through to the rest of the precedence chain, and the user sees a one-line note naming what was ignored. The note
+  appears only when content that attempts a recognized override cannot be used; prose the suite has no use for is
+  passed over silently, with no note. The note recurs on each run where the problem is present.
+- **Rationale:** The config is an optional convenience; letting it block work would make it a liability. The
+  attempted-override rule gives a crisp boundary between "broken config the user should fix" (note) and "extra prose"
+  (silence). A per-run note is bounded at one line; suppressing repeats would require skills to carry state across
+  runs, which is new machinery the simpler version does not need.
 - **Evidence:** Research validation finding V9, which required explicit failure-mode handling before recommending the
   design.
 - **Rejected alternatives:**
   - Failing fast on a malformed file — rejected because a typo in an optional file should never stop a review or a
     plan.
   - Silent ignoring with no note — rejected because the user would have no way to notice a broken override.
+  - Showing the note once per session instead of per run — rejected because skills hold no cross-run state; the
+    one-line cost is accepted (F17).
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F5, F6, F17
 - **Dependent decisions:** —
 - **Referenced in spec:** Edge Cases and Failure Modes; User Interactions.
 
 ### D10: project-discovery offers a CLAUDE.md pointer
 
-- **Question:** How does a contributor who has never heard of `.han/config.md` find out it exists and is in effect?
+- **Question:** How does a contributor who has never heard of `.han/config.md` find out it exists and is in effect —
+  and what happens to that pointer when the file goes away?
 - **Decision:** The project-discovery skill, when run in a project that has the file, offers to write a one-line
-  pointer to it into the project's CLAUDE.md, beside the Project Discovery section it already maintains. The pointer is
-  written only with user consent and never duplicated.
+  pointer to it into the project's CLAUDE.md, beside the Project Discovery section it already maintains. It never adds
+  a second pointer when any reference to the file is already present, however the contributor has edited it. When the
+  file is gone but a pointer remains, the skill offers to remove the stale pointer. Both the write and the removal
+  happen only with user consent.
 - **Rationale:** Nothing in Claude Code surfaces a `.han/` folder on its own; the pointer puts the file in the document
-  every contributor already reads, and directly mitigates D6's visibility trade-off.
+  every contributor already reads, and directly mitigates D6's visibility trade-off. A dangling pointer would mislead
+  every reader of CLAUDE.md indefinitely, so the pointer needs a removal path with the same consent rule as its
+  creation.
 - **Evidence:** Research validation finding V3, which found Han's own precedent (project-discovery writes into
   auto-loaded files precisely because they are auto-loaded) and elevated the pointer to part of the recommendation.
   Codebase: `han-core/skills/project-discovery/SKILL.md` (research A21).
@@ -202,6 +235,59 @@
   - No discoverability aid — rejected because a Han-invented convention has zero native discoverability and would
     silently outrank visible CLAUDE.md values (D6).
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F7
 - **Dependent decisions:** —
-- **Referenced in spec:** Actors and Triggers; Alternate Flows and States; Edge Cases and Failure Modes.
+- **Referenced in spec:** Actors and Triggers; Alternate Flows and States; Edge Cases and Failure Modes; Coordinations.
+
+### D14: The output directory is a base; skills keep their structure beneath it
+
+- **Question:** When the config sets an output directory, does it flatten every skill's output into one folder, or
+  redirect a base under which each skill keeps its own structure? And what bounds the value?
+- **Decision:** The value is a base directory, resolved relative to the project root the skill runs in. Skills keep
+  their own folder and file structure beneath it — a planning skill still writes its plan folder with an artifacts
+  subfolder, only rooted under the configured base. The skill creates the directory on first write if it does not
+  exist. A value that points outside the project, or that cannot be written, is refused with a one-line note and the
+  skill falls back to its default output location; deliverables are never written outside the project.
+- **Rationale:** The originating need was "write all markdown outputs to `.scratch/`" — a base to redirect, not a
+  request to flatten structured multi-file deliverables into one directory, which would make skills like plan-a-feature
+  collide with themselves. Auto-creation follows from D9's never-block rule: an absent directory is the normal state on
+  first configured run, and refusing to write would turn the convenience into a failure. Containment inside the
+  project is a data-integrity guard against accidents (an absolute path pasted from another machine, a stray leading
+  slash), not a security boundary.
+- **Evidence:** User-described need in the research report's framing question ("write all markdown outputs to
+  `.scratch/`"); existing structured outputs across the suite (research A19: per-skill output paths, including
+  multi-file plan folders); D9 (never-block rule).
+- **Rejected alternatives:**
+  - One flat directory receiving every deliverable — rejected because multi-file deliverables would collide and
+    per-skill organization would be lost.
+  - Honoring paths outside the project — rejected because a mistaken config could silently scatter or overwrite files
+    elsewhere on the machine.
+  - Failing the run on an unwritable path — rejected under D9; degradation to the default location keeps work moving.
+- **Linked technical notes:** T1
+- **Driven by findings:** F1, F5
+- **Dependent decisions:** —
+- **Referenced in spec:** Outcome; Primary Flow; Edge Cases and Failure Modes; Out of Scope.
+
+### D15: The config is discovered from the skill's working directory
+
+- **Question:** Where does a skill look for `.han/config.md` — the current working directory, a walk up to a repository
+  root, or somewhere else? And what does that mean in a monorepo?
+- **Decision:** The skill looks for `.han/config.md` relative to the directory it runs in — the same place it already
+  looks for CLAUDE.md and the discovery file. In a monorepo, each package can carry its own config, and a skill run
+  from a package directory sees that package's file. A skill run from a directory with no config behaves as if the
+  file were absent, even when one exists elsewhere in the repository.
+- **Rationale:** This matches how every existing project-context source in the suite is resolved, so the config is
+  found exactly where the rest of a skill's context is found — one rule for engineers to learn, and no new search
+  behavior to specify or maintain. The limitation (a nested working directory does not see a repo-root config) is the
+  same limitation the suite's existing context sources already have, and it is stated in the spec's edge cases rather
+  than papered over.
+- **Evidence:** Codebase — the existing probe convention resolves from the working directory
+  (`han-coding/skills/code-review/SKILL.md:19`, corroborated across the suite per research A18, A23).
+- **Rejected alternatives:**
+  - Walking up parent directories to a repository root — rejected because it invents a search behavior no other Han
+    context source has, and silently answers the monorepo shared-config question the suite has no evidence to answer
+    yet.
+- **Linked technical notes:** T1
+- **Driven by findings:** F4
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; Alternate Flows and States; Edge Cases and Failure Modes.

--- a/docs/plans/han-project-config/artifacts/decision-log.md
+++ b/docs/plans/han-project-config/artifacts/decision-log.md
@@ -1,0 +1,207 @@
+# Decision Log: Project-Local Han Configuration
+
+## Trivial decisions
+
+- D11: Absent or empty config file means today's behavior — a project without `.han/config.md` sees no change and no
+  note. — Referenced in spec: Outcome; Alternate Flows and States.
+- D12: Settings that do not apply to the running skill are ignored without comment (considered a per-skill "setting not
+  used here" note; rejected because it would add noise to every run in a configured project). — Referenced in spec:
+  Primary Flow.
+- D13: The config file is a normal version-controlled file in the consuming project's repository. — Referenced in spec:
+  User Interactions.
+
+## Full decisions
+
+### D1: One dedicated markdown file at the project root
+
+- **Question:** Where does a consuming project's Han configuration live?
+- **Decision:** In a single dedicated file, `.han/config.md`, at the consuming project's root. The project creates and
+  owns it; Han cannot ship or seed it from the plugin side.
+- **Rationale:** A dedicated file gives Han full ownership of the schema and keeps the override surface out of the
+  team's shared narrative files. The plugin cannot carry it: a CLAUDE.md at a plugin's root is not loaded as project
+  context, and the plugin manifest's user-configuration mechanism is user-scoped only, so neither can deliver a
+  per-repo, version-controlled override.
+- **Evidence:** Research report `docs/research/han-config-extensibility.md` (provided; recommendation O1). The
+  cannot-ship constraint is research source A13 (web, single-source, flagged for an empirical check — see spec OI-1).
+- **Rejected alternatives:**
+  - A `.claude/rules/han.md` rules file (research O2) — rejected because rules content is ambient guidance with a
+    documented soft-compliance ceiling, occupies context in every session, and no skill can verify it loaded.
+  - A `## Han Configuration` section in the project's CLAUDE.md (research O3) — rejected as the primary home because it
+    grows an always-loaded file Anthropic recommends keeping lean and invites merge friction in a shared narrative
+    file; retained as a complement via the pointer in D10.
+  - JSON configuration (research O4) — rejected because the overrides are mostly content a model interprets, and the
+    surveyed evidence shows JSON degrading into prose stuffed inside strings for that use; see D2.
+- **Linked technical notes:** T1
+- **Driven by findings:** —
+- **Dependent decisions:** D2, D3, D8, D10
+- **Referenced in spec:** Primary Flow; Coordinations; Out of Scope.
+
+### D2: Markdown with a structured header block, not JSON
+
+- **Question:** What format does the configuration file use?
+- **Decision:** Markdown. A small structured header block at the top carries the simple values (such as the output
+  directory); named markdown sections carry the list-shaped overrides (such as extra agents).
+- **Rationale:** Two independent vendors converged on exactly this hybrid shape for model-consumed configuration, and
+  every surveyed AI coding tool splits machine-enforced settings from model-interpreted instructions along this line.
+  The header block still gives the handful of simple values a structured, checkable home.
+- **Evidence:** Research sources A2 (Claude Code memory docs) and A3 (Cursor rules docs) — web, corroborating each
+  other; format-split pattern corroborated across A2, A5, A6, A7.
+- **Rejected alternatives:**
+  - Pure JSON (research O4) — rejected because open-ended, model-interpreted overrides degrade into prose inside
+    strings, and tolerance for custom keys in `settings.json` is unconfirmed (research A12).
+- **Linked technical notes:** T1
+- **Driven by findings:** —
+- **Dependent decisions:** D9
+- **Referenced in spec:** Primary Flow; User Interactions.
+
+### D3: Skills read the file deterministically, not ambiently
+
+- **Question:** How does the configuration reach a skill on every run?
+- **Decision:** Each skill reads the file itself during project-context resolution, before the skill's own work begins.
+  The configuration reaches the model on every run of every participating skill, independent of the model's judgment.
+- **Rationale:** Ambient instruction files carry a documented soft-compliance ceiling; only a skill-side read
+  guarantees the configuration is in context. Han's skills already prove the mechanism: more than fifteen skills load
+  project context this way today, and the new file slots into the same resolution step.
+- **Evidence:** Codebase — `han-coding/skills/code-review/SKILL.md:16-20` (the probe block) and `:86-89` (the fallback
+  chain), corroborated across the suite (research A18, A23). Soft-compliance ceiling: research A2 (web).
+- **Rejected alternatives:**
+  - Ambient loading via rules files or CLAUDE.md alone — rejected because compliance is not guaranteed and no skill can
+    verify the content loaded (research A2, A15).
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** D4, D6
+- **Referenced in spec:** Actors and Triggers; Primary Flow; Coordinations.
+
+### D4: Every Han skill participates
+
+- **Question:** Which skills read the configuration in v1? 26 SKILL.md files carry a `## Project Context` block today;
+  15 real skills (Atlassian, Linear, communication, plugin-builder) do not.
+- **Decision:** Every Han skill participates. The 15 skills without a project-context resolution step gain one as part
+  of this feature.
+- **Rationale:** User chose full coverage over the research's narrower proposal. Uniform participation means an
+  engineer never has to remember which skills honor the config; combined with D12 (inapplicable settings silently
+  ignored), full coverage costs nothing in noise.
+- **Evidence:** User input, overriding the research report's V2 scoping proposal.
+- **Rejected alternatives:**
+  - Only the 26 skills that already resolve project context (the research's recommendation) — rejected by the user in
+    favor of a uniform contract.
+  - A pilot subset of agent-dispatching skills — rejected by the user; partial coverage makes the feature harder to
+    explain and trust.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** D12
+- **Referenced in spec:** Primary Flow.
+
+### D5: Extra agents join the candidate pool under existing caps
+
+- **Question:** How do project-supplied extra agents interact with a skill's hardcoded roster, signal-based selection,
+  and size-band caps?
+- **Decision:** Config-named agents join the candidate pool and compete under the same signal-based selection and the
+  same size-band caps as the skill's own roster. A name that does not resolve to an agent available in the session is
+  skipped with a one-line note, and dispatch proceeds.
+- **Rationale:** Joining the pool covers the stated need (project-defined agents get considered) without changing any
+  skill's selection logic or cost profile. Roster validation keeps a typo or stale name from silently breaking
+  dispatch.
+- **Evidence:** User input. Roster mechanics: codebase, research A20 (`plan-implementation`, `code-review`, `research`
+  SKILL.md roster tables). Validation requirement: research validation finding V9.
+- **Rejected alternatives:**
+  - Reprioritizing only the skill's own roster — rejected because it does not cover the stated need for
+    project-supplied agents.
+  - Extra agents exempt from caps, always dispatched — rejected because it changes every configured run's cost and
+    undermines the size-band discipline.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Outcome; Primary Flow; Edge Cases and Failure Modes; Out of Scope.
+
+### D6: Precedence: explicit input, config file, discovery sources, defaults
+
+- **Question:** When sources disagree, which value wins?
+- **Decision:** Explicit user input first, then `.han/config.md`, then CLAUDE.md's `## Project Discovery` section, then
+  `project-discovery.md`, then the skill's built-in defaults. Conflicts resolve silently in that order.
+- **Rationale:** A dedicated configuration file the engineer wrote on purpose should beat generic discovery output. The
+  known trade-off — a value visible in CLAUDE.md silently outranked by a file the team may forget — is mitigated by the
+  CLAUDE.md pointer (D10). The research labels this order a design proposal to validate in use, not a derived fact.
+- **Evidence:** User input, accepting the research report's proposed order (flagged as a design proposal in validation
+  finding V4).
+- **Rejected alternatives:**
+  - CLAUDE.md outranks the config file — rejected because it makes the dedicated config unable to override the very
+    sources it exists to override.
+  - Surfacing every conflict to the user instead of resolving it — rejected because it turns a routine resolution step
+    into a recurring interruption.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** D10
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes.
+
+### D7: v1 override set: output directory and extra agents only
+
+- **Question:** Which overrides does the file support at launch?
+- **Decision:** Exactly two: the output directory for skill-written markdown deliverables, and the extra agents for
+  dispatching skills to consider.
+- **Rationale:** These are the two user-described needs the research was commissioned against. Every additional
+  override class fails the YAGNI evidence test today; the file format (D2) leaves room to add more when evidence
+  arrives.
+- **Evidence:** User-described needs recorded in the research report's framing question; YAGNI evidence test.
+- **Rejected alternatives:**
+  - A general free-form per-skill instructions section — rejected under the evidence test and deferred with a named
+    reopening trigger (see the spec's Deferred section).
+- **Linked technical notes:** T1
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Outcome.
+
+### D8: One file in v1, not a folder
+
+- **Question:** Is the configuration one file or a `.han/` folder of per-concern files?
+- **Decision:** One file, `.han/config.md`, in v1.
+- **Rationale:** A deliberate simplification to avoid speculative structure, not a claim that one file is superior on
+  the merits. The research names the migration cost of splitting later and accepts it; the reopening trigger is
+  recorded in the spec's Deferred section.
+- **Evidence:** Research report recommendation and validation finding V8 (which reframed the single file as a v1
+  simplification after noting a folder would mirror Han's per-artifact probe convention more closely).
+- **Rejected alternatives:**
+  - A folder of per-concern files — rejected for v1 because there are only two override classes to hold; deferred, not
+    discarded.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Deferred (YAGNI).
+
+### D9: Graceful degradation: a bad config can never break a skill
+
+- **Question:** What happens when the file is malformed, names unknown settings, or lists agents that do not exist?
+- **Decision:** A configuration problem can never fail a skill run. Unusable content is ignored, the affected settings
+  fall through to the rest of the precedence chain, and the user sees a one-line note naming what was ignored.
+  Content that applies cleanly produces no note at all.
+- **Rationale:** The config is an optional convenience; letting it block work would make it a liability. The one-line
+  note keeps degradation visible without turning it into an interruption.
+- **Evidence:** Research validation finding V9, which required explicit failure-mode handling before recommending the
+  design.
+- **Rejected alternatives:**
+  - Failing fast on a malformed file — rejected because a typo in an optional file should never stop a review or a
+    plan.
+  - Silent ignoring with no note — rejected because the user would have no way to notice a broken override.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Edge Cases and Failure Modes; User Interactions.
+
+### D10: project-discovery offers a CLAUDE.md pointer
+
+- **Question:** How does a contributor who has never heard of `.han/config.md` find out it exists and is in effect?
+- **Decision:** The project-discovery skill, when run in a project that has the file, offers to write a one-line
+  pointer to it into the project's CLAUDE.md, beside the Project Discovery section it already maintains. The pointer is
+  written only with user consent and never duplicated.
+- **Rationale:** Nothing in Claude Code surfaces a `.han/` folder on its own; the pointer puts the file in the document
+  every contributor already reads, and directly mitigates D6's visibility trade-off.
+- **Evidence:** Research validation finding V3, which found Han's own precedent (project-discovery writes into
+  auto-loaded files precisely because they are auto-loaded) and elevated the pointer to part of the recommendation.
+  Codebase: `han-core/skills/project-discovery/SKILL.md` (research A21).
+- **Rejected alternatives:**
+  - No discoverability aid — rejected because a Han-invented convention has zero native discoverability and would
+    silently outrank visible CLAUDE.md values (D6).
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Actors and Triggers; Alternate Flows and States; Edge Cases and Failure Modes.

--- a/docs/plans/han-project-config/artifacts/feature-technical-notes.md
+++ b/docs/plans/han-project-config/artifacts/feature-technical-notes.md
@@ -1,0 +1,17 @@
+# Feature Technical Notes: Project-Local Han Configuration
+
+## T1: Config file schema shape
+
+- **Context:** The Primary Flow and User Interactions sections commit engineers to writing a file with "a structured
+  header block for simple settings and named sections for list-shaped overrides." That contract only works if the
+  shape is pinned down, and the shape is a new Han-owned convention not discoverable from any existing code.
+- **Technical detail:** `.han/config.md` opens with optional YAML frontmatter carrying the simple scalar settings — an
+  output-directory key for skill-written markdown deliverables — followed by a markdown body with named sections for
+  the list-shaped overrides: an extra-agents section listing agent names (optionally grouped per skill) for
+  dispatching skills to add to their candidate pool. Skills load the file through the same inline `!`-probe pattern
+  their `## Project Context` blocks already use (for example `cat .han/config.md 2>/dev/null`), so the content is
+  spliced into the prompt before the skill's steps run. Exact key names and section headings are finalized during
+  implementation planning; the frontmatter-plus-named-sections split is the committed shape.
+- **Supports decisions:** D1, D2, D7
+- **Driven by findings:** —
+- **Referenced in spec:** Primary Flow; User Interactions.

--- a/docs/plans/han-project-config/artifacts/feature-technical-notes.md
+++ b/docs/plans/han-project-config/artifacts/feature-technical-notes.md
@@ -13,6 +13,6 @@
   existing CLAUDE.md and project-discovery probes, so the content is spliced into the prompt before the skill's steps
   run. Exact key names, section headings, and agent-name matching rules are finalized during implementation planning;
   the frontmatter-plus-named-sections split is the committed shape.
-- **Supports decisions:** D1, D2, D7, D14, D15
+- **Supports decisions:** D1, D2, D5, D7, D14, D15
 - **Driven by findings:** F1, F2, F4
 - **Referenced in spec:** Primary Flow; User Interactions.

--- a/docs/plans/han-project-config/artifacts/feature-technical-notes.md
+++ b/docs/plans/han-project-config/artifacts/feature-technical-notes.md
@@ -6,12 +6,13 @@
   header block for simple settings and named sections for list-shaped overrides." That contract only works if the
   shape is pinned down, and the shape is a new Han-owned convention not discoverable from any existing code.
 - **Technical detail:** `.han/config.md` opens with optional YAML frontmatter carrying the simple scalar settings — an
-  output-directory key for skill-written markdown deliverables — followed by a markdown body with named sections for
-  the list-shaped overrides: an extra-agents section listing agent names (optionally grouped per skill) for
-  dispatching skills to add to their candidate pool. Skills load the file through the same inline `!`-probe pattern
-  their `## Project Context` blocks already use (for example `cat .han/config.md 2>/dev/null`), so the content is
-  spliced into the prompt before the skill's steps run. Exact key names and section headings are finalized during
-  implementation planning; the frontmatter-plus-named-sections split is the committed shape.
-- **Supports decisions:** D1, D2, D7
-- **Driven by findings:** —
+  output-directory key whose value is a base path relative to the project root — followed by a markdown body with a
+  named extra-agents section listing agent names as one global list (per-skill grouping is deferred; see the spec's
+  Deferred section). Skills load the file through the same inline `!`-probe pattern their `## Project Context` blocks
+  already use (for example `cat .han/config.md 2>/dev/null`), resolved from the skill's working directory like the
+  existing CLAUDE.md and project-discovery probes, so the content is spliced into the prompt before the skill's steps
+  run. Exact key names, section headings, and agent-name matching rules are finalized during implementation planning;
+  the frontmatter-plus-named-sections split is the committed shape.
+- **Supports decisions:** D1, D2, D7, D14, D15
+- **Driven by findings:** F1, F2, F4
 - **Referenced in spec:** Primary Flow; User Interactions.

--- a/docs/plans/han-project-config/artifacts/implementation-decision-log.md
+++ b/docs/plans/han-project-config/artifacts/implementation-decision-log.md
@@ -1,0 +1,225 @@
+# Implementation Decision Log: Project-Local Han Configuration
+
+<!--
+This file records every implementation decision committed while planning Project-Local Han Configuration.
+Behavioral and implementation statements live in [../feature-implementation-plan.md](../feature-implementation-plan.md) --
+this file captures the question, rationale, evidence, and rejected alternatives for each decision.
+Round-by-round history lives in [implementation-iteration-history.md](implementation-iteration-history.md).
+
+D-N numbers in this file are IMPLEMENTATION decisions. They are distinct from the spec's D1-D15
+(kept in ../decision-log.md). Spec decisions are cited here as "spec D5", "spec D14", and so on.
+-->
+
+## Trivial decisions
+
+- D-12: Skill and agent edits follow the han-plugin-builder guidance — every SKILL.md and agent change made for this feature is authored against `han-plugin-builder/skills/guidance/references/`, as the repo CLAUDE.md mandates for all skill and agent changes. — Referenced in plan: Constraints and Boundaries; Work Units and Sequencing.
+- D-13: The annotated schema example is authored only after the tokens are pinned — `docs/configuration.md` and its single annotated example are written after the schema tokens in D-4 are fixed, so the example cannot show a key name that later changes. — Referenced in plan: Work Units and Sequencing.
+
+## Full decisions
+
+### D-1: Probe line stays inline in every SKILL.md; only the interpretation prose is factored
+
+- **Question:** Can the whole config-resolution feature be factored into one shared file that skills link to, or must something land inside each participating SKILL.md?
+- **Decision:** The one-line config read stays inline in each participating SKILL.md, inside a `## Project Context` block, matching the existing `!`-probe convention. Only the interpretation of what is read (precedence, degradation and the one-line-note rule, containment, the extra-agent pool-join) is a candidate for a shared file.
+- **Rationale:** Claude Code executes a `!`-backtick probe in place, at prompt-assembly time, from the skill's own working directory. A probe moved into an included reference file would never run. So the read is structurally forced to be inline, one bullet per file, and the plan must land a bullet in every participating SKILL.md rather than zero. The committed mechanics in spec T1 already commit to this same inline pattern (`cat .han/config.md 2>/dev/null`).
+- **Evidence:**
+  - Codebase: `han-coding/skills/code-review/SKILL.md:16-20` (the inline `!`-probe block).
+  - Spec technical note T1 (`../feature-technical-notes.md`), which commits the read to the identical mechanism.
+  - Round 1 structural-analyst finding S1 and junior-developer finding JD-001, independently reaching the same conclusion (claim C1).
+- **Rejected alternatives:**
+  - Factor the entire feature (read and interpretation) into one file skills reference — rejected because a `!`-probe cannot execute from an include; the read must be inline (S1).
+- **Specialist owner:** Han contributor editing SKILL.md files.
+- **Revisit criterion:** Claude Code gains a mechanism that lets an included reference file execute a probe on behalf of the referencing skill.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-2, D-7
+- **Referenced in plan:** Implementation Approach; Work Units and Sequencing
+
+### D-2: One canonical config-resolution rule file in han-core, vendored byte-identical per plugin
+
+- **Question:** Where does the shared interpretation prose (precedence, degradation, note rule, containment, pool-join) live, given three plugins are designed to depend on nothing?
+- **Decision:** One canonical rule file, `han-core/references/config-rule.md`, carries the interpretation contract. It is vendored byte-identical into the `references/` folder of every plugin that carries a SKILL.md (the twelve: han-communication, han-core, han-documentation, han-research, han-planning, han-coding, han-github, han-reporting, han-feedback, han-atlassian, han-linear, han-plugin-builder). The file carries the schema tokens (D-4), the spec D6 precedence chain, the spec D9 degradation and one-line-note rule, the spec D14 containment test (D-5), the spec D15 working-directory rule, and the spec D5 pool-join rule.
+- **Rationale:** The interpretation is multi-paragraph and must be applied identically by every participating skill, so it needs one canonical home rather than a paraphrase per file. Vendoring copies (the `yagni-rule.md` precedent) needs no manifest change. The alternative, cross-plugin skill invocation (the `readability-rule.md` precedent), would force new dependency edges onto han-feedback, han-linear, and han-plugin-builder, contradicting their documented depends-on-nothing design.
+- **Evidence:**
+  - Codebase precedent: `han-core/references/yagni-rule.md` and `han-core/references/evidence-rule.md` vendored byte-identical into five plugins (md5-identical copies).
+  - `CONTRIBUTING.md:202-205`, which documents the dependency-edge carve-out that keeps han-linear and han-feedback edge-free.
+  - The three `plugin.json` files (`han-feedback`, `han-linear`, `han-plugin-builder`) carry no `dependencies` key.
+  - Round 1 findings S2, S3, JD-001, IA-003 (claim C2); resolved in Round 2 as OQ-1.
+- **Rejected alternatives:**
+  - Cross-plugin skill invocation of one canonical file (the readability pattern) — rejected because it forces new dependency edges onto three plugins deliberately designed to depend on nothing (S2; `CONTRIBUTING.md:202-205`).
+  - Pure inline duplication of the interpretation in every SKILL.md — rejected because the note-rule boundary (spec D9) and precedence chain must stay byte-identical across files, and the documented SKILL.md churn would drift the copies (JD-008, IA-003).
+- **Specialist owner:** Han contributor; structural boundary owned against structural-analyst guidance.
+- **Revisit criterion:** A future feature needs a dependency-free plugin to consume the contract through skill invocation rather than a vendored copy, or the vendored copies are observed to drift (see D-3).
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1, R2
+- **Dependent decisions:** D-3, D-4, D-5, D-9
+- **Referenced in plan:** Implementation Approach; Work Units and Sequencing
+
+### D-3: Keep the vendored rule file short and mechanical; defer sync tooling
+
+- **Question:** With twelve vendored copies and no sync mechanism in the repo, how is drift between copies kept manageable?
+- **Decision:** Keep `config-rule.md` short and mechanical (the precedence order, the note format, the containment test, the pool-join sentence, the schema tokens) so an eyeball diff during any future edit is cheap. No automated sync tool or diff checker is built now.
+- **Rationale:** Twelve copies is more drift-prone than the existing five-copy `yagni-rule.md` precedent, and the repo has no tool that diffs vendored copies between Han's own plugins. A short, mechanical file keeps twelve copies close to as cheap to keep synced as five were. Sync tooling has no evidence forcing it today and fails the YAGNI evidence test.
+- **Evidence:**
+  - Codebase: the only vendoring script in the repo, `han-plugin-builder/skills/guidance/scripts/init-guidance.sh`, copies into external consuming repos, not between Han's own plugins; the five `yagni-rule.md` copies stay synced by manual convention.
+  - Round 1 structural-analyst finding S3 (claim C2/C3).
+- **Rejected alternatives:**
+  - Add a diff checker or documentation-sweep step that compares vendored copies — deferred because no drift has been observed and the machinery fails the YAGNI evidence test today (S3).
+- **Specialist owner:** Han contributor.
+- **Revisit criterion:** Drift is observed between vendored copies after landing.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** —
+- **Referenced in plan:** Implementation Approach; Deferred (YAGNI); Risks and Assumptions
+
+### D-4: Pin the config schema tokens
+
+- **Question:** What are the exact schema tokens spec T1 left open (the output-base key, the extra-agents section heading, and the agent-name matching rule)?
+- **Decision:** The frontmatter key for the output base is `output-directory`. The extra-agents section heading is `## Extra Agents`. Entries are one agent per list line, accepted in qualified `plugin:agent` form or bare-name form, matched case-insensitively against the agents available in the session. An entry that does not resolve is skipped with the spec D5 one-line note.
+- **Rationale:** The tokens come from T1's own wording and suite convention. T1 names "an output-directory key," so the key is `output-directory`. The roster tables already use qualified names like `han-research:research-analyst`, so the matching rule accepts qualified names; accepting the bare name too keeps hand-authoring forgiving. Case-insensitive matching against session-available agents follows spec D5's session-availability reading. These tokens are fixed once and reused verbatim in every skill and in the canonical rule file, so no two copies disagree on a key name.
+- **Evidence:**
+  - Spec technical note T1, which names "an output-directory key" and defers exact tokens to implementation planning.
+  - Codebase: `han-research/skills/research/SKILL.md:141` uses the qualified `han-research:research-analyst` form.
+  - Spec D5, which validates entries against session availability.
+  - Round 1 findings JD-005 and F8; resolved in Round 2 as OQ-5 (claim C3).
+- **Rejected alternatives:**
+  - Leave matching to per-skill interpretation — rejected because 39 skills interpreting name-matching independently would resolve the same config file differently (JD-005, JD-008).
+  - Accept only qualified `plugin:agent` names — rejected because hand-authored files will carry bare names; the forgiving reading serves the feature's purpose (spec D5).
+- **Specialist owner:** Han contributor.
+- **Revisit criterion:** A real config file needs a token the pinned set cannot express (for example a second scalar override), which lands under spec D7's room-to-grow format.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1, R2
+- **Dependent decisions:** D-10, D-13
+- **Referenced in plan:** Implementation Approach; Work Units and Sequencing
+
+### D-5: Output-directory containment test
+
+- **Question:** What concrete, prompt-expressible rule keeps the output base inside the project, given spec D15 declined to define a repo root and git is optional?
+- **Decision:** The output-directory value must be a relative path. Reject absolute paths and any path whose normalized form escapes the working directory: a leading slash, a drive prefix, or `..` traversal above the working directory. Resolve an accepted value relative to the working directory. A rejected value falls back to the skill's default output location with the spec D9 one-line note.
+- **Rationale:** The rule is expressible in prompt text with no repo-root or git concept, which matters because spec D15 pins discovery to the working directory and code-review has a git-absent mode. It matches spec D14's accident-not-adversary intent: it guards against a pasted absolute path or a stray leading slash, not an attacker.
+- **Evidence:**
+  - Spec D14 (containment intent) and spec D15 (working-directory basis).
+  - Finding F4, which recorded that "project root was never defined behaviorally"; codebase `han-coding/skills/code-review/SKILL.md:93-94` (git-absent Mode C).
+  - Round 1 finding JD-004; resolved in Round 2 as OQ-4 (claim C7).
+- **Rejected alternatives:**
+  - Derive a repo root from git and test containment against it — rejected because git is optional (code-review Mode C) and spec D15 declined to define a repo root (JD-004).
+- **Specialist owner:** Han contributor.
+- **Revisit criterion:** A real project needs an output base outside the working directory, which would reopen spec D14's containment intent.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1, R2
+- **Dependent decisions:** —
+- **Referenced in plan:** Implementation Approach; Definition of Done
+
+### D-6: Wrapper skills pass explicit output paths, so spec D6 keeps temp files in place
+
+- **Question:** When a han-atlassian wrapper invokes a wrapped skill "to a temporary file," does the wrapped skill's honoring of the output base relocate that file away from where the wrapper expects it?
+- **Decision:** No relocation. Spec D6 already answers it: explicit input outranks the config file. A wrapper that directs its wrapped skill to write to a temporary path is giving explicit output instructions, which win over the configured base. The wrapper skills' briefs pass an explicit path when they invoke a wrapped skill.
+- **Rationale:** All six han-atlassian skills are wrappers, and all six are in the set gaining a config-only block, so the wrapped skill (for example `investigate`) will participate and honor the base unless told otherwise. Spec D6's precedence chain settles the interaction with no new behavior: the explicit path the wrapper passes is the top tier of the chain.
+- **Evidence:**
+  - Spec D6 (precedence: explicit input first).
+  - Codebase: `han-atlassian/skills/investigate-to-confluence/SKILL.md:22-23,55` (invokes `han-coding:investigate` "to a temporary file").
+  - Round 1 finding JD-003; resolved in Round 2 as OQ-3 (claim C6).
+- **Rejected alternatives:**
+  - Add a wrapper-specific bypass rule so wrapped temp files ignore the base — rejected because spec D6 already covers it through explicit input; a new bypass rule is redundant machinery (OQ-3 resolution).
+- **Specialist owner:** Han contributor editing the han-atlassian wrapper skills.
+- **Revisit criterion:** A wrapper is found that invokes a wrapped skill without passing an explicit path, so the wrapped file lands under the configured base unexpectedly.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1, R2
+- **Dependent decisions:** —
+- **Referenced in plan:** Implementation Approach; Work Units and Sequencing
+
+### D-7: Three work passes; the fifteen no-block skills get a minimal config-only block
+
+- **Question:** How is the suite-wide edit scoped across the participating skills, and what block do the skills without a `## Project Context` block get?
+- **Decision:** Three separate passes. First, the skills that already carry a `## Project Context` block get one new probe bullet plus a pointer to the canonical rule file. Second, the skills without a block get a minimal config-only block carrying just the `.han/config.md` probe line and the pointer, not the full git/CLAUDE.md/discovery probe set. Third, the dispatching skills get a bespoke per-skill pool-join edit into their own roster tables, as its own work unit, reusing each skill's own cap vocabulary.
+- **Rationale:** The skills without a block mostly do not resolve CLAUDE.md or discovery context today because their work does not need it, so giving them the full probe set would add probes with no spec D6 tier to consult them against, an unjustified addition. The dispatching-skill roster tables are shaped differently per skill, so the pool-join is a bespoke insertion, not a uniform pasted block; unifying the roster tables is unrelated, larger surgery with no evidence behind it.
+- **Evidence:**
+  - Round 1 structural-analyst findings S5 (minimal block) and S6 (bespoke pool-join); junior-developer JD-002.
+  - Codebase: `han-research/skills/research/SKILL.md:139-169` (a roster shape) versus other skills' differing shapes.
+  - Resolved in Round 2 as OQ-2 (claims C4, C5).
+- **Rejected alternatives:**
+  - Give all fifteen no-block skills the full existing `## Project Context` block — rejected because it adds git/CLAUDE.md/discovery probes those skills have no spec D6 tier to use (S5, YAGNI evidence test).
+  - Fold the pool-join into the probe-block pass as "add one line to N files" — rejected because each roster table is shaped differently, so the estimate would under-scope the bespoke work (JD-002, S6).
+  - Unify the roster tables into one shared format as part of this feature — deferred as unrelated larger surgery with no evidence (S6).
+- **Specialist owner:** Han contributor.
+- **Revisit criterion:** A future feature needs one canonical roster-table format across dispatching skills.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1, R2
+- **Dependent decisions:** D-8, D-9
+- **Referenced in plan:** Implementation Approach; Work Units and Sequencing; Deferred (YAGNI)
+
+### D-8: Enumerate participating skills at execution time; never hardcode totals
+
+- **Question:** How does the plan name which skills participate, given spec D4's stated counts are stale?
+- **Decision:** Enumerate participating skills at execution time by globbing `*/skills/*/SKILL.md`. Never hardcode a total. Spec D4's stated 26-with and 15-without counts are stale against today's tree (24 with a block and 15 without, of 39), and the counts drift as the suite changes.
+- **Rationale:** The repo convention is count-free (indexes stay complete, not counted), and hardcoding a stale 26 would misdirect the edit. Globbing at execution time picks up the current tree whatever it holds when the work runs.
+- **Evidence:**
+  - Repo CLAUDE.md convention: "indexes stay complete, not counted."
+  - Discovery notes and grep: `*/skills/*/SKILL.md` returns 39 (24 with a `## Project Context` block, 15 without); spec D4 states 26/15.
+  - Round 1 junior-developer finding and discovery notes (claim C12).
+- **Rejected alternatives:**
+  - Inherit spec D4's 26/15 counts into the plan — rejected because they are stale against the tree and the repo convention forbids hardcoded totals (C12).
+- **Specialist owner:** Han contributor.
+- **Revisit criterion:** None; the count-free convention is a standing repo rule.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-9
+- **Referenced in plan:** Constraints and Boundaries; Work Units and Sequencing; Definition of Done
+
+### D-9: Definition of done is a grep completeness check plus representative spot-runs
+
+- **Question:** With no test harness, how is a 39-file edit verified as done?
+- **Decision:** Two checks. A grep-based completeness check confirms every participating SKILL.md carries the probe line and the pointer, every plugin carries the vendored rule file, and the vendored copies are byte-identical to the canonical file. Then a manual spot-run of one representative skill per category (a deliverable-writer, a dispatcher, a wrapper, and a config-irrelevant skill), each run against a present, an absent, and a broken config. No CI, test runner, or fixture repo is built.
+- **Rationale:** The repo has no automated test harness for skills, so verification is grep plus manual runs. The grep check proves structural completeness across all files; the spot-runs prove the behavior in each category actually works against the three config states. New CI or fixtures fail the YAGNI evidence test today.
+- **Evidence:**
+  - Discovery notes: no CI or test harness runs skills; verification is manual.
+  - Spec D4's uniform-participation promise (every skill must carry the read).
+  - Round 1 junior-developer finding JD-006; resolved in Round 2 as OQ-6 (claim C8).
+- **Rejected alternatives:**
+  - Build a CI job, test runner, or fixture repo to verify the edit — deferred because no config-drift regression has been observed and the machinery fails the YAGNI evidence test today (JD-006).
+- **Specialist owner:** Han contributor.
+- **Revisit criterion:** A config-drift regression is observed after landing.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1, R2
+- **Dependent decisions:** —
+- **Referenced in plan:** Definition of Done; Testing Strategy; Deferred (YAGNI)
+
+### D-10: One canonical operator doc at docs/configuration.md, plus scent links
+
+- **Question:** What documentation does the feature need, given Han cannot seed the config file and an engineer has no correct source to author from?
+- **Decision:** Add one canonical operator doc, `docs/configuration.md`, as the single home of the annotated schema example and the plain-language contract (what the file is and who writes it, the two v1 overrides, the precedence chain, the degradation contract, the working-directory and monorepo rule). Add a scent link and a "Where to go next" entry in `docs/concepts.md`, one bullet in quickstart Path D, and register the new doc and the canonical contract home in the repo CLAUDE.md. Update `han-core/skills/project-discovery/SKILL.md` and its long-form doc `han-core/docs/skills/project-discovery.md` for the spec D10 pointer behavior. Do not sweep all ~39 skill long-form docs, and skip `docs/choosing-a-han-plugin.md`, `docs/workflows.md`, and the four mechanic docs.
+- **Rationale:** Han cannot seed the file, so an engineer with no canonical doc guesses the frontmatter key and lands in spec D9's silent-degradation path. The four existing cross-suite mechanics each have a repo-root concept doc and a concepts.md entry, so a config convention every skill honors on every run needs the same slot. Per-skill docs do not re-document a cross-suite mechanic, so a blanket sweep of 39 skill docs has no named need and is cut. project-discovery is the one skill whose documented behavior materially changes (it gains the pointer offer).
+- **Evidence:**
+  - Codebase precedent: `docs/sizing.md`, `docs/yagni.md`, `docs/evidence.md`, `docs/readability.md`, each introduced in `docs/concepts.md`.
+  - `han-core/docs/skills/project-discovery.md`, which currently omits the spec D10 pointer behavior.
+  - Spec Out of Scope: Han cannot ship or seed the file (`../feature-specification.md`).
+  - Round 1 information-architect findings IA-001, IA-002, IA-004, IA-005, IA-006, IA-007, IA-008, IA-009 (claims C10, C11).
+- **Rejected alternatives:**
+  - Put the schema example in each participating skill's doc — rejected because 39 copies would drift and the repo enforces single-source for shared rules (IA-002).
+  - Sweep a config note into all ~39 skill long-form docs — deferred because per-skill docs do not re-document cross-suite mechanics and no named task needs the same sentence in 39 places (IA-006).
+  - Update `docs/choosing-a-han-plugin.md` and `docs/workflows.md` — deferred because the config is not a plugin and adds no chain step (IA-009).
+- **Specialist owner:** Han contributor; information-architect guidance owns the doc structure.
+- **Revisit criterion:** A specific skill's config interaction is genuinely non-obvious (reopens the per-skill doc note); the config becomes install-gated (reopens choosing-a-han-plugin.md); a workflow's documented output path becomes misleading (reopens workflows.md).
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** D-13
+- **Referenced in plan:** Implementation Approach; Work Units and Sequencing; Deferred (YAGNI)
+
+### D-11: project-discovery gains a pointer step reusing its consent and dedup pattern
+
+- **Question:** Where does spec D10's CLAUDE.md pointer offer and stale-cleanup behavior fit in the project-discovery skill?
+- **Decision:** Add a new step to `han-core/skills/project-discovery/SKILL.md` between the existing write step and the verification step. It checks for `.han/config.md`, checks for an existing pointer in the target file, and uses the same `AskUserQuestion`-gated consent and dedup baseline the skill already carries. It offers to add a one-line pointer when the file exists and no reference is present, and offers to remove a stale pointer when the file is gone. No new skill or reference file is created.
+- **Rationale:** The skill already has the exact shape spec D10 needs: a dedup baseline against the target file and a consent-gated write. The pointer is a distinct concern from the Project Discovery section (it targets a line beside that section and has its own presence lifecycle), so it fits as its own step rather than folded into the write step. No new abstraction is justified; spec D10 is the only evidence needed.
+- **Evidence:**
+  - Codebase: `han-core/skills/project-discovery/SKILL.md:72-106` (the existing write step with dedup and consent, then verification).
+  - Spec D10 (the pointer offer and stale-cleanup behavior).
+  - Round 1 structural-analyst finding S7 (claim C13).
+- **Rejected alternatives:**
+  - Fold the pointer logic into the existing write step — rejected because the pointer targets a different location and has an independent presence lifecycle, making it a distinct concern (S7).
+  - Create a new skill or reference file for the pointer — rejected because the existing step sequence already carries the consent and dedup pattern; no new abstraction is justified (S7).
+- **Specialist owner:** Han contributor editing project-discovery.
+- **Revisit criterion:** The pointer behavior grows beyond a one-line add and remove, needing its own reusable component.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1
+- **Dependent decisions:** —
+- **Referenced in plan:** Implementation Approach; Work Units and Sequencing

--- a/docs/plans/han-project-config/artifacts/implementation-iteration-history.md
+++ b/docs/plans/han-project-config/artifacts/implementation-iteration-history.md
@@ -1,0 +1,103 @@
+# Implementation Iteration History: Project-Local Han Configuration
+
+<!--
+This file records how the implementation plan for Project-Local Han Configuration evolved across
+discussion rounds. Committed decisions live in [implementation-decision-log.md](implementation-decision-log.md)
+and the primary plan lives in [../feature-implementation-plan.md](../feature-implementation-plan.md).
+
+This file ALSO consolidates the per-round aggregation output — no separate facilitation files are written.
+The claim ledger, Open Questions, and spec-maturity tags from each round live as fields on that round's entry below.
+-->
+
+## R1: Parallel specialist review plus the OI-1 live check
+
+- **Specialists engaged:** junior-developer, structural-analyst, information-architect. In parallel, the OI-1
+  live-install check ran via a Claude Code documentation agent (spec Open Items required it during implementation
+  planning, before plan approval).
+- **New input provided:** Initial feature specification, decision log, team findings, technical notes (T1), and the
+  Step 2 discovery notes (`.discovery-notes.md`).
+- **Claim ledger:**
+
+  | # | Claim | Raised by | Category | State |
+  | - | ----- | --------- | -------- | ----- |
+  | C1 | The `!`-probe line must be inline per SKILL.md (probes execute in place; an include cannot run them); only the interpretation prose (D6 precedence, D9 degradation/note rule, D14 containment, D5 pool-join) is a factoring candidate. | structural-analyst (S1), junior-developer (JD-001) | overlap | Evidenced (`han-coding/skills/code-review/SKILL.md:16-20`; T1) |
+  | C2 | Sharing the resolution contract via cross-plugin skill invocation (readability pattern) would force new dependency edges onto han-feedback, han-linear, and han-plugin-builder — the plugins deliberately designed to depend on nothing. Vendored per-plugin copies (yagni-rule pattern) need no manifest change. | structural-analyst (S2, S3), junior-developer (JD-001/OQ1), information-architect (IA-003) | assumption-refuted | Evidenced (`CONTRIBUTING.md:202-205`; the three `plugin.json` files carry no `dependencies` key; md5-identical yagni-rule copies across 5 plugins) |
+  | C3 | Canonical ownership of the `.han/config.md` schema (exact key names, section heading, agent-name matching) belongs in one han-core reference file; vendored copies must be byte-identical mechanical copies, kept short to keep 12-copy drift manageable. | structural-analyst (S3, S4), junior-developer (JD-005, JD-008), information-architect (IA-002, IA-003) | overlap | Evidenced (`han-core/references/` precedent; T1 defers tokens to implementation planning) |
+  | C4 | The 15 skills without a `## Project Context` block need only a minimal config-only block (the probe line), not the full CLAUDE.md/discovery/git probe set. | structural-analyst (S5) | edge-case | Evidenced (those skills have no D6 discovery tiers to consult; YAGNI evidence test) |
+  | C5 | The extra-agents pool-join is a bespoke per-skill edit across ~10 dispatching skills with differently shaped roster tables, not a uniform pasted block; do not unify the roster tables. | structural-analyst (S6), junior-developer (JD-002/OQ2) | overlap | Evidenced (`han-research/skills/research/SKILL.md:139-169` vs other roster shapes) |
+  | C6 | When a han-atlassian wrapper invokes a wrapped skill "to a temporary file," the wrapped skill honoring the output base could relocate the file the wrapper expects. | junior-developer (JD-003/OQ3) | edge-case | Evidenced (`han-atlassian/skills/investigate-to-confluence/SKILL.md:22-23,55`; resolved in R2 via D6) |
+  | C7 | D14's "outside the project" containment needs a concrete prompt-expressible rule, since D15 declined to define a repo root and git is optional. | junior-developer (JD-004/OQ4) | ambiguity | Evidenced (F4; `code-review/SKILL.md:93-94` Mode C) |
+  | C8 | With no test harness, the 39-file edit needs a stated definition of done: a grep-based completeness check plus representative spot-runs; no new CI or fixtures. | junior-developer (JD-006/OQ6) | edge-case | Evidenced (discovery notes: no harness; D4 uniform-participation promise) |
+  | C9 | OI-1 must gate plan approval; a negative result reopens D1. | junior-developer (JD-007/OQ7), information-architect (sequencing note) | overlap | Evidenced (spec Open Items OI-1); check ran this round — see resolutions |
+  | C10 | The consuming-engineer docs are load-bearing (Han cannot seed the file): one canonical operator doc at repo-root `docs/` (proposed `docs/configuration.md`) carrying the only annotated schema example; scent links in `docs/concepts.md` and quickstart Path D; CLAUDE.md registration; project-discovery SKILL.md and long-form doc updated for D10. | information-architect (IA-001, IA-002, IA-004, IA-005, IA-007, IA-008) | edge-case | Evidenced (`docs/sizing.md`/`yagni.md`/`evidence.md`/`readability.md` precedent; `docs/concepts.md:126-201`; `han-core/docs/skills/project-discovery.md` omits D10 behavior) |
+  | C11 | Do NOT sweep all ~39 skill long-form docs, and skip `docs/choosing-a-han-plugin.md`, `docs/workflows.md`, and the four mechanic docs. | information-architect (IA-006, IA-009) | YAGNI-candidate | Evidenced (cross-suite mechanics precedent: per-skill docs do not re-document them) |
+  | C12 | D4's stated counts (26/15) are stale against the tree (24/15 of 39); the plan must enumerate participating skills at execution time, never hardcode totals. | junior-developer, discovery notes | edge-case | Evidenced (grep of `*/skills/*/SKILL.md`; repo count-free convention) |
+  | C13 | D10's pointer offer fits project-discovery as a new step between the existing write step and verification, reusing its consent/dedup pattern; no new abstraction. | structural-analyst (S7) | edge-case | Evidenced (`han-core/skills/project-discovery/SKILL.md:72-106`) |
+  | C14 | T1 contradiction check: none found; T1's mechanics match the codebase exactly. | structural-analyst (S8), junior-developer, information-architect | T#-check | Evidenced (independent verification against `code-review/SKILL.md:16-20`) |
+
+- **Open Questions raised:**
+  - OQ-1: Where does the canonical config-resolution guidance live, given three plugins depend on nothing? (C2, C3)
+  - OQ-2: Are the dispatching-skill edits scoped as a separate bespoke pass? (C5)
+  - OQ-3: Does the output base apply to a wrapped skill's temporary files when a wrapper invokes it? (C6)
+  - OQ-4: What is the concrete prompt-expressible containment test for the output base? (C7)
+  - OQ-5: What are the fixed schema tokens — output-directory key, extra-agents heading, agent-name matching rule? (C3)
+  - OQ-6: What is the definition of done and verification method for the suite-wide edit? (C8)
+  - OQ-7: Is OI-1 sequenced as the gating step zero, and what did the check find? (C9)
+- **Spec-maturity tags:** plan-level: OQ-1 through OQ-7 (all seven). spec-level: none. T#-contradiction: none. The
+  spec-maturity gate did not trip; no PM facilitation call was made.
+- **Resolution source:** carried into R2.
+- **Decisions produced:** —
+- **Changed in plan:** —
+- **Next-step recommendation (deterministic):** Continue iterating — junior-developer named system-architect (OQ-1)
+  and behavioral-analyst (OQ-3) as candidate handoffs, and plan-level Open Questions remained unresolved. R2 first
+  attempts evidence resolution per Step 6 before any re-engagement.
+
+## R2: Evidence-resolution pass
+
+- **Specialists engaged:** None re-engaged. Every Open Question resolved by evidence already in hand — the two named
+  handoffs (system-architect for OQ-1, behavioral-analyst for OQ-3) were not launched because R1's own convergent
+  evidence and the spec's committed decisions settled both questions without new analysis.
+- **New input provided:** The OI-1 check result (returned during R1), the convergent R1 findings, the feature spec's
+  D6 precedence chain re-read against OQ-3.
+- **Claim ledger:** No new claims. C1 through C14 carried forward unchanged; C6's state updated from open to resolved
+  (see OQ-3 below).
+- **Open Questions raised:** None new. Resolutions of R1's seven:
+  - **OQ-1 — resolved by evidence.** Canonical config-resolution rule file in `han-core/references/`, vendored
+    byte-identical into every plugin that carries skills, kept deliberately short. The alternative (cross-plugin
+    skill invocation) fails on hard evidence: it would force new dependency edges onto han-feedback, han-linear, and
+    han-plugin-builder, contradicting their documented depends-on-nothing design (`CONTRIBUTING.md:202-205`, repo
+    CLAUDE.md). Structural-analyst and junior-developer reached the same answer independently; the system-architect
+    handoff was unnecessary.
+  - **OQ-2 — resolved by evidence.** Yes: the plan scopes the dispatching-skill pool-join edits as their own work
+    unit, per skill, reusing each skill's own cap vocabulary; roster tables are not unified (YAGNI, S6).
+  - **OQ-3 — resolved by evidence.** The spec already answers it: D6 puts explicit input above the config file. A
+    wrapper that directs its wrapped skill to write "to a temporary file" is giving explicit output instructions,
+    which outrank the configured base. The plan records this reading and has the wrapper skills' briefs pass explicit
+    paths; no behavioral change and no behavioral-analyst handoff needed.
+  - **OQ-4 — resolved by evidence.** Containment test expressed from D15's working-directory basis: the value must be
+    a relative path; reject absolute paths and any path whose normalized form escapes the working directory (a
+    leading `/`, a drive prefix, or `..` traversal above the working directory), then resolve relative to the working
+    directory. Matches D14's accident-not-adversary intent and needs no repo-root or git concept.
+  - **OQ-5 — resolved by evidence.** Tokens pinned from T1's own wording and suite convention: frontmatter key
+    `output-directory` (T1 names "an output-directory key"); extra-agents section heading `## Extra Agents`; entries
+    are one agent per list line, accepted in qualified `plugin:agent` form (the suite's roster convention, research
+    A20) or bare-name form, matched case-insensitively against agents available in the session; anything unresolved
+    is skipped with the D5 one-line note.
+  - **OQ-6 — resolved by evidence.** Definition of done: a grep-based completeness check (every participating
+    SKILL.md carries the probe line; every plugin carries the vendored rule file; vendored copies are byte-identical
+    to canonical) plus manual spot-runs of one representative skill per category — a deliverable-writer, a
+    dispatcher, a wrapper, and a config-irrelevant skill, each with a present, absent, and broken config. No CI, no
+    fixture repo (YAGNI; reopening trigger recorded).
+  - **OQ-7 — resolved by evidence.** The OI-1 check ran during R1 via the Claude Code docs agent. Verdict: the
+    load-bearing claim holds. Official plugin docs confirm a plugin-root CLAUDE.md is not loaded as project context,
+    and plugin user-configuration is user-scoped — project-level `.claude/settings.json` entries for it are
+    explicitly ignored. The one nuance found — a plugin can be *enabled* at project scope via `enabledPlugins` in
+    `.claude/settings.json` — governs plugin activation, not delivery of per-repo override values, so it does not
+    give Han a way to ship or seed the config. D1 stands; OI-1 is closed, and the plan is not blocked on it.
+- **Spec-maturity tags:** plan-level: 7 of 7 resolved. spec-level: none. T#-contradiction: none. Gate did not trip.
+- **Resolution source:** OQ-1 evidence; OQ-2 evidence; OQ-3 evidence (spec D6); OQ-4 evidence; OQ-5 evidence (T1 plus
+  suite convention); OQ-6 evidence; OQ-7 evidence (live documentation check plus local install inspection).
+- **Decisions produced:** —
+- **Changed in plan:** —
+- **Next-step recommendation (deterministic):** Go to synthesis. No open plan-level questions remain, no handoffs are
+  outstanding, and the round produced zero new findings.

--- a/docs/plans/han-project-config/artifacts/implementation-iteration-history.md
+++ b/docs/plans/han-project-config/artifacts/implementation-iteration-history.md
@@ -46,8 +46,8 @@ The claim ledger, Open Questions, and spec-maturity tags from each round live as
 - **Spec-maturity tags:** plan-level: OQ-1 through OQ-7 (all seven). spec-level: none. T#-contradiction: none. The
   spec-maturity gate did not trip; no PM facilitation call was made.
 - **Resolution source:** carried into R2.
-- **Decisions produced:** —
-- **Changed in plan:** —
+- **Decisions produced:** D-1, D-2, D-3, D-4, D-5, D-6, D-7, D-8, D-9, D-10, D-11, D-12, D-13 (every implementation decision traces to an R1 finding; D-8, D-10, D-11, D-12 and the R1 halves of the rest were settled by R1 convergent evidence, the seven OQ-linked decisions carried into R2).
+- **Changed in plan:** Implementation Approach (all subsections); Work Units and Sequencing; Definition of Done; Testing Strategy; Risks and Assumptions; Deferred (YAGNI).
 - **Next-step recommendation (deterministic):** Continue iterating — junior-developer named system-architect (OQ-1)
   and behavioral-analyst (OQ-3) as candidate handoffs, and plan-level Open Questions remained unresolved. R2 first
   attempts evidence resolution per Step 6 before any re-engagement.
@@ -97,7 +97,7 @@ The claim ledger, Open Questions, and spec-maturity tags from each round live as
 - **Spec-maturity tags:** plan-level: 7 of 7 resolved. spec-level: none. T#-contradiction: none. Gate did not trip.
 - **Resolution source:** OQ-1 evidence; OQ-2 evidence; OQ-3 evidence (spec D6); OQ-4 evidence; OQ-5 evidence (T1 plus
   suite convention); OQ-6 evidence; OQ-7 evidence (live documentation check plus local install inspection).
-- **Decisions produced:** —
-- **Changed in plan:** —
+- **Decisions produced:** D-2, D-4, D-5, D-6, D-7, D-9, D-13 (the seven decisions settled by R2's OQ resolutions; each also lists R1 under Driven by rounds).
+- **Changed in plan:** Implementation Approach (Where the shared contract lives; The config schema tokens; Keeping the output base inside the project; Extra agents joining the candidate pool; Wrapper skills and wrapped temporary files); Work Units and Sequencing; Definition of Done.
 - **Next-step recommendation (deterministic):** Go to synthesis. No open plan-level questions remain, no handoffs are
   outstanding, and the round produced zero new findings.

--- a/docs/plans/han-project-config/artifacts/team-findings.md
+++ b/docs/plans/han-project-config/artifacts/team-findings.md
@@ -1,0 +1,14 @@
+# Team Findings: Project-Local Han Configuration
+
+This file records every finding raised by the review team for Project-Local Han Configuration, and how each was
+resolved. Behavioral outcomes live in [../feature-specification.md](../feature-specification.md); decisions the
+findings affected live in [decision-log.md](decision-log.md); load-bearing mechanics live in
+[feature-technical-notes.md](feature-technical-notes.md).
+
+## Major findings
+
+<!-- Populated after the review team returns. -->
+
+## Minor edits
+
+<!-- Populated after the review team returns. -->

--- a/docs/plans/han-project-config/artifacts/team-findings.md
+++ b/docs/plans/han-project-config/artifacts/team-findings.md
@@ -5,10 +5,192 @@ resolved. Behavioral outcomes live in [../feature-specification.md](../feature-s
 findings affected live in [decision-log.md](decision-log.md); load-bearing mechanics live in
 [feature-technical-notes.md](feature-technical-notes.md).
 
+Review team: junior-developer, edge-case-explorer, gap-analyzer (medium-size feature, three specialists).
+
 ## Major findings
 
-<!-- Populated after the review team returns. -->
+### F1: Output-directory semantics were undefined
+
+- **Agent:** junior-developer (also raised as "asserted without evidence" by gap-analyzer)
+- **Finding:** The spec treated "output directory" as one monolithic value without saying whether it flattens every
+  skill's output into one folder or redirects a base that preserves each skill's structure — the feature's core
+  override had undefined behavior. The gap-analyzer separately flagged the auto-creation behavior as a commitment with
+  no decision-log home.
+- **Resolution:** New decision D14: the value is a base directory relative to the project root; skills keep their own
+  folder and file structure beneath it; the directory is created on first write. Grounded in the originating need
+  ("write all markdown outputs to `.scratch/`") and the suite's structured multi-file deliverables.
+- **Resolved by:** evidence
+- **Affected decisions:** D14 (new)
+- **Affected tech-notes:** T1
+- **Changed in spec:** Outcome; Primary Flow; Edge Cases and Failure Modes.
+
+### F2: Spec and tech notes disagreed on global versus per-skill extra agents
+
+- **Agent:** junior-developer
+- **Finding:** The Primary Flow read as one global extra-agents list while T1 said "optionally grouped per skill" —
+  two different behaviors.
+- **Resolution:** One global list in v1; signal-based selection already filters agents irrelevant to a skill's domain.
+  Per-skill grouping deferred with a named trigger in the spec's Deferred section. T1 and D5 updated to agree.
+- **Resolved by:** evidence (simpler-version test)
+- **Affected decisions:** D5
+- **Affected tech-notes:** T1
+- **Changed in spec:** Primary Flow; User Interactions; Deferred (YAGNI).
+
+### F3: Displacement of default specialists under the cap was an unstated consequence
+
+- **Agent:** junior-developer
+- **Finding:** "Compete under the same caps" means a selected extra agent can push a default specialist out of a
+  capped team, and the spec never said so.
+- **Resolution:** Stated plainly in Primary Flow step 5: displacement is intended and happens without comment. It is
+  the meaning of the user's chosen option (capped competition over cap-exempt addition); a per-run displacement notice
+  would reintroduce the noise D12 avoids.
+- **Resolved by:** evidence (follows from the user's D5 choice)
+- **Affected decisions:** D5
+- **Affected tech-notes:** —
+- **Changed in spec:** Primary Flow.
+
+### F4: Where the config is discovered was undefined for subdirectory and monorepo runs
+
+- **Agent:** junior-developer and edge-case-explorer (independently)
+- **Finding:** "Project root" was never defined behaviorally. The existing probe convention resolves from the working
+  directory, so a skill run from a nested package would silently miss a repo-root config while the spec promised
+  "every skill honors it."
+- **Resolution:** New decision D15: discovery is from the skill's working directory, matching every existing
+  project-context source. Monorepo packages carry their own file; the no-config-here-but-one-exists-elsewhere case is
+  now an explicit edge-case row (behaves as absent).
+- **Resolved by:** evidence (codebase convention)
+- **Affected decisions:** D15 (new)
+- **Affected tech-notes:** T1
+- **Changed in spec:** Primary Flow; Alternate Flows and States; Edge Cases and Failure Modes.
+
+### F5: No containment or usability rule for the output-directory value
+
+- **Agent:** edge-case-explorer (also raised by junior-developer; blank-value case raised separately by
+  edge-case-explorer)
+- **Finding:** Nothing addressed a value resolving outside the project (absolute path, traversal, stray leading
+  slash), an unwritable path, or a recognized key with a blank value — plausible hand-authoring accidents with
+  data-integrity consequences.
+- **Resolution:** Containment rule in D14: values outside the project or unwritable are refused with a one-line note
+  and the skill falls back to its default location; deliverables are never written outside the project. Blank or
+  unusable values fall through the precedence chain with a note, per D9. Three edge-case rows added.
+- **Resolved by:** evidence
+- **Affected decisions:** D14, D9
+- **Affected tech-notes:** —
+- **Changed in spec:** Edge Cases and Failure Modes; Out of Scope.
+
+### F6: The boundary between "malformed" (note) and "only prose" (silent) was fuzzy
+
+- **Agent:** junior-developer (non-text content case from edge-case-explorer folded in)
+- **Finding:** A file that is all prose has no valid header block — the spec gave no rule deciding whether that gets
+  the malformed-content note or the silent only-prose treatment. Non-text file content was likewise unaddressed.
+- **Resolution:** Crisp rule added to D9 and the edge-case table's preamble: a note appears only when content that
+  attempts a recognized override cannot be used; content the suite has no use for is passed over silently. Non-text
+  content degrades the same way as unparseable content.
+- **Resolved by:** evidence
+- **Affected decisions:** D9
+- **Affected tech-notes:** —
+- **Changed in spec:** Edge Cases and Failure Modes.
+
+### F7: The CLAUDE.md pointer had no lifecycle after the config file goes away
+
+- **Agent:** edge-case-explorer (dedup-basis ambiguity from junior-developer folded in)
+- **Finding:** A pointer written into CLAUDE.md would dangle forever if `.han/config.md` were later deleted, and the
+  dedup rule was undefined against a contributor-edited pointer line.
+- **Resolution:** D10 extended: discovery never adds a pointer when any reference to the file is already present,
+  however edited, and offers to remove a stale pointer when the file is gone — with the same consent rule as creation.
+  The alternate flow was renamed "Discovery keeps the pointer honest" and covers both directions.
+- **Resolved by:** evidence
+- **Affected decisions:** D10
+- **Affected tech-notes:** —
+- **Changed in spec:** Alternate Flows and States; Coordinations; Edge Cases and Failure Modes.
+
+### F8: Duplicate, skill-named, and self-referencing extra-agent entries were unhandled
+
+- **Agent:** edge-case-explorer
+- **Finding:** The edge table only covered names that fail to resolve — not an entry duplicating a roster agent
+  (double-counted against the cap?), a name matching only in different casing, a skill name mistaken for an agent, or
+  the running skill itself.
+- **Resolution:** Two behaviors added to D5 and the edge table: a duplicate has no effect (one candidate, counted
+  once), and anything that does not resolve to a dispatchable agent — including skill names and self-references —
+  gets the standard skip-with-note. Exact name-matching rules are implementation detail left to plan-implementation.
+- **Resolved by:** evidence
+- **Affected decisions:** D5
+- **Affected tech-notes:** —
+- **Changed in spec:** Primary Flow; Edge Cases and Failure Modes.
+
+### F9: An oversized config file is read on every run
+
+- **Agent:** edge-case-explorer
+- **Finding:** Every skill run reads the whole file, so pasted long notes impose a recurring context cost across the
+  entire suite for that project; the spec had no size behavior.
+- **Resolution:** Keep-it-small guidance stated in User Interactions ("everything in it is read on every skill run").
+  A hard size limit or truncation rule fails the evidence test today and is deferred with a measured-bloat reopening
+  trigger.
+- **Resolved by:** evidence (YAGNI simpler-version)
+- **Affected decisions:** —
+- **Affected tech-notes:** —
+- **Changed in spec:** User Interactions; Deferred (YAGNI).
+
+### F10: All-skills participation challenged as a YAGNI candidate
+
+- **Agent:** junior-developer
+- **Finding:** For skills that neither write configurable deliverables nor dispatch agents, the added config read
+  delivers no behavior; the research's 26-skill scope was the strictly simpler version, and the reviewer asked for the
+  user's choice to be reconfirmed rather than silently kept.
+- **Resolution:** The decision stands on the user's explicit choice, made earlier in this session with the trade-off
+  presented (the narrower scope was the recommended option and the user chose full coverage). Recorded on D4 rather
+  than re-asked; the challenge is surfaced in the final presentation for conscious reconfirmation.
+- **Resolved by:** user input (prior, explicit)
+- **Affected decisions:** D4
+- **Affected tech-notes:** —
+- **Changed in spec:** —
+
+### F11: The precedence order's "validate in use" caveat had no follow-up mechanism
+
+- **Agent:** gap-analyzer
+- **Finding:** The research flagged the precedence order as a design proposal to validate in use (V4), and the spec
+  gave the equally-flagged A13 constraint an open item (OI-1) but gave V4 nothing.
+- **Resolution:** OI-2 added: post-ship validation of the config-beats-CLAUDE.md direction, with a
+  surprised-user-report trigger for revisiting D6.
+- **Resolved by:** evidence
+- **Affected decisions:** D6
+- **Affected tech-notes:** —
+- **Changed in spec:** Open Items.
+
+### F12: Precedence semantics were only meaningful for single-value settings
+
+- **Agent:** junior-developer
+- **Finding:** "Explicit user input first" is clear for a scalar like the output directory but undefined for the
+  extra-agents list — replace or merge?
+- **Resolution:** D6 now scopes the chain to single-value settings; for the list, precedence works by addition —
+  explicitly named agents are always considered and config entries join them as candidates, matching the suite's
+  existing explicit-naming dispatch convention.
+- **Resolved by:** evidence
+- **Affected decisions:** D6
+- **Affected tech-notes:** —
+- **Changed in spec:** Primary Flow.
+
+### F13: OI-1 was parked as non-blocking despite guarding the foundational decision
+
+- **Agent:** junior-developer
+- **Finding:** The untested single-source constraint (research A13) underpins D1; a check that could invalidate the
+  feature's foundational decision was labeled non-blocking with a "simplification" framing.
+- **Resolution:** OI-1 sharpened: the check must run during implementation planning before the plan is approved, and a
+  negative result reopens D1 rather than merely simplifying.
+- **Resolved by:** evidence
+- **Affected decisions:** D1
+- **Affected tech-notes:** —
+- **Changed in spec:** Open Items.
 
 ## Minor edits
 
-<!-- Populated after the review team returns. -->
+- F14: ".han/config.md already lives in a folder" — D1/D8 wording tightened so "one file, not a folder" clearly means
+  a single file inside `.han/` — junior-developer — Primary Flow; Deferred (YAGNI).
+- F15: V8's migration-cost and not-superior-on-the-merits framing restored in D8 and the Deferred entry —
+  gap-analyzer — Deferred (YAGNI).
+- F16: The looser session-availability reading of V9's roster-validation wording documented on D5 with rationale —
+  gap-analyzer — —.
+- F17: Per-run note retained over once-per-session (skills hold no cross-run state); recorded as a rejected
+  alternative on D9 — junior-developer — —.
+- F18: Symlink-shared config across monorepo packages flagged as a completeness-only case; not adopted, no spec
+  change — edge-case-explorer — —.

--- a/docs/plans/han-project-config/feature-implementation-plan.md
+++ b/docs/plans/han-project-config/feature-implementation-plan.md
@@ -1,0 +1,196 @@
+# Feature Implementation Plan: Project-Local Han Configuration
+
+This plan adds one optional file, `.han/config.md`, that a consuming project can carry to adjust how Han skills behave in that project. It controls two things: where skills write their markdown outputs, and which extra agents dispatching skills consider.
+
+The work is entirely prompt-text edits across the plugin suite: SKILL.md files, one new shared reference file vendored per plugin, the project-discovery skill, and documentation. There is no runtime, no build, and no automated test suite, so verification is a grep completeness check plus manual spot-runs.
+
+The one thing to know first: the read of the config file must land inline in every participating SKILL.md. A Claude Code probe only runs where it is written ([D-1](artifacts/implementation-decision-log.md#d-1-probe-line-stays-inline-in-every-skillmd-only-the-interpretation-prose-is-factored)).
+
+## Outcome
+
+When this plan is executed, an engineer on a consuming project can write their Han overrides once, in a single `.han/config.md` file. Every Han skill then honors those overrides on every run in that project. A project without the file behaves exactly as the suite does today: no note, no change.
+
+Two overrides ship. The first is a base directory: skills write their markdown deliverables under it, while keeping their own folder structure beneath it. The second is a global list of extra agents: dispatching skills add these to their candidate pool.
+
+A bad config file can never fail a skill run. The worst it does is get ignored, with a one-line note.
+
+## User Stories
+
+- **US-1:** As an engineer on a consuming project, I want to set one base directory for Han's markdown outputs, so that every skill writes its deliverables where my project keeps them instead of the skill defaults.
+- **US-2:** As an engineer on a consuming project, I want to name extra agents my project defines, so that Han's dispatching skills consider them alongside their built-in rosters.
+- **US-3:** As an engineer on a consuming project, I want a broken or partial config file to degrade quietly to defaults with a one-line note, so that a typo never blocks a review or a plan.
+- **US-4:** As an engineer who has never heard of `.han/config.md`, I want project-discovery to surface it in CLAUDE.md, so that I can see the file exists and is in effect.
+- **US-5:** As a Han contributor, I want one canonical source for the config schema and its resolution rules, so that 39 skills interpret the same file identically and I have one correct place to author from.
+
+## Constraints and Boundaries
+
+- **Driving constraint:** The feature promises that *every* Han skill honors the config. That uniform-participation promise (spec D4) is what forces the suite-wide edit and the single canonical contract; a partial rollout would make the feature harder to explain and trust.
+- **Out of scope:** Han cannot ship or seed the file; the consuming project creates and owns it (spec D1, confirmed by the OI-1 live check). The config shapes skill behavior only; it is not a security boundary, does not define new agents, and does not change any skill's selection logic or caps.
+- **Enumerate, never count:** The plan names participating skills by globbing `*/skills/*/SKILL.md` at execution time and never hardcodes a total; spec D4's stated 26/15 counts are stale against today's tree ([D-8](artifacts/implementation-decision-log.md#d-8-enumerate-participating-skills-at-execution-time-never-hardcode-totals)).
+- **Authoring standard:** Every SKILL.md and agent edit follows the han-plugin-builder guidance, as the repo CLAUDE.md mandates ([D-12](artifacts/implementation-decision-log.md#trivial-decisions)).
+
+## Implementation Approach
+
+The feature splits cleanly into two layers.
+
+The first layer is the read: one line, inline in each participating skill. It must live inline because Claude Code runs a `!`-backtick probe in place at prompt-assembly time, and an included file could never execute it ([D-1](artifacts/implementation-decision-log.md#d-1-probe-line-stays-inline-in-every-skillmd-only-the-interpretation-prose-is-factored)).
+
+The second layer is interpretation: what the read config means (precedence, degradation, the note rule, containment, the agent pool-join). That interpretation is shared prose that lives in one canonical file. This read-inline, interpret-from-a-reference shape is the same pattern the suite already uses.
+
+### Where the shared contract lives
+
+One canonical rule file holds the interpretation contract. It is vendored byte-identical into every plugin that carries a skill ([D-2](artifacts/implementation-decision-log.md#d-2-one-canonical-config-resolution-rule-file-in-han-core-vendored-byte-identical-per-plugin)).
+
+Vendoring needs no plugin manifest change. Sharing the contract instead through cross-plugin skill invocation would force new dependency edges onto han-feedback, han-linear, and han-plugin-builder, three plugins designed to depend on nothing. The file is kept short and mechanical so its twelve copies stay eyeball-diffable without sync tooling ([D-3](artifacts/implementation-decision-log.md#d-3-keep-the-vendored-rule-file-short-and-mechanical-defer-sync-tooling)).
+
+- Canonical file: `han-core/references/config-rule.md`, vendored into the `references/` folder of each of the twelve skill-carrying plugins.
+
+### The config schema tokens
+
+The tokens spec T1 left open are pinned here so every skill and the canonical file use them verbatim ([D-4](artifacts/implementation-decision-log.md#d-4-pin-the-config-schema-tokens)). These are decision-bearing values, not incidental detail.
+
+- Output base: frontmatter key `output-directory`, value is a relative path.
+- Extra agents: section heading `## Extra Agents`, one agent per list line.
+- Agent-name matching: qualified `plugin:agent` or bare name, matched case-insensitively against agents available in the session; an unresolved entry is skipped with the spec D5 one-line note.
+
+### Keeping the output base inside the project
+
+The containment guard is expressed with no repo-root or git concept, because discovery is pinned to the working directory and git is optional ([D-5](artifacts/implementation-decision-log.md#d-5-output-directory-containment-test)).
+
+The value must be a relative path. An absolute path, a drive prefix, or a `..` traversal above the working directory is refused, and the skill falls back to its default location with a one-line note. This guards against accidents such as a pasted absolute path, matching spec D14's intent. It is not a guard against an adversary.
+
+### Extra agents joining the candidate pool
+
+The extra-agents join is a bespoke edit per dispatching skill, not a uniform pasted block, because each skill's roster table is shaped differently ([D-7](artifacts/implementation-decision-log.md#d-7-three-work-passes-the-fifteen-no-block-skills-get-a-minimal-config-only-block)). Each dispatching skill splices the config's extra agents into its own candidate pool under its own existing caps, reusing its own cap vocabulary. The roster tables are not unified; that is unrelated surgery with no evidence behind it.
+
+### Wrapper skills and wrapped temporary files
+
+A wrapper that invokes a wrapped skill "to a temporary file" passes an explicit output path. That path outranks the configured base under spec D6, so the temporary file stays where the wrapper expects ([D-6](artifacts/implementation-decision-log.md#d-6-wrapper-skills-pass-explicit-output-paths-so-spec-d6-keeps-temp-files-in-place)). The six han-atlassian wrapper skills' briefs pass explicit paths when they invoke a wrapped skill.
+
+### Discoverability through project-discovery
+
+The project-discovery skill gains a new step between its existing write step and verification, reusing the consent and dedup pattern it already carries ([D-11](artifacts/implementation-decision-log.md#d-11-project-discovery-gains-a-pointer-step-reusing-its-consent-and-dedup-pattern)). It offers to add a one-line CLAUDE.md pointer when the config exists, and offers to remove a stale pointer when the file is gone, both only with user consent. No new skill or reference file is created.
+
+- Touch point: `han-core/skills/project-discovery/SKILL.md`, plus its long-form doc.
+
+### Documentation surfaces
+
+One canonical operator doc is the single home of the annotated schema example and the plain-language contract ([D-10](artifacts/implementation-decision-log.md#d-10-one-canonical-operator-doc-at-docsconfigurationmd-plus-scent-links)). This is because Han cannot seed the file itself; without one correct source, an engineer will guess at the frontmatter key. Every other surface carries a scent link only, never a second copy of the example. The wide doc sweep is deliberately avoided.
+
+- New doc: `docs/configuration.md` (single canonical home).
+- Scent links: `docs/concepts.md` (subsection plus a "Where to go next" bullet), quickstart Path D (one bullet), repo CLAUDE.md registration.
+
+## Work Units and Sequencing
+
+Work units are sequenced so the canonical contract and tokens land before anything copies them, and the docs example lands only after the tokens are pinned.
+
+| #   | Work Unit | Story | Delivers | Depends On | Verification |
+| --- | --------- | ----- | -------- | ---------- | ------------ |
+| 0   | OI-1 live-install check (gating) | US-5 | Confirmation that a plugin cannot seed a per-repo config, so `.han/config.md` in the consuming project stands | — | Check ran during R1; verdict CONFIRMED, spec D1 stands |
+| 1   | Author the canonical rule file and pin the schema tokens | US-1, US-2, US-3, US-5 | One `config-rule.md` carrying the tokens, precedence, degradation, note rule, containment, and pool-join sentence ([D-2](artifacts/implementation-decision-log.md#d-2-one-canonical-config-resolution-rule-file-in-han-core-vendored-byte-identical-per-plugin), [D-4](artifacts/implementation-decision-log.md#d-4-pin-the-config-schema-tokens), [D-5](artifacts/implementation-decision-log.md#d-5-output-directory-containment-test)) | 0 | Tokens fixed; file reads as a short mechanical contract |
+| 2   | Vendor the rule file byte-identical into each skill-carrying plugin | US-5 | Twelve `references/config-rule.md` copies identical to the canonical file ([D-2](artifacts/implementation-decision-log.md#d-2-one-canonical-config-resolution-rule-file-in-han-core-vendored-byte-identical-per-plugin), [D-3](artifacts/implementation-decision-log.md#d-3-keep-the-vendored-rule-file-short-and-mechanical-defer-sync-tooling)) | 1 | Byte-identical check across copies |
+| 3   | Add the probe bullet and pointer to skills that already carry a `## Project Context` block | US-1, US-2, US-3 | Each existing-block skill reads the config and points to the rule file ([D-1](artifacts/implementation-decision-log.md#d-1-probe-line-stays-inline-in-every-skillmd-only-the-interpretation-prose-is-factored), [D-7](artifacts/implementation-decision-log.md#d-7-three-work-passes-the-fifteen-no-block-skills-get-a-minimal-config-only-block)) | 2 | Grep: probe line present in each enumerated file |
+| 4   | Add a minimal config-only block to skills without one | US-1, US-2, US-3 | Each no-block skill reads the config through a minimal block, not the full discovery set ([D-7](artifacts/implementation-decision-log.md#d-7-three-work-passes-the-fifteen-no-block-skills-get-a-minimal-config-only-block)) | 2 | Grep: probe line present; no added git/CLAUDE.md probes |
+| 5   | Bespoke extra-agents pool-join into each dispatching skill | US-2 | Each dispatching skill adds config extra agents to its pool under its own caps ([D-7](artifacts/implementation-decision-log.md#d-7-three-work-passes-the-fifteen-no-block-skills-get-a-minimal-config-only-block)) | 2 | Spot-run a dispatcher against a config naming an extra agent |
+| 6   | Pass explicit paths from the han-atlassian wrappers | US-1 | Wrapped temporary files stay in place under spec D6 ([D-6](artifacts/implementation-decision-log.md#d-6-wrapper-skills-pass-explicit-output-paths-so-spec-d6-keeps-temp-files-in-place)) | 2 | Spot-run a wrapper; temp file lands where the wrapper expects |
+| 7   | Add the project-discovery pointer step and update its long-form doc | US-4 | project-discovery offers to add and remove the CLAUDE.md pointer with consent ([D-11](artifacts/implementation-decision-log.md#d-11-project-discovery-gains-a-pointer-step-reusing-its-consent-and-dedup-pattern)) | 2 | Spot-run project-discovery with the config present and absent |
+| 8   | Author `docs/configuration.md` and add the scent links | US-5 | One canonical doc with the annotated example, plus concepts.md, quickstart, and CLAUDE.md links ([D-10](artifacts/implementation-decision-log.md#d-10-one-canonical-operator-doc-at-docsconfigurationmd-plus-scent-links), [D-13](artifacts/implementation-decision-log.md#trivial-decisions)) | 1 | Example matches the pinned tokens; one canonical copy only |
+| 9   | Run the completeness check and representative spot-runs | US-1, US-2, US-3, US-4 | Confirmation the edit is complete and behaves in each category ([D-9](artifacts/implementation-decision-log.md#d-9-definition-of-done-is-a-grep-completeness-check-plus-representative-spot-runs)) | 3, 4, 5, 6, 7 | See Definition of Done |
+
+## Definition of Done
+
+- [ ] Every participating SKILL.md, enumerated by globbing `*/skills/*/SKILL.md`, carries the `.han/config.md` probe line and the pointer to the canonical rule file ([D-8](artifacts/implementation-decision-log.md#d-8-enumerate-participating-skills-at-execution-time-never-hardcode-totals), [D-9](artifacts/implementation-decision-log.md#d-9-definition-of-done-is-a-grep-completeness-check-plus-representative-spot-runs)).
+- [ ] Every skill-carrying plugin has a `references/config-rule.md` byte-identical to the canonical `han-core/references/config-rule.md` ([D-2](artifacts/implementation-decision-log.md#d-2-one-canonical-config-resolution-rule-file-in-han-core-vendored-byte-identical-per-plugin), [D-9](artifacts/implementation-decision-log.md#d-9-definition-of-done-is-a-grep-completeness-check-plus-representative-spot-runs)).
+- [ ] A deliverable-writing skill writes under a configured `output-directory` while keeping its own folder structure, and refuses an absolute or escaping path with a one-line note, falling back to its default ([D-4](artifacts/implementation-decision-log.md#d-4-pin-the-config-schema-tokens), [D-5](artifacts/implementation-decision-log.md#d-5-output-directory-containment-test)).
+- [ ] A dispatching skill adds a config-named extra agent to its pool under its caps, and skips an unresolvable entry with a one-line note ([D-7](artifacts/implementation-decision-log.md#d-7-three-work-passes-the-fifteen-no-block-skills-get-a-minimal-config-only-block)).
+- [ ] A skill run with no config, or an empty config, behaves exactly as today with no note (spec D11).
+- [ ] project-discovery offers to add the pointer when the config exists and to remove it when the file is gone, both consent-gated ([D-11](artifacts/implementation-decision-log.md#d-11-project-discovery-gains-a-pointer-step-reusing-its-consent-and-dedup-pattern)).
+- [ ] `docs/configuration.md` holds the only annotated schema example, matching the pinned tokens, with scent links from concepts.md, quickstart Path D, and CLAUDE.md ([D-10](artifacts/implementation-decision-log.md#d-10-one-canonical-operator-doc-at-docsconfigurationmd-plus-scent-links)).
+
+## Testing Strategy
+
+There is no automated test harness for skills in this repo, so verification is a structural check plus manual runs ([D-9](artifacts/implementation-decision-log.md#d-9-definition-of-done-is-a-grep-completeness-check-plus-representative-spot-runs)).
+
+- **Observable behaviors to test:** a deliverable-writer honoring the output base and refusing an escaping path; a dispatcher adding and skipping extra agents; a wrapper keeping its temporary file in place; a config-irrelevant skill ignoring settings silently; project-discovery adding and removing the pointer.
+- **Edge cases requiring coverage:** each representative skill run against a present config, an absent config, and a broken config (malformed header, blank value, unresolvable agent name).
+- **Test doubles posture and levels:** none; verification is grep for structural completeness plus manual skill runs, since the deliverable is prompt text with no runtime.
+
+## Risks and Assumptions
+
+### Risks
+
+| ID  | Risk | Impact | Mitigation | Owner |
+| --- | ---- | ------ | ---------- | ----- |
+| R1  | The twelve vendored copies of `config-rule.md` drift apart over time | A cross-project config file resolves differently depending on which plugin's skill reads it | Keep the file short and mechanical so an eyeball diff during any edit is cheap; add tooling only if drift is observed ([D-3](artifacts/implementation-decision-log.md#d-3-keep-the-vendored-rule-file-short-and-mechanical-defer-sync-tooling)) | Han contributor |
+| R2  | The one-line-note rule (spec D9) is a model-judgment boundary that skills may apply inconsistently | Some skills note a broken override, others stay silent, confusing the engineer | State the note rule once in the canonical file, not paraphrased per skill; verify with the broken-config spot-runs ([D-2](artifacts/implementation-decision-log.md#d-2-one-canonical-config-resolution-rule-file-in-han-core-vendored-byte-identical-per-plugin)) | Han contributor |
+| R3  | SKILL.md files are high-churn suite-wide; concurrent edits may collide with this 39-file pass | Merge friction or a skill missing the probe line after a rebase | Land the passes in sequence, run the grep completeness check at the end to catch any file that lost the bullet ([D-9](artifacts/implementation-decision-log.md#d-9-definition-of-done-is-a-grep-completeness-check-plus-representative-spot-runs)) | Han contributor |
+
+### Assumptions
+
+| ID  | Assumption | What Changes If Wrong | Status |
+| --- | ---------- | --------------------- | ------ |
+| A1  | A plugin cannot ship or seed a per-repo config value, so the consuming project must carry `.han/config.md` (spec D1) | The feature's foundational decision reopens; the config could live plugin-side instead | Verified (OI-1 live check, CONFIRMED during R1) |
+| A2  | The precedence order (config beats CLAUDE.md, spec D6) matches what engineers expect | A surprised-user report reopens spec D6's ordering | Runtime-only (spec OI-2, post-ship validation) |
+| A3  | Skills apply the pinned tokens and containment rule identically from one shared file | Cross-project config files resolve inconsistently | Runtime-only (proven by the representative spot-runs) |
+
+## Deferred (YAGNI)
+
+### Cross-plugin skill-invocation sharing of the config rules
+
+- **Why deferred:** Simpler-version replacement. Sharing the contract through skill invocation (the readability pattern) would add dependency edges to han-feedback, han-linear, and han-plugin-builder, which are designed to depend on nothing. Byte-identical vendored copies of one canonical file satisfy the same need with no manifest change.
+- **Reopen when:** A future feature needs a dependency-free plugin to consume the contract through skill invocation rather than a vendored copy.
+- **Source:** R1 structural-analyst S2/S3; the larger version is the rejected alternative on [D-2](artifacts/implementation-decision-log.md#d-2-one-canonical-config-resolution-rule-file-in-han-core-vendored-byte-identical-per-plugin).
+
+### Automated sync or diff tooling for the vendored copies
+
+- **Why deferred:** Evidence test. No drift has been observed, and the repo has no tool that diffs vendored copies between its own plugins. A short mechanical file is the simpler mitigation.
+- **Reopen when:** Drift is observed between vendored copies after landing.
+- **Source:** R1 structural-analyst S3; rejected alternative on [D-3](artifacts/implementation-decision-log.md#d-3-keep-the-vendored-rule-file-short-and-mechanical-defer-sync-tooling).
+
+### A full discovery block for the fifteen no-block skills
+
+- **Why deferred:** Evidence test. Those skills have no spec D6 discovery tier to consult a CLAUDE.md or git probe against; a full block adds probes with no named need. A minimal config-only block is the simpler version.
+- **Reopen when:** One of those skills gains work that needs the full discovery chain.
+- **Source:** R1 structural-analyst S5; rejected alternative on [D-7](artifacts/implementation-decision-log.md#d-7-three-work-passes-the-fifteen-no-block-skills-get-a-minimal-config-only-block).
+
+### Unifying the dispatching skills' roster tables
+
+- **Why deferred:** Evidence test. Each roster table is shaped differently, and unifying them is unrelated, larger surgery with no evidence behind it.
+- **Reopen when:** A future feature needs one canonical roster-table format across dispatching skills.
+- **Source:** R1 structural-analyst S6; rejected alternative on [D-7](artifacts/implementation-decision-log.md#d-7-three-work-passes-the-fifteen-no-block-skills-get-a-minimal-config-only-block).
+
+### New CI, test runner, or fixture repo for verification
+
+- **Why deferred:** Evidence test. No config-drift regression has been observed; a grep completeness check plus representative spot-runs verifies the edit today.
+- **Reopen when:** A config-drift regression is observed after landing.
+- **Source:** R1 junior-developer JD-006; rejected alternative on [D-9](artifacts/implementation-decision-log.md#d-9-definition-of-done-is-a-grep-completeness-check-plus-representative-spot-runs).
+
+### A blanket config note in every participating skill's long-form doc
+
+- **Why deferred:** Evidence test. Per-skill docs do not re-document a cross-suite mechanic, and no named task needs the same sentence in 39 places.
+- **Reopen when:** A specific skill whose config interaction is genuinely non-obvious is found.
+- **Source:** R1 information-architect IA-006; rejected alternative on [D-10](artifacts/implementation-decision-log.md#d-10-one-canonical-operator-doc-at-docsconfigurationmd-plus-scent-links).
+
+### Updates to choosing-a-han-plugin.md, workflows.md, and the four mechanic docs
+
+- **Why deferred:** Evidence test. The config is not a plugin and adds no chain step, so these surfaces are orthogonal.
+- **Reopen when:** The config becomes install-gated (choosing-a-han-plugin.md), or a workflow's documented output path becomes misleading (workflows.md).
+- **Source:** R1 information-architect IA-009; rejected alternative on [D-10](artifacts/implementation-decision-log.md#d-10-one-canonical-operator-doc-at-docsconfigurationmd-plus-scent-links).
+
+## Open Items
+
+- **OI-2 (inherited from spec):** The precedence order (config beats CLAUDE.md, spec D6) is a design proposal to validate in use, not a derived fact. The first few real projects using the file should confirm the direction matches engineer expectations.
+  - **Resolves when:** Feedback from real use confirms the order, or a surprised-user report triggers revisiting spec D6.
+  - **Blocks implementation:** No. The order is settled for v1; this tracks post-ship validation only.
+
+## Sources and Plan Records
+
+- **Feature specification:** [feature-specification.md](feature-specification.md)
+- **Specification companions:** [decision log](artifacts/decision-log.md), [team findings](artifacts/team-findings.md), [technical notes](artifacts/feature-technical-notes.md)
+- **Specification decisions inherited / open items to respect:** spec D1-D15 (notably D4 uniform participation, D5 pool-join, D6 precedence, D9 degradation, D10 pointer, D14 containment, D15 working-directory) / OI-2
+- **Decision rationale and rejected alternatives:** [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Team composition and round-by-round history:** [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md)
+
+## Recommendation
+
+Ship as planned. Every plan-level open question was resolved by evidence across two rounds. OI-1 closed as confirmed during planning, so spec D1 stands. The one remaining open item, OI-2, is post-ship validation only; it does not block. The post-ship owner is the Han contributor maintaining the suite.

--- a/docs/plans/han-project-config/feature-specification.md
+++ b/docs/plans/han-project-config/feature-specification.md
@@ -1,15 +1,15 @@
 # Feature Specification: Project-Local Han Configuration
 
-A project that uses Han can add one configuration file at its root that adjusts how Han skills behave in that project:
-where skills write their markdown outputs, and which extra agents skills consider when choosing whom to dispatch. Every
-Han skill reads the file reliably on every run, so the overrides take effect without depending on the model remembering
-to look.
+A project that uses Han can add one configuration file that adjusts how Han skills behave in that project: where skills
+write their markdown outputs, and which extra agents skills consider when choosing whom to dispatch. Every Han skill
+reads the file reliably on every run, so the overrides take effect without depending on the model remembering to look.
 
 ## Outcome
 
 An engineer on a consuming project writes their Han overrides once, in one file, and every Han skill honors them from
-then on. The two overrides this feature delivers: a project-chosen output directory for skill-written markdown
-deliverables, and a project-supplied list of extra agents for dispatching skills to consider
+then on. The two overrides this feature delivers: a project-chosen base directory under which skills write their
+markdown deliverables ([D14](artifacts/decision-log.md#d14-the-output-directory-is-a-base-skills-keep-their-structure-beneath-it)),
+and a project-supplied list of extra agents for dispatching skills to consider
 ([D7](artifacts/decision-log.md#d7-v1-override-set-output-directory-and-extra-agents-only)). A project without the file
 sees no change of any kind ([D11](artifacts/decision-log.md#trivial-decisions)).
 
@@ -24,25 +24,35 @@ sees no change of any kind ([D11](artifacts/decision-log.md#trivial-decisions)).
 
 ## Primary Flow
 
-1. An engineer creates a `.han/config.md` file at the project root
-   ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-at-the-project-root)). The file holds a small
-   structured header block for simple settings, such as the output directory, and named sections for list-shaped
+1. An engineer creates a `.han/config.md` file — a single file inside a `.han/` folder at the project root
+   ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-carried-by-the-consuming-project)). The file holds a
+   small structured header block for simple settings, such as the output directory, and named sections for list-shaped
    overrides, such as extra agents
    ([D2](artifacts/decision-log.md#d2-markdown-with-a-structured-header-block-not-json),
    [T1](artifacts/feature-technical-notes.md#t1-config-file-schema-shape)).
-2. When any Han skill starts, it reads the file during project-context resolution. The read is built into the skill
-   itself, so the configuration reaches the model on every run rather than depending on ambient instructions the model
-   may or may not follow ([D3](artifacts/decision-log.md#d3-skills-read-the-file-deterministically-not-ambiently)).
-   Every Han skill participates ([D4](artifacts/decision-log.md#d4-every-han-skill-participates)).
-3. The skill resolves each setting through a fixed precedence chain: explicit user input first, then the configuration
-   file, then the CLAUDE.md Project Discovery section, then the project-discovery file, then the skill's built-in
-   defaults ([D6](artifacts/decision-log.md#d6-precedence-explicit-input-config-file-discovery-sources-defaults)).
-4. Steps that write markdown deliverables write them under the configured output directory, creating it if it does not
-   exist yet.
+2. When any Han skill starts, it looks for the file from the directory the skill runs in — the same place it already
+   looks for the project's CLAUDE.md and discovery file — so in a monorepo each package can carry its own configuration
+   ([D15](artifacts/decision-log.md#d15-the-config-is-discovered-from-the-skills-working-directory)). The read is built
+   into the skill itself, so the configuration reaches the model on every run rather than depending on ambient
+   instructions the model may or may not follow
+   ([D3](artifacts/decision-log.md#d3-skills-read-the-file-deterministically-not-ambiently)). Every Han skill
+   participates ([D4](artifacts/decision-log.md#d4-every-han-skill-participates)).
+3. The skill resolves each single-value setting through a fixed precedence chain: explicit user input first, then the
+   configuration file, then the CLAUDE.md Project Discovery section, then the project-discovery file, then the skill's
+   built-in defaults
+   ([D6](artifacts/decision-log.md#d6-precedence-explicit-input-config-file-discovery-sources-defaults)). For the
+   list-shaped extra-agents setting, precedence works by addition rather than replacement: agents the user names
+   explicitly are always considered, and the configuration's entries join them as candidates ([D6](artifacts/decision-log.md#d6-precedence-explicit-input-config-file-discovery-sources-defaults)).
+4. Steps that write markdown deliverables write them under the configured base directory, keeping each skill's own
+   folder and file structure beneath it, and creating the directory on first write if it does not exist
+   ([D14](artifacts/decision-log.md#d14-the-output-directory-is-a-base-skills-keep-their-structure-beneath-it)).
 5. Skills that dispatch specialist agents add the configuration's extra agents to their candidate pool. The extra
-   agents compete under the same signal-based selection and the same size-band caps as the skill's own roster
-   ([D5](artifacts/decision-log.md#d5-extra-agents-join-the-candidate-pool-under-existing-caps)). A named agent that
-   does not resolve to an agent available in the session is skipped with a one-line note.
+   agents compete under the same signal-based selection and the same size-band caps as the skill's own roster, which
+   means a selected extra agent can take a slot a default specialist would otherwise have filled — that displacement is
+   intended and happens without comment
+   ([D5](artifacts/decision-log.md#d5-extra-agents-join-the-candidate-pool-under-existing-caps)). An entry that
+   duplicates an agent already in the pool has no effect, and an entry that does not resolve to a dispatchable agent is
+   skipped with a one-line note.
 6. Settings that do not apply to the running skill are ignored without comment
    ([D12](artifacts/decision-log.md#trivial-decisions)). A skill that produces no markdown output ignores the output
    directory; a skill that dispatches no agents ignores the extra-agents list.
@@ -51,44 +61,55 @@ sees no change of any kind ([D11](artifacts/decision-log.md#trivial-decisions)).
 
 ### No configuration file present
 
-- **Entry condition:** The project has no `.han/config.md`, or the file is empty.
+- **Entry condition:** The skill's working directory has no `.han/config.md`, or the file is empty.
 - **Sequence:** The skill resolves project context exactly as it does today, from the remaining sources in the
   precedence chain.
 - **Exit:** Skill behavior is byte-for-byte the behavior the suite has now. No note is shown
   ([D11](artifacts/decision-log.md#trivial-decisions)).
 
-### Discovery offers to make the file findable
+### Discovery keeps the pointer honest
 
-- **Entry condition:** The project-discovery skill runs in a project that has a `.han/config.md`.
-- **Sequence:** The skill offers to add a one-line pointer to the configuration file in the project's CLAUDE.md, beside
-  the Project Discovery section it already maintains, so the file is visible in the document every contributor already
-  reads ([D10](artifacts/decision-log.md#d10-project-discovery-offers-a-claudemd-pointer)).
-- **Exit:** The pointer is written only with the user's consent, and never duplicated on later runs.
+- **Entry condition:** The project-discovery skill runs in a project.
+- **Sequence:** When a `.han/config.md` exists, the skill offers to add a one-line pointer to it in the project's
+  CLAUDE.md, beside the Project Discovery section it already maintains, so the file is visible in the document every
+  contributor already reads. It never adds a second pointer when any reference to the file is already present. When
+  the file is gone but a pointer remains, the skill offers to remove the stale pointer
+  ([D10](artifacts/decision-log.md#d10-project-discovery-offers-a-claudemd-pointer)).
+- **Exit:** The pointer is written or removed only with the user's consent, and CLAUDE.md never accumulates duplicate
+  or dangling references.
 
 ## Edge Cases and Failure Modes
 
 A bad configuration file can never fail a skill run; the worst it can do is be ignored
-([D9](artifacts/decision-log.md#d9-graceful-degradation-a-bad-config-can-never-break-a-skill)).
+([D9](artifacts/decision-log.md#d9-graceful-degradation-a-bad-config-can-never-break-a-skill)). The rule for when the
+user hears about it: a one-line note appears only when content that attempts a recognized override cannot be used.
+Content the suite has no use for is passed over silently.
 
-| Condition                                                          | Required Behavior                                                                                                                                                       |
-| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Header block is malformed or the file is unparseable               | The skill ignores the unusable portion, resolves those settings from the rest of the precedence chain, and shows the user a one-line note naming what was ignored.       |
-| A setting name is not one the suite recognizes                     | The setting is ignored with a one-line note; recognized settings in the same file still apply.                                                                           |
-| An extra-agents entry names an agent the session cannot resolve    | That entry is skipped with a one-line note naming it; dispatch proceeds with the remaining candidates ([D5](artifacts/decision-log.md#d5-extra-agents-join-the-candidate-pool-under-existing-caps)). |
-| The configured output directory does not exist                     | The skill creates it when it first writes a deliverable there.                                                                                                           |
-| The config file and CLAUDE.md disagree on a setting                | The config file wins, silently, per the precedence chain ([D6](artifacts/decision-log.md#d6-precedence-explicit-input-config-file-discovery-sources-defaults)). The CLAUDE.md pointer ([D10](artifacts/decision-log.md#d10-project-discovery-offers-a-claudemd-pointer)) exists to keep that override visible. |
-| The file exists but contains only prose the suite has no use for   | Nothing applies; the skill behaves as if the file were absent, with no note.                                                                                             |
+| Condition                                                                | Required Behavior                                                                                                                                                       |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Header block is malformed, or the file is unreadable as text             | The skill ignores the unusable portion, resolves those settings from the rest of the precedence chain, and shows a one-line note naming what was ignored ([D9](artifacts/decision-log.md#d9-graceful-degradation-a-bad-config-can-never-break-a-skill)). |
+| A setting name is not one the suite recognizes                           | The setting is ignored with a one-line note; recognized settings in the same file still apply.                                                                           |
+| A recognized setting has a blank or unusable value                       | Treated the same as unrecognized content: ignored with a one-line note, and the setting falls through the precedence chain.                                              |
+| The output-directory value points outside the project, or cannot be written | The value is refused with a one-line note and the skill falls back to its default output location; deliverables are never written outside the project ([D14](artifacts/decision-log.md#d14-the-output-directory-is-a-base-skills-keep-their-structure-beneath-it)). |
+| The configured output directory does not exist                           | The skill creates it when it first writes a deliverable there ([D14](artifacts/decision-log.md#d14-the-output-directory-is-a-base-skills-keep-their-structure-beneath-it)). |
+| An extra-agents entry does not resolve to a dispatchable agent           | The entry — a misspelling, a skill name, the running skill itself, or anything else that is not a dispatchable agent — is skipped with a one-line note naming it; dispatch proceeds with the remaining candidates ([D5](artifacts/decision-log.md#d5-extra-agents-join-the-candidate-pool-under-existing-caps)). |
+| An extra-agents entry duplicates an agent already in the candidate pool  | The duplicate has no effect: the agent is one candidate, counted once against the caps.                                                                                  |
+| The config file and CLAUDE.md disagree on a setting                      | The config file wins, silently, per the precedence chain ([D6](artifacts/decision-log.md#d6-precedence-explicit-input-config-file-discovery-sources-defaults)). The CLAUDE.md pointer ([D10](artifacts/decision-log.md#d10-project-discovery-offers-a-claudemd-pointer)) exists to keep that override visible. |
+| The skill runs from a directory with no config, in a repo that has one elsewhere | The skill behaves as if the file were absent; discovery is from the working directory only ([D15](artifacts/decision-log.md#d15-the-config-is-discovered-from-the-skills-working-directory)). |
+| The file exists but contains only prose the suite has no use for         | Nothing applies; the skill behaves as if the file were absent, with no note.                                                                                             |
 
 ## User Interactions
 
 The configuration file itself is the feature's user surface; no new commands or prompts are added.
 
-- **Affordances:** One markdown file the engineer edits by hand: a structured header block for simple values and named
-  sections for extra agents ([T1](artifacts/feature-technical-notes.md#t1-config-file-schema-shape)). The file lives in
-  the project and travels through version control like any other file ([D13](artifacts/decision-log.md#trivial-decisions)).
-- **Feedback:** When a skill ignores part of the file — malformed content, an unrecognized setting, an unresolvable
-  agent name — it tells the user in one line what it ignored and why. When everything applies cleanly, the skill says
-  nothing about the config.
+- **Affordances:** One markdown file the engineer edits by hand: a structured header block for simple values and a
+  named section listing extra agents ([T1](artifacts/feature-technical-notes.md#t1-config-file-schema-shape)). The file
+  is meant to stay small — everything in it is read on every skill run — and it travels through version control like
+  any other file ([D13](artifacts/decision-log.md#trivial-decisions)).
+- **Feedback:** When a skill refuses part of the file — malformed content, an unrecognized setting, an unusable value,
+  an unresolvable agent name — it tells the user in one line what it ignored and why, on each run where the problem is
+  present ([D9](artifacts/decision-log.md#d9-graceful-degradation-a-bad-config-can-never-break-a-skill)). When
+  everything applies cleanly, the skill says nothing about the config.
 - **Error states:** None that stop work. Configuration problems degrade to defaults; they never block or fail the
   skill run ([D9](artifacts/decision-log.md#d9-graceful-degradation-a-bad-config-can-never-break-a-skill)).
 
@@ -97,16 +118,18 @@ The configuration file itself is the feature's user surface; no new commands or 
 | Coordinating System         | Direction | Interaction                                                                 | Ordering / Consistency Requirement                                                              |
 | --------------------------- | --------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | Every Han skill             | inbound   | Reads `.han/config.md` during project-context resolution                     | The read completes before the skill's own work begins, on every run, without model discretion.   |
-| project-discovery skill     | outbound  | Offers to write a pointer line into the project's CLAUDE.md                  | Written only with user consent; deduplicated so repeat runs never add a second pointer.          |
-| Consuming project's repo    | inbound   | Carries the file; Han cannot ship or seed it from the plugin side            | The project owns the file's contents and history ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-at-the-project-root)). |
+| project-discovery skill     | outbound  | Offers to write, and to remove when stale, a pointer line in the project's CLAUDE.md | Written or removed only with user consent; never duplicated, never left dangling without an offer to clean it. |
+| Consuming project's repo    | inbound   | Carries the file; Han cannot ship or seed it from the plugin side            | The project owns the file's contents and history ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-carried-by-the-consuming-project)). |
 
 ## Out of Scope
 
 - **Enforcement beyond skill behavior.** The configuration shapes what skills do; it does not gate tools, block
-  actions, or act as a security boundary.
+  actions, or act as a security boundary. The output-directory containment rule
+  ([D14](artifacts/decision-log.md#d14-the-output-directory-is-a-base-skills-keep-their-structure-beneath-it)) protects
+  against accidents, not adversaries.
 - **Shipping or seeding the file from the plugin.** Han cannot bundle a project-level configuration that activates on
   install; the consuming project creates and owns the file
-  ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-at-the-project-root)).
+  ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-carried-by-the-consuming-project)).
 - **Defining new agents.** The extra-agents override selects among agents that already exist in the session (from any
   installed plugin or the project's own agent definitions); it does not create agents.
 - **Changing any skill's selection logic or caps.** Extra agents enter the existing selection process; the process
@@ -116,12 +139,23 @@ The configuration file itself is the feature's user surface; no new commands or 
 
 ### A folder of per-concern configuration files
 
-- **Why deferred:** Simpler-version test. One file satisfies both named needs today; a `.han/` folder of per-skill or
-  per-concern files is structure with no current content to fill it, and the research flagged the single file as the
-  deliberate v1 simplification ([D8](artifacts/decision-log.md#d8-one-file-in-v1-not-a-folder)).
-- **Reopen when:** The single file grows enough per-skill sections that editing or reviewing it becomes a reported
-  pain, or a third override class lands that is naturally file-shaped.
+- **Why deferred:** Simpler-version test. One file inside `.han/` satisfies both named needs today; a folder of
+  per-skill or per-concern files is structure with no current content to fill it. The research is explicit that this
+  is a v1 simplification, not a claim that one file is superior on the merits, and that splitting later carries a
+  migration cost: existing projects' config files would need to be split and moved
+  ([D8](artifacts/decision-log.md#d8-one-file-in-v1-not-a-folder)).
+- **Reopen when:** The single file grows enough sections that editing or reviewing it becomes a reported pain, or a
+  third override class lands that is naturally file-shaped.
 - **Source:** Research report validation finding V8.
+
+### Per-skill grouping of extra agents
+
+- **Why deferred:** Simpler-version test. A single global list satisfies the described need — the project's agents get
+  considered — because signal-based selection already filters out agents irrelevant to a given skill's domain. Grouping
+  entries per skill adds schema surface with no named need behind it ([F2](artifacts/team-findings.md#f2-spec-and-tech-notes-disagreed-on-global-versus-per-skill-extra-agents)).
+- **Reopen when:** A project reports an extra agent being selected by a skill where it does not belong, or asks to
+  scope an agent to specific skills.
+- **Source:** Review finding F2 (junior-developer).
 
 ### Free-form prose instruction overrides per skill
 
@@ -132,24 +166,44 @@ The configuration file itself is the feature's user surface; no new commands or 
   list-shaped.
 - **Source:** YAGNI evidence test during the interview, against the research report's stated needs.
 
+### A size limit or truncation rule for the config file
+
+- **Why deferred:** Evidence test. The file's whole content is read on every skill run, so an oversized file carries a
+  recurring cost — but no measured incident supports a hard limit today, and the keep-it-small guidance in User
+  Interactions is the strictly simpler version ([F9](artifacts/team-findings.md#f9-an-oversized-config-file-is-read-on-every-run)).
+- **Reopen when:** A real project's config measurably bloats skill context or degrades skill behavior.
+- **Source:** Review finding F9 (edge-case-explorer).
+
 ## Open Items
 
 - **OI-1:** The constraint that forces the configuration into the consuming project rests on a single documentation
-  page that was never tested against a live plugin install (research source A13). A cheap empirical check — install a
-  plugin carrying a project-scoped user-configuration entry and see whether it is honored — should run before
-  implementation locks in. If the constraint turns out to be wrong, simpler plugin-carried options reopen.
+  page that was never tested against a live plugin install (research source A13). The check is cheap — install a
+  plugin carrying a project-scoped user-configuration entry and see whether it is honored — and it must run during
+  implementation planning, before the implementation plan is approved. A negative result does not merely simplify: it
+  reopens the feature's foundational decision
+  ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-carried-by-the-consuming-project)) about where the
+  configuration lives.
   - **Resolves when:** The live-install check is performed during implementation planning.
-  - **Blocks implementation:** No — the check is cheap and the current design remains valid either way; a positive
-    result would simplify, not invalidate.
+  - **Blocks implementation:** No — it does not block starting the implementation plan, but the plan must not be
+    approved until the check has run.
+- **OI-2:** The precedence order ([D6](artifacts/decision-log.md#d6-precedence-explicit-input-config-file-discovery-sources-defaults))
+  is a design proposal the research explicitly says to validate in use, not a derived fact. After the feature ships,
+  the first few real projects using the file should confirm the config-beats-CLAUDE.md direction matches what engineers
+  expect.
+  - **Resolves when:** Feedback from real use confirms the order, or a surprised-user report triggers revisiting D6.
+  - **Blocks implementation:** No — the order is settled for v1; this item tracks post-ship validation.
 
 ## Summary
 
-- **Outcome delivered:** One optional project-root configuration file that reliably adjusts every Han skill's output
+- **Outcome delivered:** One optional project-carried configuration file that reliably adjusts every Han skill's output
   location and agent candidate pool in that project, and changes nothing when absent.
 - **Primary actors:** Engineers on consuming projects (write it), Han skills (read it), project-discovery (points to it).
-- **Decisions settled by evidence:** 7 — see [artifacts/decision-log.md](artifacts/decision-log.md)
-- **Decisions settled by user input:** 6 — see [artifacts/decision-log.md](artifacts/decision-log.md)
-- **Sub-agents consulted:** pending review — see [artifacts/team-findings.md](artifacts/team-findings.md)
-- **Key adjustments from review:** pending review — see [artifacts/team-findings.md](artifacts/team-findings.md)
-- **Remaining open items:** 1
+- **Decisions settled by evidence:** 12 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Decisions settled by user input:** 3 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Sub-agents consulted:** junior-developer, edge-case-explorer, gap-analyzer — see
+  [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Key adjustments from review:** The output directory became a base that preserves each skill's structure with a
+  containment rule; extra agents became a single global list with duplicate and non-agent entries handled; config
+  discovery was pinned to the skill's working directory; and the CLAUDE.md pointer gained a stale-cleanup offer.
+- **Remaining open items:** 2
 - **Technical notes:** 1 — see [artifacts/feature-technical-notes.md](artifacts/feature-technical-notes.md)

--- a/docs/plans/han-project-config/feature-specification.md
+++ b/docs/plans/han-project-config/feature-specification.md
@@ -1,0 +1,155 @@
+# Feature Specification: Project-Local Han Configuration
+
+A project that uses Han can add one configuration file at its root that adjusts how Han skills behave in that project:
+where skills write their markdown outputs, and which extra agents skills consider when choosing whom to dispatch. Every
+Han skill reads the file reliably on every run, so the overrides take effect without depending on the model remembering
+to look.
+
+## Outcome
+
+An engineer on a consuming project writes their Han overrides once, in one file, and every Han skill honors them from
+then on. The two overrides this feature delivers: a project-chosen output directory for skill-written markdown
+deliverables, and a project-supplied list of extra agents for dispatching skills to consider
+([D7](artifacts/decision-log.md#d7-v1-override-set-output-directory-and-extra-agents-only)). A project without the file
+sees no change of any kind ([D11](artifacts/decision-log.md#trivial-decisions)).
+
+## Actors and Triggers
+
+- **Actors** — Engineers on a consuming project write and maintain the configuration file. Han skills read it. The
+  project-discovery skill can make it discoverable by offering to add a pointer to the project's CLAUDE.md
+  ([D10](artifacts/decision-log.md#d10-project-discovery-offers-a-claudemd-pointer)).
+- **Triggers** — Any Han skill run in the project reads the configuration as part of resolving project context, before
+  the skill's own work begins ([D3](artifacts/decision-log.md#d3-skills-read-the-file-deterministically-not-ambiently)).
+- **Preconditions** — None. The file is optional, and the feature imposes no setup step on projects that do not use it.
+
+## Primary Flow
+
+1. An engineer creates a `.han/config.md` file at the project root
+   ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-at-the-project-root)). The file holds a small
+   structured header block for simple settings, such as the output directory, and named sections for list-shaped
+   overrides, such as extra agents
+   ([D2](artifacts/decision-log.md#d2-markdown-with-a-structured-header-block-not-json),
+   [T1](artifacts/feature-technical-notes.md#t1-config-file-schema-shape)).
+2. When any Han skill starts, it reads the file during project-context resolution. The read is built into the skill
+   itself, so the configuration reaches the model on every run rather than depending on ambient instructions the model
+   may or may not follow ([D3](artifacts/decision-log.md#d3-skills-read-the-file-deterministically-not-ambiently)).
+   Every Han skill participates ([D4](artifacts/decision-log.md#d4-every-han-skill-participates)).
+3. The skill resolves each setting through a fixed precedence chain: explicit user input first, then the configuration
+   file, then the CLAUDE.md Project Discovery section, then the project-discovery file, then the skill's built-in
+   defaults ([D6](artifacts/decision-log.md#d6-precedence-explicit-input-config-file-discovery-sources-defaults)).
+4. Steps that write markdown deliverables write them under the configured output directory, creating it if it does not
+   exist yet.
+5. Skills that dispatch specialist agents add the configuration's extra agents to their candidate pool. The extra
+   agents compete under the same signal-based selection and the same size-band caps as the skill's own roster
+   ([D5](artifacts/decision-log.md#d5-extra-agents-join-the-candidate-pool-under-existing-caps)). A named agent that
+   does not resolve to an agent available in the session is skipped with a one-line note.
+6. Settings that do not apply to the running skill are ignored without comment
+   ([D12](artifacts/decision-log.md#trivial-decisions)). A skill that produces no markdown output ignores the output
+   directory; a skill that dispatches no agents ignores the extra-agents list.
+
+## Alternate Flows and States
+
+### No configuration file present
+
+- **Entry condition:** The project has no `.han/config.md`, or the file is empty.
+- **Sequence:** The skill resolves project context exactly as it does today, from the remaining sources in the
+  precedence chain.
+- **Exit:** Skill behavior is byte-for-byte the behavior the suite has now. No note is shown
+  ([D11](artifacts/decision-log.md#trivial-decisions)).
+
+### Discovery offers to make the file findable
+
+- **Entry condition:** The project-discovery skill runs in a project that has a `.han/config.md`.
+- **Sequence:** The skill offers to add a one-line pointer to the configuration file in the project's CLAUDE.md, beside
+  the Project Discovery section it already maintains, so the file is visible in the document every contributor already
+  reads ([D10](artifacts/decision-log.md#d10-project-discovery-offers-a-claudemd-pointer)).
+- **Exit:** The pointer is written only with the user's consent, and never duplicated on later runs.
+
+## Edge Cases and Failure Modes
+
+A bad configuration file can never fail a skill run; the worst it can do is be ignored
+([D9](artifacts/decision-log.md#d9-graceful-degradation-a-bad-config-can-never-break-a-skill)).
+
+| Condition                                                          | Required Behavior                                                                                                                                                       |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Header block is malformed or the file is unparseable               | The skill ignores the unusable portion, resolves those settings from the rest of the precedence chain, and shows the user a one-line note naming what was ignored.       |
+| A setting name is not one the suite recognizes                     | The setting is ignored with a one-line note; recognized settings in the same file still apply.                                                                           |
+| An extra-agents entry names an agent the session cannot resolve    | That entry is skipped with a one-line note naming it; dispatch proceeds with the remaining candidates ([D5](artifacts/decision-log.md#d5-extra-agents-join-the-candidate-pool-under-existing-caps)). |
+| The configured output directory does not exist                     | The skill creates it when it first writes a deliverable there.                                                                                                           |
+| The config file and CLAUDE.md disagree on a setting                | The config file wins, silently, per the precedence chain ([D6](artifacts/decision-log.md#d6-precedence-explicit-input-config-file-discovery-sources-defaults)). The CLAUDE.md pointer ([D10](artifacts/decision-log.md#d10-project-discovery-offers-a-claudemd-pointer)) exists to keep that override visible. |
+| The file exists but contains only prose the suite has no use for   | Nothing applies; the skill behaves as if the file were absent, with no note.                                                                                             |
+
+## User Interactions
+
+The configuration file itself is the feature's user surface; no new commands or prompts are added.
+
+- **Affordances:** One markdown file the engineer edits by hand: a structured header block for simple values and named
+  sections for extra agents ([T1](artifacts/feature-technical-notes.md#t1-config-file-schema-shape)). The file lives in
+  the project and travels through version control like any other file ([D13](artifacts/decision-log.md#trivial-decisions)).
+- **Feedback:** When a skill ignores part of the file — malformed content, an unrecognized setting, an unresolvable
+  agent name — it tells the user in one line what it ignored and why. When everything applies cleanly, the skill says
+  nothing about the config.
+- **Error states:** None that stop work. Configuration problems degrade to defaults; they never block or fail the
+  skill run ([D9](artifacts/decision-log.md#d9-graceful-degradation-a-bad-config-can-never-break-a-skill)).
+
+## Coordinations
+
+| Coordinating System         | Direction | Interaction                                                                 | Ordering / Consistency Requirement                                                              |
+| --------------------------- | --------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Every Han skill             | inbound   | Reads `.han/config.md` during project-context resolution                     | The read completes before the skill's own work begins, on every run, without model discretion.   |
+| project-discovery skill     | outbound  | Offers to write a pointer line into the project's CLAUDE.md                  | Written only with user consent; deduplicated so repeat runs never add a second pointer.          |
+| Consuming project's repo    | inbound   | Carries the file; Han cannot ship or seed it from the plugin side            | The project owns the file's contents and history ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-at-the-project-root)). |
+
+## Out of Scope
+
+- **Enforcement beyond skill behavior.** The configuration shapes what skills do; it does not gate tools, block
+  actions, or act as a security boundary.
+- **Shipping or seeding the file from the plugin.** Han cannot bundle a project-level configuration that activates on
+  install; the consuming project creates and owns the file
+  ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-at-the-project-root)).
+- **Defining new agents.** The extra-agents override selects among agents that already exist in the session (from any
+  installed plugin or the project's own agent definitions); it does not create agents.
+- **Changing any skill's selection logic or caps.** Extra agents enter the existing selection process; the process
+  itself is untouched ([D5](artifacts/decision-log.md#d5-extra-agents-join-the-candidate-pool-under-existing-caps)).
+
+## Deferred (YAGNI)
+
+### A folder of per-concern configuration files
+
+- **Why deferred:** Simpler-version test. One file satisfies both named needs today; a `.han/` folder of per-skill or
+  per-concern files is structure with no current content to fill it, and the research flagged the single file as the
+  deliberate v1 simplification ([D8](artifacts/decision-log.md#d8-one-file-in-v1-not-a-folder)).
+- **Reopen when:** The single file grows enough per-skill sections that editing or reviewing it becomes a reported
+  pain, or a third override class lands that is naturally file-shaped.
+- **Source:** Research report validation finding V8.
+
+### Free-form prose instruction overrides per skill
+
+- **Why deferred:** Evidence test. The two user-described needs are the output directory and extra agents; a general
+  "any instructions you like, per skill" section has no named need behind it and would reopen the soft-compliance
+  problem the deterministic read exists to avoid.
+- **Reopen when:** A user describes a concrete third override that is instruction-shaped rather than value-shaped or
+  list-shaped.
+- **Source:** YAGNI evidence test during the interview, against the research report's stated needs.
+
+## Open Items
+
+- **OI-1:** The constraint that forces the configuration into the consuming project rests on a single documentation
+  page that was never tested against a live plugin install (research source A13). A cheap empirical check — install a
+  plugin carrying a project-scoped user-configuration entry and see whether it is honored — should run before
+  implementation locks in. If the constraint turns out to be wrong, simpler plugin-carried options reopen.
+  - **Resolves when:** The live-install check is performed during implementation planning.
+  - **Blocks implementation:** No — the check is cheap and the current design remains valid either way; a positive
+    result would simplify, not invalidate.
+
+## Summary
+
+- **Outcome delivered:** One optional project-root configuration file that reliably adjusts every Han skill's output
+  location and agent candidate pool in that project, and changes nothing when absent.
+- **Primary actors:** Engineers on consuming projects (write it), Han skills (read it), project-discovery (points to it).
+- **Decisions settled by evidence:** 7 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Decisions settled by user input:** 6 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Sub-agents consulted:** pending review — see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Key adjustments from review:** pending review — see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Remaining open items:** 1
+- **Technical notes:** 1 — see [artifacts/feature-technical-notes.md](artifacts/feature-technical-notes.md)

--- a/docs/plans/han-project-config/feature-specification.md
+++ b/docs/plans/han-project-config/feature-specification.md
@@ -1,39 +1,42 @@
 # Feature Specification: Project-Local Han Configuration
 
-A project that uses Han can add one configuration file that adjusts how Han skills behave in that project: where skills
-write their markdown outputs, and which extra agents skills consider when choosing whom to dispatch. Every Han skill
-reads the file reliably on every run, so the overrides take effect without depending on the model remembering to look.
+A project that uses Han can add one configuration file to adjust how Han skills behave in that project. The file
+controls two things: where skills write their markdown outputs, and which extra agents skills consider when choosing
+whom to dispatch. Every Han skill reads the file reliably on every run, so the overrides take effect without depending
+on the model remembering to look.
 
 ## Outcome
 
 An engineer on a consuming project writes their Han overrides once, in one file, and every Han skill honors them from
-then on. The two overrides this feature delivers: a project-chosen base directory under which skills write their
+then on. A project without the file sees no change of any kind ([D11](artifacts/decision-log.md#trivial-decisions)).
+
+This feature delivers two overrides: a project-chosen base directory under which skills write their
 markdown deliverables ([D14](artifacts/decision-log.md#d14-the-output-directory-is-a-base-skills-keep-their-structure-beneath-it)),
 and a project-supplied list of extra agents for dispatching skills to consider
-([D7](artifacts/decision-log.md#d7-v1-override-set-output-directory-and-extra-agents-only)). A project without the file
-sees no change of any kind ([D11](artifacts/decision-log.md#trivial-decisions)).
+([D7](artifacts/decision-log.md#d7-v1-override-set-output-directory-and-extra-agents-only)).
 
 ## Actors and Triggers
 
-- **Actors** — Engineers on a consuming project write and maintain the configuration file. Han skills read it. The
+- **Actors:** Engineers on a consuming project write and maintain the configuration file. Han skills read it. The
   project-discovery skill can make it discoverable by offering to add a pointer to the project's CLAUDE.md
   ([D10](artifacts/decision-log.md#d10-project-discovery-offers-a-claudemd-pointer)).
-- **Triggers** — Any Han skill run in the project reads the configuration as part of resolving project context, before
+- **Triggers:** Any Han skill run in the project reads the configuration as part of resolving project context, before
   the skill's own work begins ([D3](artifacts/decision-log.md#d3-skills-read-the-file-deterministically-not-ambiently)).
-- **Preconditions** — None. The file is optional, and the feature imposes no setup step on projects that do not use it.
+- **Preconditions:** None. The file is optional, and the feature imposes no setup step on projects that do not use it.
 
 ## Primary Flow
 
-1. An engineer creates a `.han/config.md` file — a single file inside a `.han/` folder at the project root
+1. An engineer creates a `.han/config.md` file: a single file inside a `.han/` folder at the project root
    ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-carried-by-the-consuming-project)). The file holds a
    small structured header block for simple settings, such as the output directory, and named sections for list-shaped
    overrides, such as extra agents
    ([D2](artifacts/decision-log.md#d2-markdown-with-a-structured-header-block-not-json),
    [T1](artifacts/feature-technical-notes.md#t1-config-file-schema-shape)).
-2. When any Han skill starts, it looks for the file from the directory the skill runs in — the same place it already
-   looks for the project's CLAUDE.md and discovery file — so in a monorepo each package can carry its own configuration
+2. When any Han skill starts, it looks for the file in the directory where the skill is running, the same place it
+   already looks for the project's CLAUDE.md and discovery file. That means in a monorepo, each package can carry its
+   own configuration
    ([D15](artifacts/decision-log.md#d15-the-config-is-discovered-from-the-skills-working-directory)). The read is built
-   into the skill itself, so the configuration reaches the model on every run rather than depending on ambient
+   into the skill itself. That way the configuration reaches the model on every run, rather than depending on ambient
    instructions the model may or may not follow
    ([D3](artifacts/decision-log.md#d3-skills-read-the-file-deterministically-not-ambiently)). Every Han skill
    participates ([D4](artifacts/decision-log.md#d4-every-han-skill-participates)).
@@ -44,14 +47,14 @@ sees no change of any kind ([D11](artifacts/decision-log.md#trivial-decisions)).
    list-shaped extra-agents setting, precedence works by addition rather than replacement: agents the user names
    explicitly are always considered, and the configuration's entries join them as candidates ([D6](artifacts/decision-log.md#d6-precedence-explicit-input-config-file-discovery-sources-defaults)).
 4. Steps that write markdown deliverables write them under the configured base directory, keeping each skill's own
-   folder and file structure beneath it, and creating the directory on first write if it does not exist
+   folder and file structure beneath it. The skill creates the directory on first write if it does not exist
    ([D14](artifacts/decision-log.md#d14-the-output-directory-is-a-base-skills-keep-their-structure-beneath-it)).
 5. Skills that dispatch specialist agents add the configuration's extra agents to their candidate pool. The extra
-   agents compete under the same signal-based selection and the same size-band caps as the skill's own roster, which
-   means a selected extra agent can take a slot a default specialist would otherwise have filled — that displacement is
-   intended and happens without comment
+   agents compete under the same signal-based selection and the same size-band caps as the skill's own roster. That
+   means a selected extra agent can take a slot a default specialist would otherwise have filled. That displacement is
+   intended, and it happens without comment
    ([D5](artifacts/decision-log.md#d5-extra-agents-join-the-candidate-pool-under-existing-caps)). An entry that
-   duplicates an agent already in the pool has no effect, and an entry that does not resolve to a dispatchable agent is
+   duplicates an agent already in the pool has no effect. An entry that does not resolve to a dispatchable agent is
    skipped with a one-line note.
 6. Settings that do not apply to the running skill are ignored without comment
    ([D12](artifacts/decision-log.md#trivial-decisions)). A skill that produces no markdown output ignores the output
@@ -71,9 +74,9 @@ sees no change of any kind ([D11](artifacts/decision-log.md#trivial-decisions)).
 
 - **Entry condition:** The project-discovery skill runs in a project.
 - **Sequence:** When a `.han/config.md` exists, the skill offers to add a one-line pointer to it in the project's
-  CLAUDE.md, beside the Project Discovery section it already maintains, so the file is visible in the document every
-  contributor already reads. It never adds a second pointer when any reference to the file is already present. When
-  the file is gone but a pointer remains, the skill offers to remove the stale pointer
+  CLAUDE.md, beside the Project Discovery section it already maintains. That way the file stays visible in the
+  document every contributor already reads. It never adds a second pointer when any reference to the file is already
+  present. When the file is gone but a pointer remains, the skill offers to remove the stale pointer
   ([D10](artifacts/decision-log.md#d10-project-discovery-offers-a-claudemd-pointer)).
 - **Exit:** The pointer is written or removed only with the user's consent, and CLAUDE.md never accumulates duplicate
   or dangling references.
@@ -81,8 +84,8 @@ sees no change of any kind ([D11](artifacts/decision-log.md#trivial-decisions)).
 ## Edge Cases and Failure Modes
 
 A bad configuration file can never fail a skill run; the worst it can do is be ignored
-([D9](artifacts/decision-log.md#d9-graceful-degradation-a-bad-config-can-never-break-a-skill)). The rule for when the
-user hears about it: a one-line note appears only when content that attempts a recognized override cannot be used.
+([D9](artifacts/decision-log.md#d9-graceful-degradation-a-bad-config-can-never-break-a-skill)). The user hears about a
+problem under one rule: a one-line note appears only when content that attempts a recognized override cannot be used.
 Content the suite has no use for is passed over silently.
 
 | Condition                                                                | Required Behavior                                                                                                                                                       |
@@ -104,10 +107,10 @@ The configuration file itself is the feature's user surface; no new commands or 
 
 - **Affordances:** One markdown file the engineer edits by hand: a structured header block for simple values and a
   named section listing extra agents ([T1](artifacts/feature-technical-notes.md#t1-config-file-schema-shape)). The file
-  is meant to stay small — everything in it is read on every skill run — and it travels through version control like
+  is meant to stay small, since everything in it is read on every skill run. It travels through version control like
   any other file ([D13](artifacts/decision-log.md#trivial-decisions)).
-- **Feedback:** When a skill refuses part of the file — malformed content, an unrecognized setting, an unusable value,
-  an unresolvable agent name — it tells the user in one line what it ignored and why, on each run where the problem is
+- **Feedback:** When a skill refuses part of the file (malformed content, an unrecognized setting, an unusable value,
+  an unresolvable agent name), it tells the user in one line what it ignored and why, on each run where the problem is
   present ([D9](artifacts/decision-log.md#d9-graceful-degradation-a-bad-config-can-never-break-a-skill)). When
   everything applies cleanly, the skill says nothing about the config.
 - **Error states:** None that stop work. Configuration problems degrade to defaults; they never block or fail the
@@ -130,8 +133,8 @@ The configuration file itself is the feature's user surface; no new commands or 
 - **Shipping or seeding the file from the plugin.** Han cannot bundle a project-level configuration that activates on
   install; the consuming project creates and owns the file
   ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-carried-by-the-consuming-project)).
-- **Defining new agents.** The extra-agents override selects among agents that already exist in the session (from any
-  installed plugin or the project's own agent definitions); it does not create agents.
+- **Defining new agents.** The extra-agents override selects among agents that already exist in the session, from any
+  installed plugin or the project's own agent definitions. It does not create agents.
 - **Changing any skill's selection logic or caps.** Extra agents enter the existing selection process; the process
   itself is untouched ([D5](artifacts/decision-log.md#d5-extra-agents-join-the-candidate-pool-under-existing-caps)).
 
@@ -139,10 +142,10 @@ The configuration file itself is the feature's user surface; no new commands or 
 
 ### A folder of per-concern configuration files
 
-- **Why deferred:** Simpler-version test. One file inside `.han/` satisfies both named needs today; a folder of
+- **Why deferred:** Simpler-version test. One file inside `.han/` satisfies both named needs today. A folder of
   per-skill or per-concern files is structure with no current content to fill it. The research is explicit that this
-  is a v1 simplification, not a claim that one file is superior on the merits, and that splitting later carries a
-  migration cost: existing projects' config files would need to be split and moved
+  is a v1 simplification, not a claim that one file is superior on the merits. It also notes that splitting later
+  carries a migration cost: existing projects' config files would need to be split and moved
   ([D8](artifacts/decision-log.md#d8-one-file-in-v1-not-a-folder)).
 - **Reopen when:** The single file grows enough sections that editing or reviewing it becomes a reported pain, or a
   third override class lands that is naturally file-shaped.
@@ -150,8 +153,8 @@ The configuration file itself is the feature's user surface; no new commands or 
 
 ### Per-skill grouping of extra agents
 
-- **Why deferred:** Simpler-version test. A single global list satisfies the described need — the project's agents get
-  considered — because signal-based selection already filters out agents irrelevant to a given skill's domain. Grouping
+- **Why deferred:** Simpler-version test. A single global list satisfies the described need: the project's agents get
+  considered, because signal-based selection already filters out agents irrelevant to a given skill's domain. Grouping
   entries per skill adds schema surface with no named need behind it ([F2](artifacts/team-findings.md#f2-spec-and-tech-notes-disagreed-on-global-versus-per-skill-extra-agents)).
 - **Reopen when:** A project reports an extra agent being selected by a skill where it does not belong, or asks to
   scope an agent to specific skills.
@@ -159,8 +162,8 @@ The configuration file itself is the feature's user surface; no new commands or 
 
 ### Free-form prose instruction overrides per skill
 
-- **Why deferred:** Evidence test. The two user-described needs are the output directory and extra agents; a general
-  "any instructions you like, per skill" section has no named need behind it and would reopen the soft-compliance
+- **Why deferred:** Evidence test. The two user-described needs are the output directory and extra agents. A general
+  "any instructions you like, per skill" section has no named need behind it, and it would reopen the soft-compliance
   problem the deterministic read exists to avoid.
 - **Reopen when:** A user describes a concrete third override that is instruction-shaped rather than value-shaped or
   list-shaped.
@@ -169,7 +172,7 @@ The configuration file itself is the feature's user surface; no new commands or 
 ### A size limit or truncation rule for the config file
 
 - **Why deferred:** Evidence test. The file's whole content is read on every skill run, so an oversized file carries a
-  recurring cost — but no measured incident supports a hard limit today, and the keep-it-small guidance in User
+  recurring cost. But no measured incident supports a hard limit today, and the keep-it-small guidance in User
   Interactions is the strictly simpler version ([F9](artifacts/team-findings.md#f9-an-oversized-config-file-is-read-on-every-run)).
 - **Reopen when:** A real project's config measurably bloats skill context or degrades skill behavior.
 - **Source:** Review finding F9 (edge-case-explorer).
@@ -177,33 +180,33 @@ The configuration file itself is the feature's user surface; no new commands or 
 ## Open Items
 
 - **OI-1:** The constraint that forces the configuration into the consuming project rests on a single documentation
-  page that was never tested against a live plugin install (research source A13). The check is cheap — install a
-  plugin carrying a project-scoped user-configuration entry and see whether it is honored — and it must run during
+  page that was never tested against a live plugin install (research source A13). The check is cheap: install a
+  plugin carrying a project-scoped user-configuration entry and see whether it is honored. It must run during
   implementation planning, before the implementation plan is approved. A negative result does not merely simplify: it
   reopens the feature's foundational decision
   ([D1](artifacts/decision-log.md#d1-one-dedicated-markdown-file-carried-by-the-consuming-project)) about where the
   configuration lives.
   - **Resolves when:** The live-install check is performed during implementation planning.
-  - **Blocks implementation:** No — it does not block starting the implementation plan, but the plan must not be
+  - **Blocks implementation:** No. It does not block starting the implementation plan, but the plan must not be
     approved until the check has run.
 - **OI-2:** The precedence order ([D6](artifacts/decision-log.md#d6-precedence-explicit-input-config-file-discovery-sources-defaults))
   is a design proposal the research explicitly says to validate in use, not a derived fact. After the feature ships,
   the first few real projects using the file should confirm the config-beats-CLAUDE.md direction matches what engineers
   expect.
   - **Resolves when:** Feedback from real use confirms the order, or a surprised-user report triggers revisiting D6.
-  - **Blocks implementation:** No — the order is settled for v1; this item tracks post-ship validation.
+  - **Blocks implementation:** No. The order is settled for v1; this item tracks post-ship validation.
 
 ## Summary
 
 - **Outcome delivered:** One optional project-carried configuration file that reliably adjusts every Han skill's output
   location and agent candidate pool in that project, and changes nothing when absent.
 - **Primary actors:** Engineers on consuming projects (write it), Han skills (read it), project-discovery (points to it).
-- **Decisions settled by evidence:** 12 — see [artifacts/decision-log.md](artifacts/decision-log.md)
-- **Decisions settled by user input:** 3 — see [artifacts/decision-log.md](artifacts/decision-log.md)
-- **Sub-agents consulted:** junior-developer, edge-case-explorer, gap-analyzer — see
+- **Decisions settled by evidence:** 12. See [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Decisions settled by user input:** 3. See [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Sub-agents consulted:** junior-developer, edge-case-explorer, gap-analyzer. See
   [artifacts/team-findings.md](artifacts/team-findings.md)
-- **Key adjustments from review:** The output directory became a base that preserves each skill's structure with a
-  containment rule; extra agents became a single global list with duplicate and non-agent entries handled; config
-  discovery was pinned to the skill's working directory; and the CLAUDE.md pointer gained a stale-cleanup offer.
+- **Key adjustments from review:** The output directory became a base that preserves each skill's structure, with a
+  containment rule. Extra agents became a single global list, with duplicate and non-agent entries handled. Config
+  discovery was pinned to the skill's working directory. The CLAUDE.md pointer gained a stale-cleanup offer.
 - **Remaining open items:** 2
-- **Technical notes:** 1 — see [artifacts/feature-technical-notes.md](artifacts/feature-technical-notes.md)
+- **Technical notes:** 1. See [artifacts/feature-technical-notes.md](artifacts/feature-technical-notes.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -124,6 +124,8 @@ need the real skill, spend it here.
    from existing patterns or from research. `/code-review` checks these automatically.
 4. **[`/architectural-decision-record`](../han-documentation/docs/skills/architectural-decision-record.md)** _(as needed)._ Record
    architectural decisions.
+5. **[`.han/config.md`](./configuration.md)** _(as needed)._ Carry one optional config file to set a base directory for
+   Han's markdown outputs and name extra agents for dispatching skills to consider.
 
 **You are done when:** you have a `## Project Discovery` section in your AGENTS.md or CLAUDE.md and the docs and
 standards you need to give other skills useful context.

--- a/docs/research/han-config-extensibility.md
+++ b/docs/research/han-config-extensibility.md
@@ -1,0 +1,377 @@
+# Research: Extending Han Plugins with Project-Local Configuration
+
+The question: how should Han support per-project configuration overrides, such as a `.han/` folder at a consuming
+project's root, for things like "write all markdown outputs to `.scratch/`" and "when picking agents to dispatch for a
+skill, also consider these extra agents"? Which format fits best (JSON or markdown), where should the config live
+(`.han/`, `.claude/rules/`, or CLAUDE.md), and how should every skill read it consistently?
+
+Evidence mode: strict.
+
+## Summary
+
+Use a markdown config file in a `.han/` folder at the project root, and have each Han skill load it the same
+deterministic way the skills already load project context today. Markdown wins over JSON because most of the overrides
+you want are instructions a language model must interpret, not values a parser checks, and the industry pattern across
+AI coding tools splits exactly this way: structured settings in JSON or YAML, open-ended instructions in markdown. A
+small YAML frontmatter block on that markdown file can carry the few settings that are simple values, such as an output
+directory. The `.claude/rules/` and CLAUDE.md routes both work only as soft guidance the model may or may not follow;
+reading the file from inside each skill is the only route where the config is guaranteed to be in front of the model
+every time a skill runs.
+
+The recommendation's shape is well-corroborated: the format pattern is confirmed by two independent vendors, and the
+loading mechanism is proven working in Han's own skills today. The finer design choices inside it (where the file sits
+in the precedence order, one file versus a folder of files) are design proposals this research did not find settled
+answers for, and one structural constraint rests on a single documentation page.
+
+- **Confidence:** Medium
+
+## Research Results
+
+### Every surveyed AI coding tool splits settings from instructions
+
+The tools surveyed all separate machine-enforced settings from prose instructions. Claude Code puts enforced
+configuration in `settings.json` and behavioral guidance in CLAUDE.md and `.claude/rules/` (A2). Gemini CLI does the
+same with `.gemini/settings.json` and `GEMINI.md` (A5). Aider keeps settings in `.aider.conf.yml` and coding rules in a
+`CONVENTIONS.md` the settings file merely points at (A6, A7). The older, non-AI dot-folder precedents (`.vscode/`,
+`.devcontainer/`) use JSON with comments for settings that a program, not a model, consumes (A8, A9 [single-source]).
+EditorConfig deliberately rejected JSON and YAML for a flat INI format on readability grounds (A4 [single-source]).
+
+Two vendors independently converged on a hybrid shape for rule files: a small YAML frontmatter block of machine-readable
+keys on top of a markdown body of prose instructions. Claude Code's `.claude/rules/*.md` files use a `paths` frontmatter
+glob (A2); Cursor's `.cursor/rules/*.mdc` files use `description`, `globs`, and `alwaysApply` (A3). The convergence is
+meaningful corroboration that the hybrid is a real pattern, though the two tools disagree on key names and even on
+precedence direction: Claude Code and VS Code let project config beat user config (A2, A8), while Cursor lets team rules
+beat project rules (A3). There is no cross-tool standard to inherit here. The AGENTS.md standard goes the other
+direction entirely: plain markdown, no schema at all, with nesting as its only structure (A1).
+
+### Markdown instructions are guidance; only skill-side loading is deterministic
+
+Anthropic's own documentation states plainly that CLAUDE.md and rules content is context the model tries to follow,
+with "no guarantee of strict compliance," and points to hooks for anything that must be enforced (A2). A community bug
+report shows the rules path-scoping frontmatter has had real reliability gaps (A15 [single-source]). So any design that
+relies on ambient instructions alone inherits a soft ceiling.
+
+Skills can do better. A skill's body supports `${CLAUDE_PROJECT_DIR}` substitution and dynamic context injection: an
+inline `` !`command` `` runs before the model sees the skill's content, and its output is spliced into the prompt
+verbatim (A14). Han does not need the docs to prove this works: its own skills already use exactly this mechanism to
+probe for CLAUDE.md and `project-discovery.md` today (A18, A23). The codebase evidence is the load-bearing proof here;
+the documentation page is confirmatory (validated in V6).
+
+### Han cannot ship the config; the consuming project must carry it
+
+Two constraints force the config into the consuming project. First, a CLAUDE.md at a plugin's root is not loaded as
+project context, so Han cannot bundle instructions that become live on install (A13 [single-source]). Second, the
+plugin manifest's `userConfig` mechanism is stored and read only from user-scope settings; project and local settings
+entries are ignored, so it cannot carry a per-repo, version-controlled override (A13 [single-source]). Both claims come
+from the same official documentation page and were not tested against a live plugin install (flagged in V7). Whether
+Claude Code tolerates arbitrary custom keys in a project's `.claude/settings.json` is not answered by the settings
+documentation either way (A12 [single-source]).
+
+### Han already has the machinery a config file would plug into
+
+Han's skills resolve project context through a consistent three-tier fallback: read CLAUDE.md's `## Project Discovery`
+section, fall back to `project-discovery.md`, fall back to Glob defaults (A18). The `project-discovery` skill is the
+existing precedent for machine-written, skill-consumed project context, and it writes into CLAUDE.md or AGENTS.md
+precisely because the host loads those files automatically (A21). Output paths are resolved per skill in prose, with
+real inconsistencies (code-overview writes outside the repository while planning skills target `docs/`) (A19). Agent
+rosters are hardcoded tables in each SKILL.md with signal-based selection and band caps, and today there is no
+extension point for project-supplied agents (A20). A narrow search did not surface another Claude Code plugin suite
+with a `.han/`-style config folder, and a community feature request confirms per-project plugin configuration was a
+recognized gap as of late 2025 (A16, A17 [single-source]); read that as "not found," not "does not exist" (V5).
+
+One scoping fact matters for rollout: only 26 of the 49 SKILL.md files in the repo have a `## Project Context` block to
+extend. The other 15 real skills (the Atlassian and Linear wrappers, the communication skills, the plugin-builder
+skills, and a few others) would need a separate decision about whether project overrides even apply to them (V2).
+
+## Options to Consider
+
+### O1: A `.han/config.md` markdown file, read deterministically by each skill
+
+- **What it is:** One markdown file in a `.han/` folder at the project root. Optional YAML frontmatter carries the few
+  simple values (an output directory, for example); named markdown sections carry the prose overrides (extra agents to
+  consider per skill, output conventions). Each participating skill adds a probe to its `## Project Context` block, such
+  as `` !`cat .han/config.md 2>/dev/null` ``, plus a short resolution step that honors what the file supplies.
+- **Trade-offs:** The config is guaranteed in context every time a participating skill runs, independent of the model's
+  judgment. Han fully owns the schema. The costs: it is a Han-invented convention with no native discoverability
+  (nothing in Claude Code surfaces `.han/` to the user), the rollout touches every participating skill (26 have the
+  block today; 15 need a scoping decision), and malformed or invalid content needs an explicit graceful-degradation
+  rule so a bad file cannot silently break dispatch (V9).
+- **Rests on:** (A13), (A14), (A18), (A20), (A23); format choice on (A2), (A3).
+- **Evidence status:** corroborated (loading mechanism proven in-repo; format pattern confirmed by two independent
+  vendors). The "must live in the consuming project" constraint is single-source (A13).
+
+### O2: A `.claude/rules/han.md` rules file
+
+- **What it is:** The consuming project writes Han's overrides into a Claude Code rules file, which loads ambiently and
+  shows up in `/memory` and `/context`.
+- **Trade-offs:** First-class, Anthropic-maintained surface with zero custom parsing in Han. But it is pure guidance
+  with a documented soft-compliance ceiling (A2), the path-scoping frontmatter has a reported reliability bug (A15),
+  the content occupies context in every session whether or not a Han skill runs, and no skill can verify it loaded.
+  Structured overrides such as roster extensions are exactly what free-text ambient rules handle worst.
+- **Rests on:** (A2), (A15).
+- **Evidence status:** corroborated for the mechanism; the reliability caveat is single-source (A15).
+
+### O3: A `## Han Configuration` section in the project's CLAUDE.md
+
+- **What it is:** A named section beside `## Project Discovery`, which Han's skills already know how to find and read.
+- **Trade-offs:** The tightest match to Han's existing read pattern; validation found this precedent analogy stronger
+  for O3 than for O1, since `project-discovery` targets CLAUDE.md precisely because the host auto-loads it (V3). Skills
+  could still read the section explicitly for determinism. The costs: it grows an always-loaded file Anthropic
+  recommends keeping lean, Han cannot seed or validate the section from the plugin side (A13), and mixing Han's
+  override schema into a team's shared narrative file invites drift and merge friction.
+- **Rests on:** (A2), (A13), (A18), (A21).
+- **Evidence status:** corroborated.
+
+### O4: JSON config (`.han/config.json` or custom keys in `.claude/settings.json`)
+
+- **What it is:** A structured, schema-validatable file holding Han's overrides as keys and values.
+- **Trade-offs:** Deterministic to parse and easy to validate, and the right shape for values a program checks. But
+  the overrides you named are mostly instructions a model interprets, and no surveyed source shows JSON handling
+  open-ended guidance without degrading into prose stuffed inside strings (A10 [single-source]). Whether custom keys in
+  `settings.json` are tolerated long-term is unconfirmed (A12), and Claude Code already warns on unknown plugin-manifest
+  fields under strict validation, suggesting Anthropic tightens unknown-key handling over time (A13).
+- **Rests on:** (A10), (A12), (A13).
+- **Evidence status:** single-source (caveated) on the format trade-off claims; inconclusive on settings.json custom
+  keys.
+
+## Recommendation
+
+- **Recommendation:** O1. Create a `.han/config.md` file: YAML frontmatter for the few simple values, named markdown
+  sections for the prose overrides, loaded by each participating skill through the same `!`-probe pattern the skills
+  already use. Start with one file rather than a folder of files; that is a deliberate simplification to avoid
+  speculative structure, not a claim that one file is superior on the merits, and splitting into per-concern files
+  later carries a migration cost (V8). Treat O3 as the close runner-up and a natural complement: the
+  `project-discovery` skill could offer to write a pointer to `.han/config.md` into CLAUDE.md so the config is
+  discoverable in the file every contributor already reads. Scope the rollout to the skills that already carry a
+  `## Project Context` block and resolve project context today; decide separately whether the wrapper and builder
+  skills participate at all (V2). Specify graceful degradation up front: unparseable content or unknown keys are
+  ignored with a one-line note to the user, and any project-supplied agent name is validated against the skill's actual
+  roster and band caps before it is honored (V9).
+- **Proposed precedence, marked as a design proposal:** explicit user input, then `.han/config.md`, then CLAUDE.md's
+  `## Project Discovery`, then `project-discovery.md`, then Glob defaults. No source establishes this ordering; it is a
+  design choice to validate in use, and it carries a visibility trade-off: a value the user can see in CLAUDE.md would
+  be silently outranked by a file they may forget exists (V4).
+- **Evidence basis:** The format choice (markdown with optional frontmatter over JSON) rests on corroborated evidence:
+  two independent vendors converged on the hybrid shape (A2, A3), and the settings-versus-instructions split recurs
+  across Claude Code, Gemini CLI, and Aider (A2, A5, A6, A7). The loading mechanism rests on codebase-verified evidence
+  (A18, A23) with the official skills documentation as confirmation (A14). The constraint forcing the config into the
+  consuming project rests on a single official documentation page (A13) and deserves a cheap empirical check (install a
+  plugin with a project-scoped `userConfig` entry and see whether it is honored) before implementation locks in. The
+  absence of ecosystem precedent is a narrow negative search result (A16, A17), not corroborated proof the pattern is
+  safe.
+
+## Validation
+
+The adversarial validator returned ten findings. The recommendation's shape survived; several supporting claims and
+sub-decisions were corrected or reframed.
+
+### V1: The "YAGNI culture" objection rested on a mischaracterized changelog entry
+
+- **Strategy:** Challenge the Evidence
+- **Investigation:** Read CHANGELOG.md lines 495 to 538 directly. The v4.3.1 removal of model overrides was a
+  portability fix (a Claude-specific tier name broke skills on other hosts), not a stance against configuration knobs.
+- **Result:** Refuted
+- **Impact:** The YAGNI framing in this report now rests on the named "speculative configuration knobs" anti-pattern in
+  the junior-developer agent definition and on the absence of prior precedent, not on the changelog entry (A24).
+
+### V2: "Add one probe line per skill" understates the rollout
+
+- **Strategy:** Challenge the Fix
+- **Investigation:** Grepped all SKILL.md files for `## Project Context`. 26 of 49 have the block; 15 real skills do
+  not, including all six Atlassian skills, both communication skills, and the three plugin-builder skills.
+- **Result:** Partially Refuted
+- **Impact:** The recommendation now scopes the rollout to the skills that already resolve project context and calls
+  for an explicit decision on the rest.
+
+### V3: Han's own precedent favors O3 more literally than O1
+
+- **Strategy:** Challenge the Assumptions
+- **Investigation:** Read the project-discovery skill in full. It writes into CLAUDE.md or AGENTS.md specifically
+  because the host auto-loads those files; that is precedent for an ambient file, not a separately-probed one.
+- **Result:** Partially Refuted
+- **Impact:** O3 was elevated to close runner-up and complement, and the CLAUDE.md-pointer idea was added to the
+  recommendation.
+
+### V4: The precedence order was asserted, not derived
+
+- **Strategy:** Challenge the Recommendation
+- **Investigation:** No source discusses ordering `.han/` against CLAUDE.md; the cited fallback chain has three tiers
+  that coexist in one resolution step.
+- **Result:** Refuted as a claim of derivation
+- **Impact:** The order is now labeled a design proposal, with the CLAUDE.md-visibility trade-off stated.
+
+### V5: The "no ecosystem precedent" finding is a shallow negative search
+
+- **Strategy:** Challenge the Evidence-Gathering Integrity
+- **Investigation:** The negative result rests on one closed GitHub issue and one repo family, with no second search
+  strategy.
+- **Result:** Confirmed as a gap
+- **Impact:** The report now says "a narrow search did not surface one" and does not treat the absence of precedent as
+  evidence the pattern is safe.
+
+### V6: Discounting the skills documentation does not break the recommendation
+
+- **Strategy:** Challenge the Evidence-Gathering Integrity
+- **Investigation:** The dynamic-injection mechanism the recommendation depends on is verified working in
+  code-review's SKILL.md, independent of the web source.
+- **Result:** Confirmed
+- **Impact:** Strengthens the loading-mechanism plank; the report now names the codebase evidence as load-bearing.
+
+### V7: The plugin-constraint claim is single-sourced and untested
+
+- **Strategy:** Challenge the Evidence-Gathering Integrity
+- **Investigation:** Both halves of the "config must live in the consuming project" constraint cite the same
+  documentation page, with no live-install test and no page revision date.
+- **Result:** Not independently corroborated
+- **Impact:** The report flags A13 as single-source throughout and the recommendation calls for a cheap empirical check
+  before implementation locks in.
+
+### V8: Single file versus folder of files was asserted away
+
+- **Strategy:** Challenge the Recommendation
+- **Investigation:** Per-skill override sections in one shared file trade against Han's own "each skill probes its own
+  small artifact" convention; a folder would mirror that convention more closely.
+- **Result:** Partially Refuted
+- **Impact:** The single file is now framed as a deliberate v1 simplification with a named migration cost.
+
+### V9: No failure-mode handling was specified
+
+- **Strategy:** Challenge the Fix
+- **Investigation:** Nothing in the draft addressed malformed frontmatter, unknown keys, or a config naming an agent
+  that does not exist in a skill's roster.
+- **Result:** Refuted as complete
+- **Impact:** The recommendation now includes an explicit graceful-degradation requirement and roster validation.
+
+### V10: Web sources carry access dates, not revision dates
+
+- **Strategy:** Challenge the Evidence-Gathering Integrity
+- **Investigation:** Every web source is dated 2026-07-23 as an access date only; no revision-date or archive check was
+  performed against an actively-developed product's documentation.
+- **Result:** Confirmed as a gap
+- **Impact:** Treat any hard constraint drawn from a single official page as provisional pending direct testing.
+
+### Adjustments Made
+
+Validation changed the report in five places: the YAGNI objection was re-grounded (V1), the rollout was scoped to the
+26 skills with a `## Project Context` block (V2), O3 was elevated to complement status with the CLAUDE.md-pointer idea
+(V3), the precedence order and single-file choice were relabeled as design proposals (V4, V8), and the
+graceful-degradation requirement was added (V9). The recommendation itself survived.
+
+### Confidence Assessment
+
+- **Confidence:** Medium
+- **Remaining Risks:** The "config must live in the consuming project" constraint rests on one documentation page
+  (A13) and has not been tested against a live plugin install; if wrong, JSON-plus-userConfig options reopen. The
+  rollout blast radius across the 15 skills without a `## Project Context` block needs a scoping decision before
+  implementation. No precedent from another plugin suite validates the `.han/` pattern in production (A16, A17). Web
+  sources are dated by access only, so documentation drift is possible.
+
+## Sources
+
+| ID  | Source                                        | Link / location                                                             | Retrieved  | Trust class | Summary (one line)                                                                        | Evidence status                          |
+| --- | --------------------------------------------- | --------------------------------------------------------------------------- | ---------- | ----------- | ----------------------------------------------------------------------------------------- | ---------------------------------------- |
+| A1  | AGENTS.md official site                       | https://agents.md                                                            | 2026-07-23 | web         | Plain markdown, no schema, nearest-file-wins nesting                                       | corroborated by A2, A11                  |
+| A2  | Claude Code memory docs                       | https://code.claude.com/docs/en/memory                                       | 2026-07-23 | web         | CLAUDE.md hierarchy, `.claude/rules/` with `paths` frontmatter, "no guarantee of strict compliance" | corroborated by A3, A15                  |
+| A3  | Cursor rules docs                             | https://cursor.com/docs/rules.md                                             | 2026-07-23 | web         | `.mdc` frontmatter-plus-markdown rules; team beats project beats user                      | corroborated by A2 (hybrid pattern)      |
+| A4  | EditorConfig format rationale                 | https://github.com/editorconfig/editorconfig/wiki/Why-EditorConfig-uses-an-INI-like-format | 2026-07-23 | web         | Rejected JSON/YAML/XML for flat INI on readability grounds                                 | single source (caveated)                 |
+| A5  | Gemini CLI configuration docs                 | https://geminicli.com/docs/reference/configuration/                          | 2026-07-23 | web         | `.gemini/settings.json` for settings, `GEMINI.md` for prose                                | corroborated by A2, A6                   |
+| A6  | Aider config file docs                        | https://aider.chat/docs/config/aider_conf.html                               | 2026-07-23 | web         | YAML settings file, home then repo root then cwd override order                            | corroborated by A5, A7                   |
+| A7  | Aider CONVENTIONS.md docs                     | https://aider.chat/docs/usage/conventions.html                               | 2026-07-23 | web         | Prose rules in markdown; the settings file only points at it                               | corroborated by A2, A6                   |
+| A8  | VS Code JSON docs                             | https://code.visualstudio.com/docs/languages/json                            | 2026-07-23 | web         | `.vscode/settings.json` is JSONC; workspace beats user                                     | corroborated by A9                       |
+| A9  | devcontainer.json conventions                 | https://docs.github.com/codespaces/setting-up-your-project-for-codespaces/introduction-to-dev-containers | 2026-07-23 | web         | JSONC convention for dev-container config                                                  | single source (caveated, aggregated)     |
+| A10 | JSON vs YAML vs TOML comparisons              | https://www.anbowell.com/blog/an-in-depth-comparison-of-json-yaml-and-toml/  | 2026-07-23 | web         | Format trade-offs; ecosystem convention dominates the choice                               | single source (caveated, SEO-genre)      |
+| A11 | Cross-tool AI config file comparisons         | https://www.deployhq.com/blog/ai-coding-config-files-guide                   | 2026-07-23 | web         | File-name landscape across AI coding tools; AGENTS.md deliberately minimal                 | single source (caveated)                 |
+| A12 | Claude Code settings docs                     | https://code.claude.com/docs/en/settings                                     | 2026-07-23 | web         | Settings hierarchy; silent on whether arbitrary custom keys are tolerated                  | single source (inconclusive)             |
+| A13 | Claude Code plugins reference                 | https://code.claude.com/docs/en/plugins-reference                            | 2026-07-23 | web         | Plugin CLAUDE.md not loaded; `userConfig` user-scoped only; path substitutions             | single source (caveated, load-bearing)   |
+| A14 | Claude Code skills docs                       | https://code.claude.com/docs/en/skills                                       | 2026-07-23 | web         | `${CLAUDE_PROJECT_DIR}` and `` !`command` `` dynamic context injection                     | corroborated by A18, A23 (in-repo)       |
+| A15 | Rules `paths` frontmatter bug report          | https://github.com/anthropics/claude-code/issues/17204                       | 2026-07-23 | web         | Documented `paths:` key unreliable in some configs; undocumented `globs:` works            | single source (caveated)                 |
+| A16 | Per-project plugin config feature request     | https://github.com/anthropics/claude-code/issues/11461                       | 2026-07-23 | web         | Per-project plugin configuration named as a gap, Nov 2025; closed, resolution unclear      | single source (caveated)                 |
+| A17 | SuperClaude framework repos                   | https://github.com/SuperClaude-Org/SuperClaude_Framework                     | 2026-07-23 | web         | No documented per-project override-folder precedent found                                  | single source (inconclusive, negative)   |
+| A18 | Han three-tier context fallback               | han-coding/skills/code-review/SKILL.md:16-89                                 | n/a        | codebase    | CLAUDE.md section, then project-discovery.md, then Glob defaults, via `!` probes           | corroborated across 15+ skills           |
+| A19 | Han output-path resolution patterns           | han-planning/skills/plan-a-feature/SKILL.md:74-79 (and siblings)             | n/a        | codebase    | Per-skill prose resolution; inconsistent defaults across skills                            | corroborated (multiple skills read)      |
+| A20 | Han agent roster tables                       | han-planning/skills/plan-implementation/SKILL.md:150-195 (and siblings)      | n/a        | codebase    | Hardcoded rosters with signal selection and band caps; no extension point                  | corroborated (three skills read)         |
+| A21 | project-discovery skill                       | han-core/skills/project-discovery/SKILL.md:1-107                             | n/a        | codebase    | Writes a structured section into auto-loaded CLAUDE.md or AGENTS.md, with dedup            | corroborated by A18 (consumers)          |
+| A22 | Progressive-disclosure guidance               | han-plugin-builder/skills/guidance/references/skill-building-guidance/progressive-disclosure.md | n/a | codebase    | Three loading levels; on-demand files are where a config read sits                         | corroborated by A18                      |
+| A23 | Han dynamic-injection convention              | multiple SKILL.md `## Project Context` blocks                                | n/a        | codebase    | `!`-probe with sentinel fallbacks used across the suite; 26 of 49 skills carry the block   | corroborated by A18                      |
+| A24 | No existing override mechanism in Han         | repo-wide grep; han-core/agents/junior-developer.md:289                      | n/a        | codebase    | No `.han/` or per-project override anywhere; "speculative configuration knobs" named an anti-pattern | corroborated (validated in V1)           |
+| A25 | Skill composition pattern                     | han-plugin-builder/skills/guidance/references/skill-building-guidance/skill-composition.md | n/a | codebase    | Skills compose via Skill-tool invocation; config informs selection inside existing flows   | corroborated by A18                      |
+
+### A2: Claude Code memory docs — recommendation-bearing
+
+- **Link / location:** https://code.claude.com/docs/en/memory
+- **Retrieved:** 2026-07-23
+- **Trust class:** web
+- **Summary:** Documents the CLAUDE.md scope hierarchy and load order, `.claude/rules/*.md` files with YAML `paths`
+  frontmatter globs, and the `@path` import mechanism. States that markdown instructions shape behavior but are not a
+  hard enforcement layer, with "no guarantee of strict compliance," and that enforced configuration belongs in
+  settings.json or hooks. This is the direct evidence for both the hybrid frontmatter-plus-markdown pattern and the
+  soft-compliance ceiling that rules out ambient-only designs.
+- **Evidence status:** corroborated by A3 (hybrid pattern) and A15 (reliability caveat)
+
+### A3: Cursor rules docs — recommendation-bearing
+
+- **Link / location:** https://cursor.com/docs/rules.md
+- **Retrieved:** 2026-07-23
+- **Trust class:** web
+- **Summary:** Cursor's `.cursor/rules/*.mdc` files pair YAML frontmatter (`description`, `globs`, `alwaysApply`) with
+  a markdown instruction body. An independent, competitively-differentiated vendor converging on the same shape as
+  Claude Code's rules files is the corroboration that makes the hybrid format a pattern rather than one vendor's
+  idiosyncrasy. Cursor's team-beats-project precedence direction also documents that no cross-tool layering consensus
+  exists.
+- **Evidence status:** corroborated by A2
+
+### A13: Claude Code plugins reference — recommendation-bearing
+
+- **Link / location:** https://code.claude.com/docs/en/plugins-reference
+- **Retrieved:** 2026-07-23
+- **Trust class:** web
+- **Summary:** States that a CLAUDE.md at a plugin's root is not loaded as project context, and that plugin `userConfig`
+  values are stored and read only from user-scope settings, with project and local entries ignored. Together these force
+  a per-repo override into a file the consuming project carries and Han's skills read themselves. Both claims come from
+  this one page; validation flagged them as single-sourced and untested against a live install, so they are provisional
+  pending an empirical check.
+- **Evidence status:** single source (caveated, load-bearing)
+
+### A14: Claude Code skills docs — recommendation-bearing
+
+- **Link / location:** https://code.claude.com/docs/en/skills
+- **Retrieved:** 2026-07-23
+- **Trust class:** web
+- **Summary:** Documents `${CLAUDE_PROJECT_DIR}` substitution in skill bodies and dynamic context injection: an inline
+  `` !`command` `` runs before the model sees the skill content and its stdout is spliced into the prompt verbatim.
+  This is the mechanism that makes deterministic loading of an optional project config possible. Validation confirmed
+  Han's own skills prove the mechanism independently, so this source is confirmatory rather than load-bearing.
+- **Evidence status:** corroborated by A18, A23
+
+### A18: Han three-tier context fallback — recommendation-bearing
+
+- **Link / location:** han-coding/skills/code-review/SKILL.md:16-89
+- **Retrieved:** n/a
+- **Trust class:** codebase
+- **Summary:** Code-review, and more than fifteen sibling skills, resolve project context through `!`-command probes
+  and a fixed fallback chain: CLAUDE.md's `## Project Discovery` section, then `project-discovery.md`, then Glob
+  defaults. This working pattern is the load-bearing proof that a `.han/config.md` probe is feasible and consistent
+  with the suite's conventions, and it is the chain the new file would slot into.
+- **Evidence status:** corroborated across the suite; validated directly in V6
+
+### A20: Han agent roster tables — recommendation-bearing
+
+- **Link / location:** han-planning/skills/plan-implementation/SKILL.md:150-195; han-coding/skills/code-review/SKILL.md:214-234; han-research/skills/research/SKILL.md:137-169
+- **Retrieved:** n/a
+- **Trust class:** codebase
+- **Summary:** Agent rosters are hardcoded tables in each dispatching skill, selected by signals and capped by size
+  band, with user override by explicit naming. This is where a project-supplied "also consider these agents" override
+  must hook in, and why the recommendation requires validating any supplied agent name against the actual roster and
+  caps before honoring it.
+- **Evidence status:** corroborated (three dispatching skills read directly)
+
+### A21: project-discovery skill — recommendation-bearing
+
+- **Link / location:** han-core/skills/project-discovery/SKILL.md:1-107
+- **Retrieved:** n/a
+- **Trust class:** codebase
+- **Summary:** Han's existing precedent for machine-written, skill-consumed project context. It writes a structured
+  section into CLAUDE.md or AGENTS.md, with deduplication, because the host auto-loads those files. Validation noted
+  this precedent maps more literally onto O3 than O1, which is why the recommendation pairs the `.han/` file with a
+  CLAUDE.md pointer this skill could offer to write.
+- **Evidence status:** corroborated by A18 (its consumers)

--- a/docs/research/han-config-extensibility.md
+++ b/docs/research/han-config-extensibility.md
@@ -2,26 +2,31 @@
 
 The question: how should Han support per-project configuration overrides, such as a `.han/` folder at a consuming
 project's root, for things like "write all markdown outputs to `.scratch/`" and "when picking agents to dispatch for a
-skill, also consider these extra agents"? Which format fits best (JSON or markdown), where should the config live
-(`.han/`, `.claude/rules/`, or CLAUDE.md), and how should every skill read it consistently?
+skill, also consider these extra agents"? Which format fits best, JSON or markdown? Where should the config live, in
+`.han/`, `.claude/rules/`, or CLAUDE.md? And how should every skill read it consistently?
 
 Evidence mode: strict.
 
 ## Summary
 
-Use a markdown config file in a `.han/` folder at the project root, and have each Han skill load it the same
-deterministic way the skills already load project context today. Markdown wins over JSON because most of the overrides
-you want are instructions a language model must interpret, not values a parser checks, and the industry pattern across
-AI coding tools splits exactly this way: structured settings in JSON or YAML, open-ended instructions in markdown. A
-small YAML frontmatter block on that markdown file can carry the few settings that are simple values, such as an output
-directory. The `.claude/rules/` and CLAUDE.md routes both work only as soft guidance the model may or may not follow;
-reading the file from inside each skill is the only route where the config is guaranteed to be in front of the model
-every time a skill runs.
+Store Han's project-level settings in one dedicated markdown file kept at the root of the consuming project, and have
+every Han skill read that file the same reliable way skills already read project context today.
 
-The recommendation's shape is well-corroborated: the format pattern is confirmed by two independent vendors, and the
-loading mechanism is proven working in Han's own skills today. The finer design choices inside it (where the file sits
-in the precedence order, one file versus a folder of files) are design proposals this research did not find settled
-answers for, and one structural constraint rests on a single documentation page.
+Markdown fits better than a structured format like JSON, because most of the overrides people want are instructions a
+language model has to interpret, not fixed values a program checks. Every AI coding tool surveyed splits its
+configuration the same way: structured settings go in a format like JSON or YAML, and open-ended instructions go in
+markdown. A small block of structured values at the top of that markdown file can still hold the handful of settings
+that are simple choices, such as an output directory.
+
+Two other places could hold this configuration instead, but both work only as soft guidance that a language model may
+or may not follow. Reading the settings file directly from inside each skill is the only approach that guarantees the
+configuration reaches the model every time a skill runs.
+
+This recommendation is well supported. Two independent vendors confirm the same format pattern, and Han's own skills
+already prove the loading mechanism works today. Some of the finer design choices are less settled: research did not
+find a firm answer for where this new settings file should rank against other sources of configuration, or whether it
+should be one file or a folder of files, and one structural limit on the approach rests on a single documentation
+page.
 
 - **Confidence:** Medium
 
@@ -39,7 +44,7 @@ EditorConfig deliberately rejected JSON and YAML for a flat INI format on readab
 Two vendors independently converged on a hybrid shape for rule files: a small YAML frontmatter block of machine-readable
 keys on top of a markdown body of prose instructions. Claude Code's `.claude/rules/*.md` files use a `paths` frontmatter
 glob (A2); Cursor's `.cursor/rules/*.mdc` files use `description`, `globs`, and `alwaysApply` (A3). The convergence is
-meaningful corroboration that the hybrid is a real pattern, though the two tools disagree on key names and even on
+meaningful corroboration that the hybrid is a real pattern. But the two tools disagree on key names and even on
 precedence direction: Claude Code and VS Code let project config beat user config (A2, A8), while Cursor lets team rules
 beat project rules (A3). There is no cross-tool standard to inherit here. The AGENTS.md standard goes the other
 direction entirely: plain markdown, no schema at all, with nesting as its only structure (A1).
@@ -63,21 +68,28 @@ Two constraints force the config into the consuming project. First, a CLAUDE.md 
 project context, so Han cannot bundle instructions that become live on install (A13 [single-source]). Second, the
 plugin manifest's `userConfig` mechanism is stored and read only from user-scope settings; project and local settings
 entries are ignored, so it cannot carry a per-repo, version-controlled override (A13 [single-source]). Both claims come
-from the same official documentation page and were not tested against a live plugin install (flagged in V7). Whether
-Claude Code tolerates arbitrary custom keys in a project's `.claude/settings.json` is not answered by the settings
-documentation either way (A12 [single-source]).
+from the same official documentation page and were not tested against a live plugin install (flagged in V7).
+
+One related question stays open: whether Claude Code tolerates arbitrary custom keys in a project's
+`.claude/settings.json` is not answered by the settings documentation either way (A12 [single-source]).
 
 ### Han already has the machinery a config file would plug into
 
 Han's skills resolve project context through a consistent three-tier fallback: read CLAUDE.md's `## Project Discovery`
-section, fall back to `project-discovery.md`, fall back to Glob defaults (A18). The `project-discovery` skill is the
-existing precedent for machine-written, skill-consumed project context, and it writes into CLAUDE.md or AGENTS.md
-precisely because the host loads those files automatically (A21). Output paths are resolved per skill in prose, with
-real inconsistencies (code-overview writes outside the repository while planning skills target `docs/`) (A19). Agent
-rosters are hardcoded tables in each SKILL.md with signal-based selection and band caps, and today there is no
-extension point for project-supplied agents (A20). A narrow search did not surface another Claude Code plugin suite
-with a `.han/`-style config folder, and a community feature request confirms per-project plugin configuration was a
-recognized gap as of late 2025 (A16, A17 [single-source]); read that as "not found," not "does not exist" (V5).
+section, fall back to `project-discovery.md`, fall back to Glob defaults (A18).
+
+The `project-discovery` skill is the existing precedent for machine-written, skill-consumed project context, and it
+writes into CLAUDE.md or AGENTS.md precisely because the host loads those files automatically (A21).
+
+Output paths are resolved per skill in prose, with real inconsistencies: code-overview writes outside the repository,
+while planning skills target `docs/` (A19).
+
+Agent rosters are hardcoded tables in each SKILL.md with signal-based selection and band caps, and today there is no
+extension point for project-supplied agents (A20).
+
+A narrow search did not surface another Claude Code plugin suite with a `.han/`-style config folder. A community
+feature request confirms per-project plugin configuration was a recognized gap as of late 2025 (A16, A17
+[single-source]); read that as "not found," not "does not exist" (V5).
 
 One scoping fact matters for rollout: only 26 of the 49 SKILL.md files in the repo have a `## Project Context` block to
 extend. The other 15 real skills (the Atlassian and Linear wrappers, the communication skills, the plugin-builder
@@ -92,10 +104,10 @@ skills, and a few others) would need a separate decision about whether project o
   consider per skill, output conventions). Each participating skill adds a probe to its `## Project Context` block, such
   as `` !`cat .han/config.md 2>/dev/null` ``, plus a short resolution step that honors what the file supplies.
 - **Trade-offs:** The config is guaranteed in context every time a participating skill runs, independent of the model's
-  judgment. Han fully owns the schema. The costs: it is a Han-invented convention with no native discoverability
-  (nothing in Claude Code surfaces `.han/` to the user), the rollout touches every participating skill (26 have the
-  block today; 15 need a scoping decision), and malformed or invalid content needs an explicit graceful-degradation
-  rule so a bad file cannot silently break dispatch (V9).
+  judgment. Han fully owns the schema. The costs: it is a Han-invented convention with no native discoverability,
+  since nothing in Claude Code surfaces `.han/` to the user. The rollout touches every participating skill: 26 have
+  the block today, and 15 need a scoping decision. And malformed or invalid content needs an explicit
+  graceful-degradation rule, so a bad file cannot silently break dispatch (V9).
 - **Rests on:** (A13), (A14), (A18), (A20), (A23); format choice on (A2), (A3).
 - **Evidence status:** corroborated (loading mechanism proven in-repo; format pattern confirmed by two independent
   vendors). The "must live in the consuming project" constraint is single-source (A13).
@@ -105,8 +117,8 @@ skills, and a few others) would need a separate decision about whether project o
 - **What it is:** The consuming project writes Han's overrides into a Claude Code rules file, which loads ambiently and
   shows up in `/memory` and `/context`.
 - **Trade-offs:** First-class, Anthropic-maintained surface with zero custom parsing in Han. But it is pure guidance
-  with a documented soft-compliance ceiling (A2), the path-scoping frontmatter has a reported reliability bug (A15),
-  the content occupies context in every session whether or not a Han skill runs, and no skill can verify it loaded.
+  with a documented soft-compliance ceiling (A2). The path-scoping frontmatter has a reported reliability bug (A15).
+  The content occupies context in every session, whether or not a Han skill runs, and no skill can verify it loaded.
   Structured overrides such as roster extensions are exactly what free-text ambient rules handle worst.
 - **Rests on:** (A2), (A15).
 - **Evidence status:** corroborated for the mechanism; the reliability caveat is single-source (A15).
@@ -116,8 +128,8 @@ skills, and a few others) would need a separate decision about whether project o
 - **What it is:** A named section beside `## Project Discovery`, which Han's skills already know how to find and read.
 - **Trade-offs:** The tightest match to Han's existing read pattern; validation found this precedent analogy stronger
   for O3 than for O1, since `project-discovery` targets CLAUDE.md precisely because the host auto-loads it (V3). Skills
-  could still read the section explicitly for determinism. The costs: it grows an always-loaded file Anthropic
-  recommends keeping lean, Han cannot seed or validate the section from the plugin side (A13), and mixing Han's
+  could still read the section explicitly for determinism. The costs: it grows an always-loaded file that Anthropic
+  recommends keeping lean. Han cannot seed or validate the section from the plugin side (A13). And mixing Han's
   override schema into a team's shared narrative file invites drift and merge friction.
 - **Rests on:** (A2), (A13), (A18), (A21).
 - **Evidence status:** corroborated.
@@ -128,7 +140,7 @@ skills, and a few others) would need a separate decision about whether project o
 - **Trade-offs:** Deterministic to parse and easy to validate, and the right shape for values a program checks. But
   the overrides you named are mostly instructions a model interprets, and no surveyed source shows JSON handling
   open-ended guidance without degrading into prose stuffed inside strings (A10 [single-source]). Whether custom keys in
-  `settings.json` are tolerated long-term is unconfirmed (A12), and Claude Code already warns on unknown plugin-manifest
+  `settings.json` are tolerated long-term is unconfirmed (A12). Claude Code already warns on unknown plugin-manifest
   fields under strict validation, suggesting Anthropic tightens unknown-key handling over time (A13).
 - **Rests on:** (A10), (A12), (A13).
 - **Evidence status:** single-source (caveated) on the format trade-off claims; inconclusive on settings.json custom
@@ -138,27 +150,30 @@ skills, and a few others) would need a separate decision about whether project o
 
 - **Recommendation:** O1. Create a `.han/config.md` file: YAML frontmatter for the few simple values, named markdown
   sections for the prose overrides, loaded by each participating skill through the same `!`-probe pattern the skills
-  already use. Start with one file rather than a folder of files; that is a deliberate simplification to avoid
-  speculative structure, not a claim that one file is superior on the merits, and splitting into per-concern files
-  later carries a migration cost (V8). Treat O3 as the close runner-up and a natural complement: the
-  `project-discovery` skill could offer to write a pointer to `.han/config.md` into CLAUDE.md so the config is
-  discoverable in the file every contributor already reads. Scope the rollout to the skills that already carry a
-  `## Project Context` block and resolve project context today; decide separately whether the wrapper and builder
-  skills participate at all (V2). Specify graceful degradation up front: unparseable content or unknown keys are
-  ignored with a one-line note to the user, and any project-supplied agent name is validated against the skill's actual
-  roster and band caps before it is honored (V9).
+  already use.
+  - Start with one file rather than a folder of files. That is a deliberate simplification to avoid speculative
+    structure, not a claim that one file is superior on the merits, and splitting into per-concern files later carries
+    a migration cost (V8).
+  - Treat O3 as the close runner-up and a natural complement: the `project-discovery` skill could offer to write a
+    pointer to `.han/config.md` into CLAUDE.md, so the config is discoverable in the file every contributor already
+    reads.
+  - Scope the rollout to the skills that already carry a `## Project Context` block and resolve project context
+    today. Decide separately whether the wrapper and builder skills participate at all (V2).
+  - Specify graceful degradation up front: unparseable content or unknown keys are ignored with a one-line note to the
+    user, and any project-supplied agent name is validated against the skill's actual roster and band caps before it
+    is honored (V9).
 - **Proposed precedence, marked as a design proposal:** explicit user input, then `.han/config.md`, then CLAUDE.md's
   `## Project Discovery`, then `project-discovery.md`, then Glob defaults. No source establishes this ordering; it is a
   design choice to validate in use, and it carries a visibility trade-off: a value the user can see in CLAUDE.md would
   be silently outranked by a file they may forget exists (V4).
-- **Evidence basis:** The format choice (markdown with optional frontmatter over JSON) rests on corroborated evidence:
-  two independent vendors converged on the hybrid shape (A2, A3), and the settings-versus-instructions split recurs
+- **Evidence basis:** The format choice (markdown with optional frontmatter over JSON) rests on corroborated evidence.
+  Two independent vendors converged on the hybrid shape (A2, A3), and the settings-versus-instructions split recurs
   across Claude Code, Gemini CLI, and Aider (A2, A5, A6, A7). The loading mechanism rests on codebase-verified evidence
   (A18, A23) with the official skills documentation as confirmation (A14). The constraint forcing the config into the
-  consuming project rests on a single official documentation page (A13) and deserves a cheap empirical check (install a
-  plugin with a project-scoped `userConfig` entry and see whether it is honored) before implementation locks in. The
-  absence of ecosystem precedent is a narrow negative search result (A16, A17), not corroborated proof the pattern is
-  safe.
+  consuming project rests on a single official documentation page (A13). It deserves a cheap empirical check before
+  implementation locks in: install a plugin with a project-scoped `userConfig` entry and see whether it is honored.
+  The absence of ecosystem precedent is a narrow negative search result (A16, A17), not corroborated proof the pattern
+  is safe.
 
 ## Validation
 
@@ -252,16 +267,21 @@ sub-decisions were corrected or reframed.
 
 ### Adjustments Made
 
-Validation changed the report in five places: the YAGNI objection was re-grounded (V1), the rollout was scoped to the
-26 skills with a `## Project Context` block (V2), O3 was elevated to complement status with the CLAUDE.md-pointer idea
-(V3), the precedence order and single-file choice were relabeled as design proposals (V4, V8), and the
-graceful-degradation requirement was added (V9). The recommendation itself survived.
+Validation changed the report in five places:
+
+1. The YAGNI objection was re-grounded (V1).
+2. The rollout was scoped to the 26 skills with a `## Project Context` block (V2).
+3. O3 was elevated to complement status, with the CLAUDE.md-pointer idea added (V3).
+4. The precedence order and single-file choice were relabeled as design proposals (V4, V8).
+5. The graceful-degradation requirement was added (V9).
+
+The recommendation itself survived.
 
 ### Confidence Assessment
 
 - **Confidence:** Medium
 - **Remaining Risks:** The "config must live in the consuming project" constraint rests on one documentation page
-  (A13) and has not been tested against a live plugin install; if wrong, JSON-plus-userConfig options reopen. The
+  (A13) and has not been tested against a live plugin install. If wrong, JSON-plus-userConfig options reopen. The
   rollout blast radius across the 15 skills without a `## Project Context` block needs a scoping decision before
   implementation. No precedent from another plugin suite validates the `.han/` pattern in production (A16, A17). Web
   sources are dated by access only, so documentation drift is possible.
@@ -296,7 +316,7 @@ graceful-degradation requirement was added (V9). The recommendation itself survi
 | A24 | No existing override mechanism in Han         | repo-wide grep; han-core/agents/junior-developer.md:289                      | n/a        | codebase    | No `.han/` or per-project override anywhere; "speculative configuration knobs" named an anti-pattern | corroborated (validated in V1)           |
 | A25 | Skill composition pattern                     | han-plugin-builder/skills/guidance/references/skill-building-guidance/skill-composition.md | n/a | codebase    | Skills compose via Skill-tool invocation; config informs selection inside existing flows   | corroborated by A18                      |
 
-### A2: Claude Code memory docs — recommendation-bearing
+### A2: Claude Code memory docs (recommendation-bearing)
 
 - **Link / location:** https://code.claude.com/docs/en/memory
 - **Retrieved:** 2026-07-23
@@ -308,7 +328,7 @@ graceful-degradation requirement was added (V9). The recommendation itself survi
   soft-compliance ceiling that rules out ambient-only designs.
 - **Evidence status:** corroborated by A3 (hybrid pattern) and A15 (reliability caveat)
 
-### A3: Cursor rules docs — recommendation-bearing
+### A3: Cursor rules docs (recommendation-bearing)
 
 - **Link / location:** https://cursor.com/docs/rules.md
 - **Retrieved:** 2026-07-23
@@ -320,7 +340,7 @@ graceful-degradation requirement was added (V9). The recommendation itself survi
   exists.
 - **Evidence status:** corroborated by A2
 
-### A13: Claude Code plugins reference — recommendation-bearing
+### A13: Claude Code plugins reference (recommendation-bearing)
 
 - **Link / location:** https://code.claude.com/docs/en/plugins-reference
 - **Retrieved:** 2026-07-23
@@ -332,7 +352,7 @@ graceful-degradation requirement was added (V9). The recommendation itself survi
   pending an empirical check.
 - **Evidence status:** single source (caveated, load-bearing)
 
-### A14: Claude Code skills docs — recommendation-bearing
+### A14: Claude Code skills docs (recommendation-bearing)
 
 - **Link / location:** https://code.claude.com/docs/en/skills
 - **Retrieved:** 2026-07-23
@@ -343,7 +363,7 @@ graceful-degradation requirement was added (V9). The recommendation itself survi
   Han's own skills prove the mechanism independently, so this source is confirmatory rather than load-bearing.
 - **Evidence status:** corroborated by A18, A23
 
-### A18: Han three-tier context fallback — recommendation-bearing
+### A18: Han three-tier context fallback (recommendation-bearing)
 
 - **Link / location:** han-coding/skills/code-review/SKILL.md:16-89
 - **Retrieved:** n/a
@@ -354,7 +374,7 @@ graceful-degradation requirement was added (V9). The recommendation itself survi
   with the suite's conventions, and it is the chain the new file would slot into.
 - **Evidence status:** corroborated across the suite; validated directly in V6
 
-### A20: Han agent roster tables — recommendation-bearing
+### A20: Han agent roster tables (recommendation-bearing)
 
 - **Link / location:** han-planning/skills/plan-implementation/SKILL.md:150-195; han-coding/skills/code-review/SKILL.md:214-234; han-research/skills/research/SKILL.md:137-169
 - **Retrieved:** n/a
@@ -365,7 +385,7 @@ graceful-degradation requirement was added (V9). The recommendation itself survi
   caps before honoring it.
 - **Evidence status:** corroborated (three dispatching skills read directly)
 
-### A21: project-discovery skill — recommendation-bearing
+### A21: project-discovery skill (recommendation-bearing)
 
 - **Link / location:** han-core/skills/project-discovery/SKILL.md:1-107
 - **Retrieved:** n/a

--- a/docs/research/han-config-extensibility.md
+++ b/docs/research/han-config-extensibility.md
@@ -102,7 +102,7 @@ skills, and a few others) would need a separate decision about whether project o
 - **What it is:** One markdown file in a `.han/` folder at the project root. Optional YAML frontmatter carries the few
   simple values (an output directory, for example); named markdown sections carry the prose overrides (extra agents to
   consider per skill, output conventions). Each participating skill adds a probe to its `## Project Context` block, such
-  as `` !`cat .han/config.md 2>/dev/null` ``, plus a short resolution step that honors what the file supplies.
+  as `` !`cat .han/config.md 2>/dev/null || echo ""` ``, plus a short resolution step that honors what the file supplies.
 - **Trade-offs:** The config is guaranteed in context every time a participating skill runs, independent of the model's
   judgment. Han fully owns the schema. The costs: it is a Han-invented convention with no native discoverability,
   since nothing in Claude Code surfaces `.han/` to the user. The rollout touches every participating skill: 26 have

--- a/han-atlassian/references/config-rule.md
+++ b/han-atlassian/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-atlassian/skills/code-overview-to-confluence/SKILL.md
+++ b/han-atlassian/skills/code-overview-to-confluence/SKILL.md
@@ -17,7 +17,7 @@ allowed-tools: Read, Glob, Grep, Skill, Agent, Bash(find *), mcp__claude_ai_Atla
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-atlassian/skills/code-overview-to-confluence/SKILL.md
+++ b/han-atlassian/skills/code-overview-to-confluence/SKILL.md
@@ -15,6 +15,14 @@ argument-hint:
 allowed-tools: Read, Glob, Grep, Skill, Agent, Bash(find *), mcp__claude_ai_Atlassian__getAccessibleAtlassianResources
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 # Code Overview to Confluence
 
 This skill runs a progressive-disclosure code overview with the core `han-coding:code-overview` skill, lets the user

--- a/han-atlassian/skills/code-overview-to-confluence/SKILL.md
+++ b/han-atlassian/skills/code-overview-to-confluence/SKILL.md
@@ -69,10 +69,12 @@ the relevant conversation context. Do not summarize, trim, or reinterpret the us
 `han-coding:code-overview` runs exactly as it would on its own (target resolution, mode and size selection, parallel
 `codebase-explorer` exploration, synthesis, and the readability-review pass).
 
-`han-coding:code-overview` already writes its overview to a scratch file outside the repository and changes no code, so
-this skill adds no behavioral instructions — it only needs the resulting file. **Capture the exact scratch-file path it
-wrote** (for example `${TMPDIR:-/tmp}/code-overview-<slug>.md`). That markdown file is the source content for
-Confluence. Proceed to Step 3 once it finishes.
+`han-coding:code-overview` already writes its overview to a scratch file outside the repository and changes no code —
+**except** add one explicit instruction: it must write the overview to an explicit scratch path this skill names (for
+example `${TMPDIR:-/tmp}/code-overview-<slug>.md`). Passing the path explicitly keeps the file where this skill expects
+it even when the project's `.han/config.md` configures an output directory, because explicit input outranks the config
+(see [../../references/config-rule.md](../../references/config-rule.md)). **Capture the exact scratch-file path it
+wrote.** That markdown file is the source content for Confluence. Proceed to Step 3 once it finishes.
 
 ## Step 3: Show the File for Review
 

--- a/han-atlassian/skills/investigate-to-confluence/SKILL.md
+++ b/han-atlassian/skills/investigate-to-confluence/SKILL.md
@@ -14,6 +14,14 @@ argument-hint:
 allowed-tools: Read, Glob, Grep, Skill, Agent, Bash(find *), mcp__claude_ai_Atlassian__getAccessibleAtlassianResources
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 # Investigate to Confluence
 
 This skill runs an evidence-based investigation with the core `han-coding:investigate` skill, lets the user review the

--- a/han-atlassian/skills/investigate-to-confluence/SKILL.md
+++ b/han-atlassian/skills/investigate-to-confluence/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Read, Glob, Grep, Skill, Agent, Bash(find *), mcp__claude_ai_Atla
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-atlassian/skills/investigate-to-confluence/SKILL.md
+++ b/han-atlassian/skills/investigate-to-confluence/SKILL.md
@@ -70,7 +70,8 @@ adversarial validation, and the final report) — **except** add two explicit in
 
 - It must write the resulting investigation report to a file under `/tmp/` (for example `/tmp/<symptom-slug>.md`) rather
   than into the project's docs or plans directory. This keeps the working report out of the repo until the user decides
-  to publish it.
+  to publish it, and because the path is explicit input it outranks any `output-directory` in the project's
+  `.han/config.md` (see [../../references/config-rule.md](../../references/config-rule.md)).
 - It must **stop after producing the report**. `han-coding:investigate` normally ends by presenting the plan for
   approval and can trigger the fix's implementation on approval; this skill wants the report only, so instruct it not to
   implement the fix or change any code — this skill publishes findings, it does not ship them.

--- a/han-atlassian/skills/markdown-to-confluence/SKILL.md
+++ b/han-atlassian/skills/markdown-to-confluence/SKILL.md
@@ -16,6 +16,14 @@ allowed-tools:
   mcp__claude_ai_Atlassian__updateConfluencePage
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 # Markdown to Confluence
 
 This skill takes one local Markdown file and publishes it to a Confluence location that **the user must specify** —

--- a/han-atlassian/skills/markdown-to-confluence/SKILL.md
+++ b/han-atlassian/skills/markdown-to-confluence/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools:
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-atlassian/skills/plan-a-feature-to-confluence/SKILL.md
+++ b/han-atlassian/skills/plan-a-feature-to-confluence/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools:
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-atlassian/skills/plan-a-feature-to-confluence/SKILL.md
+++ b/han-atlassian/skills/plan-a-feature-to-confluence/SKILL.md
@@ -75,7 +75,9 @@ it through so `han-planning:plan-a-feature` runs exactly as it would on its own 
 resolution, and project-manager synthesis included — **except** add one explicit instruction: it must write its output
 folder under `/tmp/` (for example `/tmp/<feature-slug>/`) rather than into the repo's docs directory, and it should not
 prompt the user to choose or confirm an output location, because this skill owns that decision. This keeps the working
-plan out of the repo until the user decides to publish it.
+plan out of the repo until the user decides to publish it, and because the path is explicit input it outranks any
+`output-directory` in the project's `.han/config.md` (see
+[../../references/config-rule.md](../../references/config-rule.md)).
 
 Let `han-planning:plan-a-feature` complete its full process. **Capture the exact `/tmp/` paths of every file it wrote:**
 

--- a/han-atlassian/skills/plan-a-feature-to-confluence/SKILL.md
+++ b/han-atlassian/skills/plan-a-feature-to-confluence/SKILL.md
@@ -16,6 +16,14 @@ allowed-tools:
   Read, Write, Edit, Glob, Grep, Skill, Bash(find *), mcp__claude_ai_Atlassian__getAccessibleAtlassianResources
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 # Plan a Feature to Confluence
 
 This skill builds a feature specification with the core `han-planning:plan-a-feature` skill, lets the user review the

--- a/han-atlassian/skills/project-documentation-to-confluence/SKILL.md
+++ b/han-atlassian/skills/project-documentation-to-confluence/SKILL.md
@@ -17,7 +17,7 @@ allowed-tools:
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-atlassian/skills/project-documentation-to-confluence/SKILL.md
+++ b/han-atlassian/skills/project-documentation-to-confluence/SKILL.md
@@ -60,7 +60,9 @@ the feature name or document path argument, the scope, any known entry points, a
 not summarize, trim, or reinterpret the user's context; pass it through so `han-documentation:project-documentation` runs exactly
 as it would on its own — **except** add one explicit instruction: it must write the resulting documentation to a file
 under `/tmp/` (for example `/tmp/<feature-slug>.md`) rather than into the project's docs directory. This keeps the
-working draft out of the repo until the user decides to publish it.
+working draft out of the repo until the user decides to publish it, and because the path is explicit input it outranks
+any `output-directory` in the project's `.han/config.md` (see
+[../../references/config-rule.md](../../references/config-rule.md)).
 
 Let `han-documentation:project-documentation` complete its full process (codebase exploration, writing the doc, content audit,
 information-architecture review, and verification). **Capture the exact `/tmp/` file path it wrote.** That markdown file

--- a/han-atlassian/skills/project-documentation-to-confluence/SKILL.md
+++ b/han-atlassian/skills/project-documentation-to-confluence/SKILL.md
@@ -15,6 +15,14 @@ allowed-tools:
   mcp__claude_ai_Atlassian__getAccessibleAtlassianResources
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 # Project Documentation to Confluence
 
 This skill produces project documentation with the `han-documentation:project-documentation` skill, lets the user review the

--- a/han-atlassian/skills/work-items-to-jira/SKILL.md
+++ b/han-atlassian/skills/work-items-to-jira/SKILL.md
@@ -21,7 +21,7 @@ allowed-tools:
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-atlassian/skills/work-items-to-jira/SKILL.md
+++ b/han-atlassian/skills/work-items-to-jira/SKILL.md
@@ -19,6 +19,14 @@ allowed-tools:
   mcp__claude_ai_Atlassian__transitionJiraIssue, mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 # Work Items to Jira Tickets
 
 Take an already-broken-down `work-items.md` file (produced by `/plan-work-items`) and publish each slice as a Jira

--- a/han-coding/references/config-rule.md
+++ b/han-coding/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-coding/skills/architectural-analysis/SKILL.md
+++ b/han-coding/skills/architectural-analysis/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools: Read, Glob, Grep, Agent, Bash(find *)
 - git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-coding/skills/architectural-analysis/SKILL.md
+++ b/han-coding/skills/architectural-analysis/SKILL.md
@@ -155,6 +155,11 @@ note the omitted domains in the executive summary so the user can re-run larger.
 and `han-core:on-call-engineer` are signalled, prefer `han-core:on-call-engineer` if the focus area is application
 source and `han-core:devops-engineer` if it is infrastructure or pipelines; include both at large size only.
 
+Extra agents named in the project config's `## Extra Agents` list join the signal-selected specialist pool and compete
+under the same signals and band caps, per [../../references/config-rule.md](../../references/config-rule.md): add one
+only when a signal in the focus area matches its stated specialty, count it against the band's cap, and skip an entry
+that does not resolve to a dispatchable agent with a one-line note.
+
 `han-core:system-architect` is the only specialist that changes `han-core:software-architect`'s behavior: when
 `han-core:system-architect` is on the roster, `han-core:software-architect` still defers boundary-crossing findings but
 the report carries `han-core:system-architect`'s recommendations for them instead of only listing them as deferred.

--- a/han-coding/skills/architectural-analysis/SKILL.md
+++ b/han-coding/skills/architectural-analysis/SKILL.md
@@ -18,6 +18,11 @@ allowed-tools: Read, Glob, Grep, Agent, Bash(find *)
 - git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Operating Principles
 

--- a/han-coding/skills/automated-test-planning/SKILL.md
+++ b/han-coding/skills/automated-test-planning/SKILL.md
@@ -124,6 +124,11 @@ Inspect the file list before launching. Skip any that do not apply.
    bypass, injection, broken isolation, insecure defaults. Return test recommendations, not general threat modeling.
    {any additional context from user arguments}"
 
+Extra agents named in the project config's `## Extra Agents` list join this conditional-dispatch pool under the same
+file-list-signal selection, per [../../references/config-rule.md](../../references/config-rule.md): dispatch one only
+when the file list carries a signal matching its stated specialty, and skip an entry that does not resolve to a
+dispatchable agent with a one-line note.
+
 Wait for every dispatched agent to complete and collect full output for processing in Step 3.
 
 ## Step 3: Merge and Prioritize

--- a/han-coding/skills/automated-test-planning/SKILL.md
+++ b/han-coding/skills/automated-test-planning/SKILL.md
@@ -38,7 +38,7 @@ allowed-tools: Bash(git *), Bash(find *), Bash(ls *), Read, Grep, Glob, Agent
 - git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-coding/skills/automated-test-planning/SKILL.md
+++ b/han-coding/skills/automated-test-planning/SKILL.md
@@ -38,6 +38,11 @@ allowed-tools: Bash(git *), Bash(find *), Bash(ls *), Read, Grep, Glob, Agent
 - git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Step 1: Determine Scope
 

--- a/han-coding/skills/code-overview/SKILL.md
+++ b/han-coding/skills/code-overview/SKILL.md
@@ -22,7 +22,7 @@ allowed-tools: Read, Glob, Grep, Agent, Write, Bash(git *), Bash(gh *), Bash(fin
 - gh installed: !`which gh 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-coding/skills/code-overview/SKILL.md
+++ b/han-coding/skills/code-overview/SKILL.md
@@ -22,6 +22,11 @@ allowed-tools: Read, Glob, Grep, Agent, Write, Bash(git *), Bash(gh *), Bash(fin
 - gh installed: !`which gh 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Operating Principles
 

--- a/han-coding/skills/code-review/SKILL.md
+++ b/han-coding/skills/code-review/SKILL.md
@@ -18,7 +18,7 @@ When running a code review, follow the process outlined here.
 - git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-coding/skills/code-review/SKILL.md
+++ b/han-coding/skills/code-review/SKILL.md
@@ -18,6 +18,11 @@ When running a code review, follow the process outlined here.
 - git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Review Constraints
 

--- a/han-coding/skills/code-review/SKILL.md
+++ b/han-coding/skills/code-review/SKILL.md
@@ -240,6 +240,11 @@ the rubric in `references/agent-finding-classification.md`. Do not re-derive siz
 **Selection rules:**
 
 - Honor any agent the user named explicitly.
+- Extra agents named in the project config's `## Extra Agents` list join this candidate pool and compete under the same
+  signal-based selection as the roster above, per
+  [../../references/config-rule.md](../../references/config-rule.md): include one only when a signal in the file list
+  matches its stated specialty, justify the inclusion in one line, and skip an entry that does not resolve to a
+  dispatchable agent with a one-line note.
 - For each conditional agent included, justify in one line — name the file or signal that triggered inclusion.
 - Fewer is better. If a signal is borderline, **skip** the agent rather than include it. A small change that nominally
   touches a query but is not modifying its behavior does not require `han-core:data-engineer`.

--- a/han-coding/skills/coding-standard/SKILL.md
+++ b/han-coding/skills/coding-standard/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(mkdir *), Bash(find *)
 - AGENTS.md: !`find . -maxdepth 1 -name "AGENTS.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
 - Rules directory: !`find . -maxdepth 4 -type d -path "*/.claude/rules/coding-standards"`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-coding/skills/coding-standard/SKILL.md
+++ b/han-coding/skills/coding-standard/SKILL.md
@@ -16,6 +16,11 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(mkdir *), Bash(find *)
 - AGENTS.md: !`find . -maxdepth 1 -name "AGENTS.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
 - Rules directory: !`find . -maxdepth 4 -type d -path "*/.claude/rules/coding-standards"`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Step 1: Determine Mode
 

--- a/han-coding/skills/investigate/SKILL.md
+++ b/han-coding/skills/investigate/SKILL.md
@@ -77,6 +77,11 @@ every applicable specialist in parallel with the `han-core:evidence-based-invest
    {symptom}. Focus on the specific data-engineering principles violated and the concrete data-level impact. Return
    numbered findings keyed to file paths, line numbers, and schema or migration references."
 
+Extra agents named in the project config's `## Extra Agents` list join this conditional-specialist pool under the same
+symptom-driven selection, per [../../references/config-rule.md](../../references/config-rule.md): dispatch one only
+when the classified bug type matches its stated specialty, and skip an entry that does not resolve to a dispatchable
+agent with a one-line note.
+
 After all agents complete (investigators and specialists), compile an **evidence summary** — a numbered list of concrete
 findings (E1, E2, E3, ...) that will feed into the root cause analysis. Specialist findings go into the same E-series
 list, tagged with the specialist's domain (e.g., `E3 (concurrency)`).

--- a/han-coding/skills/investigate/SKILL.md
+++ b/han-coding/skills/investigate/SKILL.md
@@ -16,6 +16,11 @@ allowed-tools: Read, Glob, Grep, Agent
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Investigation Approach
 

--- a/han-coding/skills/investigate/SKILL.md
+++ b/han-coding/skills/investigate/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Read, Glob, Grep, Agent
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-coding/skills/manual-test-planning/SKILL.md
+++ b/han-coding/skills/manual-test-planning/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: Bash(git *), Read, Grep, Glob, Write, Agent
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-coding/skills/manual-test-planning/SKILL.md
+++ b/han-coding/skills/manual-test-planning/SKILL.md
@@ -12,6 +12,14 @@ argument-hint: "[optional: files, a branch, a plan, a PR, or a description of wh
 allowed-tools: Bash(git *), Read, Grep, Glob, Write, Agent
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 ## Operating Principles
 
 - **Group outcomes only when the steps are identical.** A test verifies a single outcome, or a group of related

--- a/han-coding/skills/refactor/SKILL.md
+++ b/han-coding/skills/refactor/SKILL.md
@@ -21,7 +21,7 @@ allowed-tools:
 - working tree: !`git status --porcelain 2>/dev/null | head -5`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-coding/skills/refactor/SKILL.md
+++ b/han-coding/skills/refactor/SKILL.md
@@ -21,6 +21,11 @@ allowed-tools:
 - working tree: !`git status --porcelain 2>/dev/null | head -5`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Constraints (read before anything else)
 

--- a/han-coding/skills/tdd/SKILL.md
+++ b/han-coding/skills/tdd/SKILL.md
@@ -21,7 +21,7 @@ allowed-tools:
 - current branch: !`git branch --show-current 2>/dev/null || echo unknown`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-coding/skills/tdd/SKILL.md
+++ b/han-coding/skills/tdd/SKILL.md
@@ -21,6 +21,11 @@ allowed-tools:
 - current branch: !`git branch --show-current 2>/dev/null || echo unknown`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Constraints (read before anything else)
 

--- a/han-communication/references/config-rule.md
+++ b/han-communication/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-communication/skills/edit-for-readability/SKILL.md
+++ b/han-communication/skills/edit-for-readability/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Read, Write, Glob, Grep, Agent
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-communication/skills/edit-for-readability/SKILL.md
+++ b/han-communication/skills/edit-for-readability/SKILL.md
@@ -14,6 +14,14 @@ argument-hint: "[path to a file, pasted text, or 'the draft above']"
 allowed-tools: Read, Write, Glob, Grep, Agent
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 # Edit for Readability
 
 Take a target the user already has and rewrite its prose against the shared readability standard, preserving every fact.

--- a/han-communication/skills/readability-guidance/SKILL.md
+++ b/han-communication/skills/readability-guidance/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Read
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-communication/skills/readability-guidance/SKILL.md
+++ b/han-communication/skills/readability-guidance/SKILL.md
@@ -10,6 +10,14 @@ description: >
 allowed-tools: Read
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 # Readability Guidance
 
 You have invoked `readability-guidance` to source the shared readability standard before you draft prose. This skill

--- a/han-core/docs/skills/project-discovery.md
+++ b/han-core/docs/skills/project-discovery.md
@@ -33,6 +33,11 @@ _how_ to use the skill. For what the skill does internally, read the skill defin
   Makefile was found), the skill surfaces the contradiction and asks which is correct.
 - **Multi-project aware.** Monorepos get repository-level bullets (default branch, docs, ADRs, coding standards, layout)
   plus one compact per-project block for each project's stack and commands.
+- **Keeps the `.han/config.md` pointer honest.** When the project carries a
+  [`.han/config.md`](../../../docs/configuration.md), the skill offers to add a one-line pointer to it beside the
+  Project Discovery section so the override file stays visible in the document every contributor reads. When the config
+  is gone but a pointer remains, it offers to remove the stale line. Both only with your consent, and never as a
+  duplicate of a reference that already exists.
 
 ## When to use it
 
@@ -104,7 +109,7 @@ two of fan-out plus merge time. Cheap enough to re-run on every major stack chan
 
 ## In more detail
 
-The skill walks a five-step process:
+The skill walks a six-step process:
 
 1. **Choose and read the target file.** Pick the file by priority (AGENTS.md, then CLAUDE.md, then a new CLAUDE.md).
    Read whichever exists to build the deduplication baseline of what is already documented.
@@ -115,7 +120,9 @@ The skill walks a five-step process:
 4. **Write the discovery into the target file.** Build a concise `## Project Discovery` section, drop every fact the
    file already states, ask about any contradiction, then add or update the section in place. If nothing new remains,
    write nothing.
-5. **Verification.** Spot-check a few discovered paths with Glob, confirm no placeholders remain, report results to you.
+5. **Keep the `.han/config.md` pointer honest.** When the config file exists and the target file does not reference it,
+   offer to add a one-line pointer; when the config is gone but a pointer remains, offer to remove it. Both consent-gated.
+6. **Verification.** Spot-check a few discovered paths with Glob, confirm no placeholders remain, report results to you.
 
 ## Sources
 

--- a/han-core/references/config-rule.md
+++ b/han-core/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-core/skills/project-discovery/SKILL.md
+++ b/han-core/skills/project-discovery/SKILL.md
@@ -15,6 +15,11 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(git symbolic-ref *), B
 - AGENTS.md: !`find . -maxdepth 1 -name "AGENTS.md" -type f`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - README: !`find . -maxdepth 1 -name "README*" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 # Project Discovery
 

--- a/han-core/skills/project-discovery/SKILL.md
+++ b/han-core/skills/project-discovery/SKILL.md
@@ -101,7 +101,24 @@ Then write the result into the target file:
 If, after deduplication, nothing meaningful remains to add, do **not** write an empty section. Tell the user the target
 file already covers the project's core attributes, and stop.
 
-## Step 5: Verification
+## Step 5: Keep the `.han/config.md` pointer honest
+
+Han skills read project-local overrides from `.han/config.md` when a project carries one (see
+[../../references/config-rule.md](../../references/config-rule.md)). This step keeps the target file's pointer to that
+config accurate, using the same consent gate and deduplication discipline as Step 4. The Project Context probe above
+shows whether the file exists.
+
+- **`.han/config.md` exists and the target file contains no reference to it:** use `AskUserQuestion` to offer adding a
+  one-line pointer beside the `## Project Discovery` section, for example:
+  `Han skills in this project read overrides from [.han/config.md](./.han/config.md).` Never add a pointer when any
+  reference to the file is already present, even phrased differently.
+- **`.han/config.md` does not exist but the target file still references it:** use `AskUserQuestion` to offer removing
+  the stale pointer.
+- **Otherwise:** do nothing and say nothing about the config.
+
+Write or remove the pointer only with the user's consent.
+
+## Step 6: Verification
 
 Read back the target file's `## Project Discovery` section. Confirm: no `{placeholder}` text remains, every bullet has a
 real discovered value, and nothing duplicates content stated elsewhere in the file. Spot-check 2-3 discovered paths or

--- a/han-core/skills/project-discovery/SKILL.md
+++ b/han-core/skills/project-discovery/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(git symbolic-ref *), B
 - AGENTS.md: !`find . -maxdepth 1 -name "AGENTS.md" -type f`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - README: !`find . -maxdepth 1 -name "README*" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-documentation/references/config-rule.md
+++ b/han-documentation/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-documentation/skills/architectural-decision-record/SKILL.md
+++ b/han-documentation/skills/architectural-decision-record/SKILL.md
@@ -38,6 +38,11 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(mkdir *), Bash(find *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Step 1: Determine Mode
 

--- a/han-documentation/skills/architectural-decision-record/SKILL.md
+++ b/han-documentation/skills/architectural-decision-record/SKILL.md
@@ -38,7 +38,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(mkdir *), Bash(find *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-documentation/skills/project-documentation/SKILL.md
+++ b/han-documentation/skills/project-documentation/SKILL.md
@@ -17,7 +17,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(date *), Bash(mkdir *)
 
 - CLAUDE.md exists: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-documentation/skills/project-documentation/SKILL.md
+++ b/han-documentation/skills/project-documentation/SKILL.md
@@ -17,6 +17,11 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(date *), Bash(mkdir *)
 
 - CLAUDE.md exists: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 # Project Documentation
 

--- a/han-documentation/skills/runbook/SKILL.md
+++ b/han-documentation/skills/runbook/SKILL.md
@@ -47,7 +47,7 @@ allowed-tools:
 - Today's date: !`date +%Y-%m-%d`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-documentation/skills/runbook/SKILL.md
+++ b/han-documentation/skills/runbook/SKILL.md
@@ -47,6 +47,11 @@ allowed-tools:
 - Today's date: !`date +%Y-%m-%d`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Step 1: Determine Mode
 

--- a/han-feedback/references/config-rule.md
+++ b/han-feedback/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-feedback/skills/han-feedback/SKILL.md
+++ b/han-feedback/skills/han-feedback/SKILL.md
@@ -12,6 +12,11 @@ allowed-tools: Read, Write, Bash(ls *), Bash(mkdir *), Bash(gh *), Bash(date *)
 ## Project Context
 
 - Today's date: !`date +%Y-%m-%d`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 # Capture Feedback
 

--- a/han-feedback/skills/han-feedback/SKILL.md
+++ b/han-feedback/skills/han-feedback/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Read, Write, Bash(ls *), Bash(mkdir *), Bash(gh *), Bash(date *)
 ## Project Context
 
 - Today's date: !`date +%Y-%m-%d`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-github/references/config-rule.md
+++ b/han-github/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-github/skills/post-code-review-to-pr/SKILL.md
+++ b/han-github/skills/post-code-review-to-pr/SKILL.md
@@ -24,6 +24,11 @@ be installed. In either case, immediately stop.
 - current branch: !`git branch --show-current 2>/dev/null || echo unknown`
 - default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo unknown`
 - changed files: !`gh pr diff --name-only 2>/dev/null || echo "no pr"`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Step 1: Validate PR State
 

--- a/han-github/skills/post-code-review-to-pr/SKILL.md
+++ b/han-github/skills/post-code-review-to-pr/SKILL.md
@@ -24,7 +24,7 @@ be installed. In either case, immediately stop.
 - current branch: !`git branch --show-current 2>/dev/null || echo unknown`
 - default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo unknown`
 - changed files: !`gh pr diff --name-only 2>/dev/null || echo "no pr"`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-github/skills/update-pr-description/SKILL.md
+++ b/han-github/skills/update-pr-description/SKILL.md
@@ -24,7 +24,7 @@ allowed-tools: Read, Glob, Grep, Agent, Bash(git *), Bash(gh *)
 - branch summary: !`git log origin/HEAD..HEAD --oneline 2>/dev/null || echo unknown`
 - branch stats: !`git diff origin/HEAD...HEAD --stat 2>/dev/null || echo unknown`
 - branch changes: !`git diff origin/HEAD...HEAD 2>/dev/null || echo unknown`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-github/skills/update-pr-description/SKILL.md
+++ b/han-github/skills/update-pr-description/SKILL.md
@@ -24,6 +24,11 @@ allowed-tools: Read, Glob, Grep, Agent, Bash(git *), Bash(gh *)
 - branch summary: !`git log origin/HEAD..HEAD --oneline 2>/dev/null || echo unknown`
 - branch stats: !`git diff origin/HEAD...HEAD --stat 2>/dev/null || echo unknown`
 - branch changes: !`git diff origin/HEAD...HEAD 2>/dev/null || echo unknown`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Step 1: Validate Branch State
 

--- a/han-github/skills/work-items-to-issues/SKILL.md
+++ b/han-github/skills/work-items-to-issues/SKILL.md
@@ -13,7 +13,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash(gh *), Bash(git *), Bash(find
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-github/skills/work-items-to-issues/SKILL.md
+++ b/han-github/skills/work-items-to-issues/SKILL.md
@@ -11,6 +11,14 @@ argument-hint:
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(gh *), Bash(git *), Bash(find *)
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 # Work Items to GitHub Issues
 
 Take an already-broken-down `work-items.md` file (produced by `/plan-work-items`) and publish each slice as a GitHub

--- a/han-linear/references/config-rule.md
+++ b/han-linear/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-linear/skills/work-items-to-linear/SKILL.md
+++ b/han-linear/skills/work-items-to-linear/SKILL.md
@@ -19,6 +19,14 @@ allowed-tools:
   mcp__plugin_linear_linear__list_users, mcp__plugin_linear_linear__get_user, mcp__plugin_linear_linear__list_projects
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 # Work Items to Linear Issues
 
 Take an already-broken-down `work-items.md` file (produced by `/plan-work-items`) and publish each slice as a Linear

--- a/han-linear/skills/work-items-to-linear/SKILL.md
+++ b/han-linear/skills/work-items-to-linear/SKILL.md
@@ -21,7 +21,7 @@ allowed-tools:
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-planning/references/config-rule.md
+++ b/han-planning/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-planning/skills/iterative-plan-review/SKILL.md
+++ b/han-planning/skills/iterative-plan-review/SKILL.md
@@ -15,6 +15,11 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Review Approach
 

--- a/han-planning/skills/iterative-plan-review/SKILL.md
+++ b/han-planning/skills/iterative-plan-review/SKILL.md
@@ -219,6 +219,11 @@ review. Draw from:
 **Selection rules**:
 
 - Honor any agents the user named explicitly.
+- Extra agents named in the project config's `## Extra Agents` list join this specialist pool and compete under the
+  same what-the-plan-touches selection and size caps, per
+  [../../references/config-rule.md](../../references/config-rule.md): select one only when the plan touches its stated
+  specialty, count it against the size cap, and skip an entry that does not resolve to a dispatchable agent with a
+  one-line note.
 - Justify each additional specialist in one line — what in the plan requires them.
 - `han-core:risk-analyst`, `han-core:software-architect`, and `han-core:system-architect` consume upstream findings;
   only include them when at least one of `han-core:structural-analyst`, `han-core:behavioral-analyst`, or

--- a/han-planning/skills/iterative-plan-review/SKILL.md
+++ b/han-planning/skills/iterative-plan-review/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-planning/skills/plan-a-feature/SKILL.md
+++ b/han-planning/skills/plan-a-feature/SKILL.md
@@ -16,6 +16,11 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(mkdir *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Operating Principles
 

--- a/han-planning/skills/plan-a-feature/SKILL.md
+++ b/han-planning/skills/plan-a-feature/SKILL.md
@@ -333,6 +333,12 @@ assumptions. Select the remaining specialists from this list, matching domain to
 - `han-core:gap-analyzer` — if a PRD or reference spec exists, compare the draft against it.
 - `han-core:risk-analyst` — prioritization of risks if the feature has significant blast radius.
 
+Extra agents named in the project config's `## Extra Agents` list join this review-team pool and compete under the same
+domain-to-feature matching and size cap, per
+[../../references/config-rule.md](../../references/config-rule.md): select one only when the feature touches its
+stated specialty, count it against the size cap, brief it with the spec sections relevant to its domain, and skip an
+entry that does not resolve to a dispatchable agent with a one-line note.
+
 **Mechanic-focused specialists — `han-core:structural-analyst`, `han-core:behavioral-analyst`,
 `han-core:concurrency-analyst`, `han-core:software-architect`, and `han-core:system-architect` — are intentionally
 excluded from the default spec-stage roster.** The analysts target module boundaries, runtime data flow, and concurrency

--- a/han-planning/skills/plan-a-feature/SKILL.md
+++ b/han-planning/skills/plan-a-feature/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(mkdir *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-planning/skills/plan-a-phased-build/SKILL.md
+++ b/han-planning/skills/plan-a-phased-build/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(mkdir *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-planning/skills/plan-a-phased-build/SKILL.md
+++ b/han-planning/skills/plan-a-phased-build/SKILL.md
@@ -15,6 +15,11 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(mkdir *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Operating Principles
 

--- a/han-planning/skills/plan-implementation/SKILL.md
+++ b/han-planning/skills/plan-implementation/SKILL.md
@@ -14,6 +14,11 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(git *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Operating Principles
 

--- a/han-planning/skills/plan-implementation/SKILL.md
+++ b/han-planning/skills/plan-implementation/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(git *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-planning/skills/plan-implementation/SKILL.md
+++ b/han-planning/skills/plan-implementation/SKILL.md
@@ -197,6 +197,12 @@ specialist rather than discovering a gap late. Unless the user specified a team 
 - `han-core:edge-case-explorer` — boundary values, input messiness, state-dependent failures.
 - `han-core:data-engineer` — schema changes, migrations, data movement, analytics implications.
 
+Extra agents named in the project config's `## Extra Agents` list join this specialist pool and compete under the same
+what-the-feature-touches selection and team caps, per
+[../../references/config-rule.md](../../references/config-rule.md): select one only when the feature touches its
+stated specialty, count it against the team cap, and skip an entry that does not resolve to a dispatchable agent with
+a one-line note.
+
 If the user specified which agents to include, honor that. Otherwise, state the proposed team composition to the user
 briefly before launching — one line per specialist with the reason they were selected — and proceed.
 

--- a/han-planning/skills/plan-work-items/SKILL.md
+++ b/han-planning/skills/plan-work-items/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(mkdir *)
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
 - feature-implementation-plan.md: !`find . -maxdepth 5 -name "feature-implementation-plan.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-planning/skills/plan-work-items/SKILL.md
+++ b/han-planning/skills/plan-work-items/SKILL.md
@@ -16,6 +16,11 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(mkdir *)
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
 - feature-implementation-plan.md: !`find . -maxdepth 5 -name "feature-implementation-plan.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 # Plan Work Items
 

--- a/han-plugin-builder/references/config-rule.md
+++ b/han-plugin-builder/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-plugin-builder/skills/agent-builder/SKILL.md
+++ b/han-plugin-builder/skills/agent-builder/SKILL.md
@@ -10,6 +10,14 @@ description: >
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(mkdir *)
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 ## Guidance Location
 
 The authoritative agent-authoring guidance ships in this plugin. Read the specific document a decision needs, when that

--- a/han-plugin-builder/skills/agent-builder/SKILL.md
+++ b/han-plugin-builder/skills/agent-builder/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(mkdir *)
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-plugin-builder/skills/guidance/SKILL.md
+++ b/han-plugin-builder/skills/guidance/SKILL.md
@@ -13,7 +13,7 @@ allowed-tools: Read, Glob, Grep, Bash(find *)
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-plugin-builder/skills/guidance/SKILL.md
+++ b/han-plugin-builder/skills/guidance/SKILL.md
@@ -11,6 +11,14 @@ description: >
 allowed-tools: Read, Glob, Grep, Bash(find *)
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 This skill has three modes. Pick the mode from how it was invoked, then follow only that mode's steps.
 
 - If the invocation argument is `init` or `initialize` (any case), run **Initialization Mode**.

--- a/han-plugin-builder/skills/skill-builder/SKILL.md
+++ b/han-plugin-builder/skills/skill-builder/SKILL.md
@@ -10,6 +10,14 @@ description: >
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(mkdir *)
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 ## Guidance Location
 
 The authoritative skill-authoring guidance ships in this plugin. Read the specific document a decision needs, when that

--- a/han-plugin-builder/skills/skill-builder/SKILL.md
+++ b/han-plugin-builder/skills/skill-builder/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(mkdir *)
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-reporting/references/config-rule.md
+++ b/han-reporting/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-reporting/skills/html-summary/SKILL.md
+++ b/han-reporting/skills/html-summary/SKILL.md
@@ -10,6 +10,14 @@ argument-hint: "[path to stakeholder-summary.md]"
 allowed-tools: Read, Write
 ---
 
+## Project Context
+
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
+
 # HTML Summary
 
 Convert a stakeholder summary markdown file into a single self-contained HTML report tailored for executive readers —

--- a/han-reporting/skills/html-summary/SKILL.md
+++ b/han-reporting/skills/html-summary/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Read, Write
 
 ## Project Context
 
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-reporting/skills/stakeholder-summary/SKILL.md
+++ b/han-reporting/skills/stakeholder-summary/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-reporting/skills/stakeholder-summary/SKILL.md
+++ b/han-reporting/skills/stakeholder-summary/SKILL.md
@@ -14,6 +14,11 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Operating Principles
 

--- a/han-research/references/config-rule.md
+++ b/han-research/references/config-rule.md
@@ -1,0 +1,67 @@
+# Project Config Rule (`.han/config.md`)
+
+A consuming project may carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.
+Each participating skill reads the file through the inline probe in its `## Project Context` block; this rule defines
+how every skill interprets what that probe returns, so one config file resolves identically across the whole suite.
+Every vendored copy of this file is byte-identical to the canonical `han-core/references/config-rule.md`.
+
+## Schema
+
+The file is markdown: optional YAML frontmatter for scalar settings, then named sections for list settings.
+
+- `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
+  its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
+  write when it does not exist.
+- `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
+  Match names case-insensitively against the agents available in the session.
+
+## Precedence
+
+Resolve each scalar setting through this fixed chain; the first source that supplies a value wins:
+
+1. Explicit user input to the skill, including an explicit output path passed by a calling skill.
+2. `.han/config.md`.
+3. The CLAUDE.md `## Project Discovery` section.
+4. The project-discovery file.
+5. The skill's built-in defaults.
+
+The extra-agents list adds rather than replaces: agents the user names explicitly are always considered, and the
+config's entries join them as candidates.
+
+## Working directory
+
+Look for `.han/config.md` only in the directory where the skill is running, the same place the CLAUDE.md and
+project-discovery probes look. A config elsewhere in the repository does not apply. When the probe returns nothing, no
+config is present: behave exactly as the skill does without this rule, with no note.
+
+## Output-directory containment
+
+The `output-directory` value must be a relative path that stays inside the working directory. Refuse an absolute path,
+a drive prefix, or any path whose normalized form escapes the working directory through `..` traversal. A refused
+value falls back to the skill's default output location with the one-line note. This guards against accidents, not
+adversaries.
+
+## Extra agents joining the pool
+
+A skill that selects among candidate agents adds the config's extra agents to its candidate pool. They compete under
+the skill's own signal-based selection and size caps; a selected extra agent may take a slot a default specialist
+would otherwise have filled, and that displacement happens without comment. An entry that duplicates an agent already
+in the pool has no effect: the agent is one candidate, counted once against the caps. An entry that does not resolve
+to a dispatchable agent is skipped with the one-line note naming it.
+
+## Degradation and the one-line note
+
+A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
+that attempts a recognized override cannot be used; pass over everything else silently.
+
+- Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
+  rest of the precedence chain, and note what was ignored.
+- A setting name the suite does not recognize: ignore it with a note; recognized settings in the same file still
+  apply.
+- A recognized setting with a blank or unusable value: ignore it with a note and fall through the precedence chain.
+- A setting that does not apply to the running skill (it writes no markdown deliverable, or selects no agents): ignore
+  it silently.
+- A file holding only prose the suite has no use for: behave as if the file were absent, with no note.
+
+The note is one line naming what was ignored and why, shown on each run where the problem is present. When everything
+applies cleanly, say nothing about the config.

--- a/han-research/skills/gap-analysis/SKILL.md
+++ b/han-research/skills/gap-analysis/SKILL.md
@@ -16,6 +16,11 @@ allowed-tools: Read, Write, Glob, Grep, Agent, Bash(find *), Bash(git *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Operating Principles
 

--- a/han-research/skills/gap-analysis/SKILL.md
+++ b/han-research/skills/gap-analysis/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Read, Write, Glob, Grep, Agent, Bash(find *), Bash(git *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-research/skills/gap-analysis/SKILL.md
+++ b/han-research/skills/gap-analysis/SKILL.md
@@ -183,6 +183,12 @@ from:
 - `han-core:codebase-explorer` — gaps where the current state is unfamiliar code that needs deeper discovery before the
   validators can act.
 
+Extra agents named in the project config's `## Extra Agents` list join this domain-specialist pool and compete under
+the same gap-driven selection and size caps, per
+[../../references/config-rule.md](../../references/config-rule.md): add one only when a gap touches its stated
+specialty, count it against the size cap, and skip an entry that does not resolve to a dispatchable agent with a
+one-line note.
+
 State the size, the chosen swarm composition, and the per-specialist justification to the user in a short message — for
 example:
 

--- a/han-research/skills/issue-triage/SKILL.md
+++ b/han-research/skills/issue-triage/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: Read, Write, Bash(find *), Bash(mkdir *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-research/skills/issue-triage/SKILL.md
+++ b/han-research/skills/issue-triage/SKILL.md
@@ -14,6 +14,11 @@ allowed-tools: Read, Write, Bash(find *), Bash(mkdir *)
 
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Triage Approach
 

--- a/han-research/skills/research/SKILL.md
+++ b/han-research/skills/research/SKILL.md
@@ -163,6 +163,11 @@ then `han-core:adversarial-validator` (3–5 agents); **large** runs a `han-rese
 option cluster plus `han-core:codebase-explorer`, then `han-core:adversarial-validator` (5–8 agents). The
 option-comparison angle is skipped entirely for questions with no discrete alternatives.
 
+Extra agents named in the project config's `## Extra Agents` list join the candidate pool and compete under the same
+signal-based selection and band caps, per [../../references/config-rule.md](../../references/config-rule.md): add one
+only when its stated specialty bears on the question, count it against the band's cap, and skip an entry that does not
+resolve to a dispatchable agent with a one-line note.
+
 **Announce the decision in one line before dispatching**, with the scope it reflects — for example:
 
 > **Size: medium.** "Should we adopt an event bus, and what are the options" — two domains (messaging, delivery

--- a/han-research/skills/research/SKILL.md
+++ b/han-research/skills/research/SKILL.md
@@ -21,7 +21,7 @@ allowed-tools: Read, Glob, Grep, Agent, WebSearch, WebFetch, Bash(find *)
 - git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
-- .han/config.md: !`cat .han/config.md 2>/dev/null`
+- .han/config.md: !`cat .han/config.md 2>/dev/null || echo ""`
 
 When the `.han/config.md` probe returns content, apply it per the config rule in
 [../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is

--- a/han-research/skills/research/SKILL.md
+++ b/han-research/skills/research/SKILL.md
@@ -21,6 +21,11 @@ allowed-tools: Read, Glob, Grep, Agent, WebSearch, WebFetch, Bash(find *)
 - git installed: !`which git 2>/dev/null || echo "not installed"`
 - CLAUDE.md: !`find . -maxdepth 1 -name "CLAUDE.md" -type f`
 - project-discovery.md: !`find . -maxdepth 3 -name "project-discovery.md" -type f`
+- .han/config.md: !`cat .han/config.md 2>/dev/null`
+
+When the `.han/config.md` probe returns content, apply it per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md). When it returns nothing, no project config is
+present and nothing changes.
 
 ## Operating Principles
 


### PR DESCRIPTION
## Summary

**This PR adds project-local Han configuration through an optional `.han/config.md` file, so a consuming project can redirect where skills write their deliverables and name extra agents for dispatching skills to consider, without editing the plugins.**

## Behavior changes

A consuming project can now carry one optional file, `.han/config.md`, that adjusts how Han skills behave in that project.

It supports two overrides. An `output-directory` frontmatter key sets a base directory where skills write their markdown deliverables, keeping their own folder structure beneath it. An `## Extra Agents` section names additional agents that dispatching skills weigh alongside their built-in rosters.

Every skill with a `## Project Context` block reads the file through an inline probe. A project with no config file behaves exactly as before, and it does so silently.

A new canonical rule file, `han-core/references/config-rule.md`, defines how every skill interprets the config, so one file resolves identically across the suite. It sets four contract points:

- A precedence chain: explicit input beats config beats CLAUDE.md beats project-discovery beats defaults.
- A path-containment rule: `output-directory` must be a contained relative path; absolute paths or `..` escapes fall back to the default with a one-line note.
- A pool-join rule: config-named extra agents join each skill's existing candidate pool under that skill's existing size caps.
- A degradation guarantee: a bad config is ignored with a one-line note, never a failed run.

`project-discovery` gains a consent-gated step that offers to add or remove a CLAUDE.md pointer to the config. `docs/configuration.md` is the new operator guide.

Late on the branch, a probe bug surfaced, and this PR fixes it. The probe originally shipped as `cat .han/config.md 2>/dev/null`, which exits non-zero when the file is absent. That made Claude Code's loader fail every skill run in the normal no-config case.

The fix now reads `cat .han/config.md 2>/dev/null || echo ""`, the loader-allowlisted guard, applied across all 39 files. One live-loader spot-run in a consuming project remains as a release check.

## What to look at first

1. `han-core/references/config-rule.md` is the whole behavioral contract (precedence, path containment, pool-join, degradation). Read it first. The 12 vendored copies are byte-identical, so reviewing one covers all.
2. The nine dispatching skills with bespoke pool-join edits (for example `han-planning/skills/plan-a-feature/SKILL.md`) are where extra agents compete for roster slots under each skill's caps. Check that the join respects the size cap and skips unresolvable names.
3. The probe-guard fix and its investigation note under `docs/plans/` explain why `|| echo ""` is load-bearing rather than cosmetic. This is the one change that affects every no-config project.
4. The six `han-atlassian` wrappers pass explicit output paths so their temp files outrank the configured base. Confirm that precedence interaction reads correctly against the rule's chain.
