### PR TITLE
docs(plans): specify the default-swarm-size project-config setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,8 +206,8 @@ such as Claude, shnould be referenced here.
 ### Project-local configuration
 
 - **[docs/configuration.md](./docs/configuration.md).** The operator guide for `.han/config.md`, the optional file a
-  consuming project carries to set an output base directory and extra agents for Han skills. Holds the single canonical
-  annotated schema example.
+  consuming project carries to set an output base directory, a default swarm size, and extra agents for Han skills.
+  Holds the single canonical annotated schema example.
 - **[han-core/references/config-rule.md](./han-core/references/config-rule.md).** The canonical interpretation contract
   (schema tokens, precedence, containment, pool-join, degradation) every participating skill applies. Vendored
   byte-identical into every skill-carrying plugin's `references/`; edit the canonical copy and re-sync the others.

--- a/docs/adr/0001-project-configurable-default-swarm-size.md
+++ b/docs/adr/0001-project-configurable-default-swarm-size.md
@@ -1,0 +1,79 @@
+# Project-Configurable Default Swarm Size
+
+- **Status:** accepted
+- **Date Created:** 2026-07-24 00:00
+- **Last Updated:** 2026-07-24 00:00
+
+## Context
+
+Sizing is one of the two foundational mechanics of the Han suite. Every skill that dispatches an agent swarm
+classifies the work as small, medium, or large, and that band caps the roster and iteration depth. The sizing guide
+originally stated a design principle: "Sizing is overridable, not configurable. There is no project-level 'always run
+as medium' setting." A user who wanted a different band passed it as the size argument on each invocation.
+
+That principle left a gap operators asked about: a project that wants a standing default band had no home for it, and
+the only workaround was passing the size argument on every single run. The suite had meanwhile gained a project-local
+configuration file, `.han/config.md`, with an established interpretation contract covering precedence, containment,
+and degradation.
+
+## Decision Drivers
+
+- An operator-described need for a standing project default that replaces per-invocation size arguments.
+- The config contract already defines scalar precedence (explicit input first, then config, then skill defaults) and
+  degradation (a bad config can never fail a run), so a size setting can reuse proven rules instead of inventing new
+  ones.
+- Sizing transparency: the skill must always announce the chosen band and its source.
+- The per-invocation override must stay available so a configured default never traps a single run.
+
+## Considered Options
+
+1. **Keep the principle: overridable, never configurable.**
+   - Pros: no new setting to document; per-run classification always reflects the work's signals; no risk of a stale
+     project-wide band silently under- or over-provisioning review depth.
+   - Cons: the operator need stays unmet; every run in a project that wants a fixed band costs a repeated argument;
+     the config file already exists as the natural home for exactly this kind of project default.
+2. **A configurable starting default that signals can still escalate.**
+   - Pros: adapts when the configured band is wrong for a given change; keeps some signal-based protection on risky
+     work.
+   - Cons: the configured value becomes unreliable ("why did it run large when I configured small?"); requires a new
+     escalation rule with no precedent in the suite; harder to specify, announce, and support.
+3. **A configured band forced exactly like an explicit size argument (chosen).**
+   - Pros: reuses the already-specified override semantics and the config contract's precedence chain unchanged; the
+     behavior is predictable and announced with its source; the per-run escape hatch (`dynamic`) needs no file edit.
+   - Cons: reverses a documented design principle; a project-wide `small` is honored without escalation even on
+     security-sensitive work, so under-review is possible until the operator corrects the run.
+
+## Decision
+
+We will use **Option 3**: a `default-swarm-size` setting in `.han/config.md` (`small` | `medium` | `large` |
+`dynamic`, absent = `dynamic`) that the eight sizing-aware skills adopt exactly as if the user had passed the band as
+the size argument. Explicit input always wins, and `dynamic` is also a valid explicit size that forces
+auto-classification for one run. This deliberately reverses the "overridable, not configurable" principle because the
+operator need is real, the config contract's precedence and degradation rules absorb the setting without new
+machinery, and the transparency principle (the band is always announced with its source) keeps the configured default
+visible.
+
+## Consequences
+
+**Positive:**
+
+- One config line replaces a per-invocation argument across all eight sizing-aware skills.
+- The setting inherits the contract's guarantees: explicit input wins, bad values degrade with a one-line note, and a
+  config problem can never fail a run.
+- `dynamic` gains a per-run role, so correcting a configured band never requires editing the file.
+
+**Negative:**
+
+- A configured `small` narrows review depth on work whose signals would have escalated it; the announcement naming the
+  config as the source is the guard, and a per-run override is the correction.
+- One global band scales agent cost across eight differently-scoped skills at once.
+
+**Neutral:**
+
+- The sizing guide's design-principles section now states the revised principle and points here.
+
+## Notes
+
+- Feature specification: [docs/plans/config-default-swarm-size/](../plans/config-default-swarm-size/feature-specification.md)
+- Interpretation contract: [han-core/references/config-rule.md](../../han-core/references/config-rule.md)
+- Operator guide: [docs/configuration.md](../configuration.md) · [docs/sizing.md](../sizing.md)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -203,7 +203,8 @@ table, and the fidelity guard.
 ## Project-local configuration
 
 A project can carry one optional file, `.han/config.md`, that every Han skill reads on every run. It sets a base
-directory for the skills' markdown deliverables and names extra agents for the dispatching skills to consider. A
+directory for the skills' markdown deliverables, a default swarm size for the sizing-aware skills, and extra agents
+for the dispatching skills to consider. A
 project without the file sees no change, and a broken file degrades quietly to defaults with a one-line note. Read the
 full [Configuration](./configuration.md) reference for the file's schema, the precedence chain, and the degradation
 contract.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,9 +1,10 @@
 # Project-Local Configuration
 
 A project that uses Han can carry one optional file, `.han/config.md`, to adjust how Han skills behave in that project.
-The file controls two things: where skills write their markdown deliverables, and which extra agents dispatching skills
-consider. Every Han skill reads the file on every run, so the overrides take effect without depending on the model
-remembering to look. A project without the file sees no change of any kind.
+The file controls three things: where skills write their markdown deliverables, which extra agents dispatching skills
+consider, and the default swarm size the sizing-aware skills start at. Every Han skill reads the file on every run, so
+the overrides take effect without depending on the model remembering to look. A project without the file sees no
+change of any kind.
 
 > See also: [Plugin landing page](../README.md) · [Concepts](./concepts.md) · [Quickstart](./quickstart.md) ·
 > [All skills](./skills/README.md) · [All agents](./agents/README.md)
@@ -13,9 +14,9 @@ remembering to look. A project without the file sees no change of any kind.
 - **You write the file; Han cannot.** Han cannot ship or seed a project-level config from the plugin side. You create
   `.han/config.md` by hand in a `.han/` folder at your project root, and it travels through version control like any
   other file. The annotated example below is the canonical source to author from.
-- **Two overrides ship.** `output-directory` sets one base directory for every skill's markdown deliverables.
-  `## Extra Agents` names project-defined or third-party agents that Han's dispatching skills consider alongside their
-  built-in rosters.
+- **Three overrides ship.** `output-directory` sets one base directory for every skill's markdown deliverables.
+  `default-swarm-size` sets the size band every sizing-aware skill starts at. `## Extra Agents` names project-defined
+  or third-party agents that Han's dispatching skills consider alongside their built-in rosters.
 - **A bad config can never fail a skill run.** The worst it can do is be ignored, with a one-line note naming what was
   ignored. A missing or empty file changes nothing and says nothing.
 - **The interpretation contract lives in
@@ -35,6 +36,14 @@ optional, and everything unrecognized is ignored.
 # creates the directory on first write. Must stay inside the project: absolute
 # paths and paths escaping upward are refused.
 output-directory: docs/han
+
+# Default size band for the skills that dispatch an agent swarm:
+# small | medium | large | dynamic. A band is adopted exactly as if you passed
+# it as the skill's size argument, on every sizing-aware run, so it scales
+# agent cost across all of them together. "dynamic" (or omitting the line)
+# lets each skill classify the size itself. Passing a size on an invocation,
+# including "dynamic" to auto-classify one run, always wins over this default.
+default-swarm-size: dynamic
 ---
 
 ## Extra Agents
@@ -54,6 +63,27 @@ Skills that write markdown deliverables (plans, reports, documentation) write th
 their default locations, keeping their own folder structure beneath it. A skill that writes nothing ignores the setting
 silently. The value must be a relative path that stays inside the project; an absolute path or a `..` escape is
 refused with a one-line note, and the skill falls back to its default location.
+
+### `default-swarm-size`
+
+The eight sizing-aware skills ([`/architectural-analysis`](../han-coding/docs/skills/architectural-analysis.md),
+[`/code-overview`](../han-coding/docs/skills/code-overview.md),
+[`/code-review`](../han-coding/docs/skills/code-review.md),
+[`/gap-analysis`](../han-research/docs/skills/gap-analysis.md),
+[`/iterative-plan-review`](../han-planning/docs/skills/iterative-plan-review.md),
+[`/plan-a-feature`](../han-planning/docs/skills/plan-a-feature.md),
+[`/plan-implementation`](../han-planning/docs/skills/plan-implementation.md), and
+[`/research`](../han-research/docs/skills/research.md)) start at this band instead of classifying the size themselves.
+A configured `small`, `medium`, or `large` is forced exactly like an explicit size argument: the skill skips its
+signal-based classification, scales its caps to the band, and announces the band with the config named as the source.
+Specialists are still selected by signal within the band's caps. `dynamic`, or omitting the setting, keeps today's
+auto-classification. Values are trimmed and matched case-insensitively; anything else degrades with a one-line note
+and the skill classifies the size itself.
+
+One configured band applies to all eight skills at once, and their bands scope differently (a `large` code review and
+a `large` research swarm cost different work), so a global `large` raises agent cost on every sizing-aware run. The
+per-run correction never needs a file edit: passing a size on the invocation always wins, and passing `dynamic`
+auto-classifies that run. See [Sizing](./sizing.md) for the bands and per-skill caps.
 
 ### `## Extra Agents`
 

--- a/docs/plans/config-default-swarm-size/artifacts/decision-log.md
+++ b/docs/plans/config-default-swarm-size/artifacts/decision-log.md
@@ -1,0 +1,180 @@
+# Decision Log: Project-Configured Default Swarm Size
+
+## Trivial decisions
+
+- D1: Setting name, home, values, and need — the setting is a frontmatter key named `default-swarm-size` in
+  `.han/config.md`, accepting `small`, `medium`, `large`, or `dynamic`, with `dynamic` as the fallback when the
+  setting is absent; the operator-described need is a standing project default that replaces passing the size argument
+  on every invocation. — Referenced in spec: Outcome, Primary Flow.
+- D5: `dynamic` in the config behaves identically to an absent setting — both leave the skill classifying the size
+  itself from the work's signals (considered making `dynamic` a chain-stopping value distinct from absence; rejected
+  because no lower source in the precedence chain supplies a size, so the two are behaviorally identical today). —
+  Referenced in spec: Outcome, Alternate Flows and States.
+- D8: Values are trimmed of surrounding whitespace, then matched case-insensitively (considered exact-match only;
+  rejected because the config contract already matches agent names case-insensitively, the file is authored by hand,
+  and a case or whitespace mismatch triggering a degradation note would be needless friction). — Referenced in spec:
+  Edge Cases and Failure Modes.
+
+## Full decisions
+
+### D2: The setting applies to the eight sizing-aware skills
+
+- **Question:** which skills are "all relevant skills" for a default swarm size?
+- **Decision:** the setting applies to every skill that dispatches an agent swarm and classifies its size — the eight
+  sizing-aware skills: `/architectural-analysis`, `/code-overview`, `/code-review`, `/gap-analysis`,
+  `/iterative-plan-review`, `/plan-a-feature`, `/plan-implementation`, and `/research`. A skill that dispatches no
+  swarm ignores the setting silently.
+- **Rationale:** the sizing-aware set is already defined and documented as exactly these eight skills; "relevant"
+  resolves to that set without inventing a new category. Silent ignore for non-applicable skills is the existing
+  contract behavior for settings that do not apply to the running skill.
+- **Evidence:** codebase — `docs/sizing.md` (names the eight sizing-aware skills and their bands);
+  `han-core/references/config-rule.md` § Degradation ("a setting that does not apply to the running skill: ignore it
+  silently").
+- **Rejected alternatives:**
+  - A per-skill opt-in list in the config naming which skills honor the setting — rejected because one project-wide
+    default satisfies the stated need; the per-skill variant is deferred under YAGNI in the spec.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** D3, D9
+- **Referenced in spec:** Actors and Triggers, Edge Cases and Failure Modes
+
+### D3: The setting resolves through the existing scalar precedence chain
+
+- **Question:** where does the config value sit relative to an explicit size argument and the skill's own
+  classification?
+- **Decision:** `default-swarm-size` is a scalar setting under the existing precedence chain: explicit user input
+  (the size argument or a conversational override) wins first, then `.han/config.md`, then the skill's built-in
+  default (auto-classification); the chain's intervening project-discovery sources define no swarm size and so never
+  supply a value for this setting. An unrecognized size argument supplies no explicit value — it is treated as
+  trailing context, and the chain continues to the config rather than skipping past it. When explicit input wins, the
+  config value is passed over silently. A wrapper skill that invokes a sizing-aware skill runs it in the same working
+  directory, so the wrapped skill resolves the config itself; a size the wrapper forwards is explicit input, and when
+  it forwards none the config applies.
+- **Rationale:** the config contract already defines exactly this chain for scalar settings; reusing it means one
+  rule governs both existing and new settings. The unrecognized-argument rule follows the chain's own semantics ("the
+  first source that supplies a value wins" — a typo supplies nothing), resolving the conflict with the older sizing
+  guide wording that sent an unrecognized argument straight to auto-classification.
+- **Evidence:** codebase — `han-core/references/config-rule.md` § Precedence and § Degradation;
+  `docs/configuration.md` § Precedence; `docs/sizing.md` § Overriding the size (the wording this decision supersedes);
+  `han-atlassian/skills/plan-a-feature-to-confluence/SKILL.md` (a shipped wrapper that conditionally forwards the size
+  argument).
+- **Rejected alternatives:**
+  - A dedicated precedence rule for size, separate from the scalar chain — rejected because it would be a second
+    rule to keep in sync with no behavioral difference.
+  - Letting an unrecognized size argument skip the config and force auto-classification — rejected because a typo
+    would silently bypass the project's configured default.
+- **Linked technical notes:** —
+- **Driven by findings:** F1, F2, F10
+- **Dependent decisions:** D4, D7, D10
+- **Referenced in spec:** Primary Flow, Alternate Flows and States, Edge Cases and Failure Modes, Coordinations
+
+### D4: A configured band is forced exactly like an explicit size argument
+
+- **Question:** does a configured `small`, `medium`, or `large` force the band, or set a starting default that clear
+  signals can still escalate?
+- **Decision:** the configured band is forced, exactly as if the user had passed it as the size argument: the skill
+  skips signal-based classification, adopts the band, and scales its caps to it. Specialists are still selected by
+  signal within the cap, and the configured band never bypasses a team cap. The force applies in both directions —
+  a configured `small` is honored without escalation even on cross-service or security-sensitive work, with the
+  announcement keeping the narrowed depth visible and a per-run override as the correction.
+- **Rationale:** matches the precedence chain's "first source that supplies a value wins" semantics, reuses the
+  already-specified override behavior instead of defining a new escalation rule, and avoids the support question
+  "why did it run large when I configured small?"
+- **Evidence:** user input (chose "force the band" over "escalatable starting default"); codebase —
+  `docs/sizing.md` § Overriding the size (the existing override behavior this decision mirrors).
+- **Rejected alternatives:**
+  - A starting default that strong signals can escalate — rejected by the user; harder to specify and explain, and
+    it makes the configured value unreliable.
+- **Linked technical notes:** —
+- **Driven by findings:** F3
+- **Dependent decisions:** D6, D10
+- **Referenced in spec:** Outcome, Primary Flow, Edge Cases and Failure Modes
+
+### D6: The skill announces the config as the size source
+
+- **Question:** what does the user see when the config decided the band?
+- **Decision:** the skill's existing one-line size announcement names the config as the source (in the same spirit
+  as the existing "passed via size argument" announcement), in the same place it announces an auto-classification
+  today. When the config did not decide the band — explicit override, `dynamic`, or absence — the announcement does
+  not mention the config.
+- **Rationale:** the sizing design principle is that sizing is transparent and the skill always announces the chosen
+  band with its source; a silently config-forced band would make swarm behavior unexplainable to a user who forgot
+  the setting exists.
+- **Evidence:** codebase — `docs/sizing.md` § Design principles ("Sizing is transparent") and the existing
+  "Medium: passed via `$size`" announcement pattern.
+- **Rejected alternatives:**
+  - Announce nothing when the config supplies the band — rejected because it violates the transparency principle
+    and hides why a run dispatched more or fewer agents than expected.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow, User Interactions, Edge Cases and Failure Modes
+
+### D7: An unusable value degrades with the existing one-line note
+
+- **Question:** what happens when the setting's value is blank or not one of the four accepted values?
+- **Decision:** the skill ignores the value with the existing one-line degradation note naming what was ignored and
+  why, and falls through the precedence chain to auto-classification. Other recognized settings in the same file
+  still apply, and the run never fails because of the setting.
+- **Rationale:** this is the config contract's existing rule for a recognized setting with a blank or unusable
+  value; the new setting inherits it rather than defining new failure behavior.
+- **Evidence:** codebase — `han-core/references/config-rule.md` § Degradation and the one-line note.
+- **Rejected alternatives:**
+  - Failing the run or prompting the user to fix the value — rejected because the contract commits to "a bad config
+    can never fail a skill run."
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Alternate Flows and States, Edge Cases and Failure Modes
+
+### D9: The documentation surfaces that change with the feature
+
+- **Question:** which documented surfaces must change so no doc contradicts the new behavior?
+- **Decision:** these surfaces ship with the behavior: the shared config interpretation contract gains the new
+  setting (canonical copy first, every vendored copy re-synced identically in the same change, and the setting is
+  defined once there so all eight skills resolve it uniformly); the configuration guide's canonical annotated example
+  gains the setting plus a note that one configured band applies to all eight sizing-aware skills and scales their
+  agent cost together; the sizing guide's design-principle statement that sizing is "overridable, not configurable"
+  is revised, and its size-override section adds `dynamic` as an accepted per-run value and the
+  unrecognized-argument fall-through rule; and an ADR records the reversal of the "overridable, not configurable"
+  principle.
+- **Rationale:** the sizing guide's current text directly contradicts the feature in two places (the design
+  principle and the unrecognized-argument rule); leaving either would make the docs wrong on day one. Sizing is
+  documented as one of the suite's two foundational mechanics, so reversing its stated principle earns a durable
+  decision record, not only a prose edit. The contract and the configuration guide are the two canonical homes the
+  config feature already established for schema and operator guidance.
+- **Evidence:** codebase — `docs/sizing.md` § Design principles ("Sizing is overridable, not configurable") and
+  § Overriding the size; `docs/configuration.md` (the canonical annotated example);
+  `han-core/references/config-rule.md` § Schema and the byte-identical vendoring convention in CLAUDE.md; the
+  `architectural-decision-record` skill in han-documentation. User input: record the ADR.
+- **Rejected alternatives:**
+  - Documenting the setting only in the configuration guide and leaving the sizing guide untouched — rejected
+    because the sizing guide would then state a principle the suite no longer follows.
+  - Prose edit only, no ADR — rejected by the user; a foundational-mechanic reversal deserves a durable record.
+- **Linked technical notes:** —
+- **Driven by findings:** F1, F6, F9, F13
+- **Dependent decisions:** —
+- **Referenced in spec:** User Interactions, Coordinations
+
+### D10: `dynamic` is a valid explicit per-run size
+
+- **Question:** how does a user get one auto-classified run when the config fixes a band, without editing the config
+  file?
+- **Decision:** `dynamic` is accepted as an explicit size — passed as the size argument or asked conversationally —
+  meaning "auto-classify this run." As explicit input it wins over a configured band under the precedence chain, for
+  that run only. This also gives the `dynamic` token a behavioral job beyond documenting intent in the config.
+- **Rationale:** without an escape hatch, every exception to a configured band costs a config-file edit; the size
+  argument is the existing per-run channel, and extending its accepted values is strictly simpler than inventing a
+  new flag. Accepting `dynamic` per-run also closes the YAGNI question of a fourth config value with no behavioral
+  distinction from absence.
+- **Evidence:** user input (chose per-run `dynamic` over a conversational-only escape hatch and over dropping the
+  token); codebase — `docs/sizing.md` § Overriding the size (the argument channel being extended).
+- **Rejected alternatives:**
+  - Conversational-only escape hatch — rejected because the argument is the documented, deterministic channel and
+    the token already exists in the value set.
+  - Dropping `dynamic` from the accepted values entirely — rejected because the operator wants the self-documenting
+    config token, and the per-run role gives it behavior.
+- **Linked technical notes:** —
+- **Driven by findings:** F7, F8
+- **Dependent decisions:** —
+- **Referenced in spec:** Outcome, Alternate Flows and States, Edge Cases and Failure Modes

--- a/docs/plans/config-default-swarm-size/artifacts/team-findings.md
+++ b/docs/plans/config-default-swarm-size/artifacts/team-findings.md
@@ -1,0 +1,124 @@
+# Team Findings: Project-Configured Default Swarm Size
+
+This file records every finding raised by the review team and how each was resolved. Behavioral outcomes live in
+[../feature-specification.md](../feature-specification.md); decisions the findings affected live in
+[decision-log.md](decision-log.md). No feature-technical-notes.md exists — no load-bearing mechanic qualified.
+
+Review team: han-core:edge-case-explorer (F1–F4), han-core:junior-developer (F5–F13). Size: small (team cap 2).
+
+## Major findings
+
+### F1: An unrecognized size argument would silently bypass the configured band
+
+- **Agent:** edge-case-explorer
+- **Finding:** the sizing guide says an unrecognized size argument (a typo like `mediun`) is treated as trailing
+  context and the skill "falls back to auto-classification" — which, with the config inserted into the chain, would
+  skip the configured band entirely. The spec did not say which rule wins, and the sizing guide's override section was
+  missing from the doc surfaces in D9.
+- **Resolution:** an unrecognized size argument supplies no explicit value, so the chain continues to the config.
+  Added to the "Explicit size beats the config" flow and the edge-case table; D3 records the rule and the superseded
+  sizing-guide wording; D9 adds the sizing guide's override section to the surfaces that change.
+- **Resolved by:** evidence
+- **Affected decisions:** D3, D9
+- **Changed in spec:** Alternate Flows and States, Edge Cases and Failure Modes
+
+### F2: Wrapper skills that conditionally forward a size were unaddressed
+
+- **Agent:** edge-case-explorer
+- **Finding:** shipped wrapper skills (for example the Confluence wrappers) forward the size argument only when the
+  user passed one; the spec was silent on how the wrapped skill resolves the config and which channel counts as
+  explicit input.
+- **Resolution:** added a Coordinations row: the wrapper runs the wrapped skill in the same working directory, the
+  wrapped skill resolves the config itself, a forwarded size is explicit input and wins, and no forwarded size means
+  the config applies. D3 records the rule.
+- **Resolved by:** evidence
+- **Affected decisions:** D3
+- **Changed in spec:** Actors and Triggers, Coordinations
+
+### F3: The higher-severity direction — configured `small` on risky work — was implicit
+
+- **Agent:** edge-case-explorer
+- **Finding:** the edge-case table covered `large` on trivially small work (a token-cost concern) but not `small`
+  forced onto cross-service or security-sensitive work (an under-review concern with materially different severity).
+- **Resolution:** added the mirrored edge-case row: the configured `small` is honored with no escalation, the
+  announcement keeps the narrowed depth visible, and a per-run override is the correction. D4 now states the force
+  applies in both directions.
+- **Resolved by:** evidence
+- **Affected decisions:** D4
+- **Changed in spec:** Edge Cases and Failure Modes, Out of Scope
+
+### F4: Whitespace-padded values were unspecified
+
+- **Agent:** edge-case-explorer
+- **Finding:** D8 covered case-insensitivity but not hand-editing artifacts like `" medium "`; unclear whether they
+  match or degrade with a note.
+- **Resolution:** values are trimmed before case-insensitive matching; folded into D8 and the edge-case table row.
+- **Resolved by:** evidence
+- **Affected decisions:** D8
+- **Changed in spec:** Edge Cases and Failure Modes
+
+### F6: Reversing a documented foundational principle warranted an ADR decision
+
+- **Agent:** junior-developer
+- **Finding:** the sizing guide states "Sizing is overridable, not configurable"; this feature reverses it, and the
+  suite has an ADR mechanism for exactly this kind of reversal, but the spec handled it as a prose edit only.
+- **Resolution:** the user chose to record an ADR alongside the sizing-guide revision; captured in D9 and the
+  Coordinations row.
+- **Resolved by:** user input
+- **Affected decisions:** D9
+- **Changed in spec:** Coordinations
+
+### F7: No per-run escape back to auto-classification
+
+- **Agent:** junior-developer
+- **Finding:** with a band configured, the size argument (three accepted values) could not express "auto-classify
+  this run," so every exception would cost a config-file edit.
+- **Resolution:** the user chose to accept `dynamic` as an explicit per-run size meaning "auto-classify this run,"
+  winning over the configured band for that run. New decision D10; new alternate flow.
+- **Resolved by:** user input
+- **Affected decisions:** D10
+- **Changed in spec:** Outcome, Alternate Flows and States, Edge Cases and Failure Modes
+
+### F8: The `dynamic` config value had no behavioral distinction from omission (YAGNI candidate)
+
+- **Agent:** junior-developer
+- **Finding:** `dynamic` in the config was behaviorally identical to leaving the line out — a fourth value to
+  document and degrade around, with no job.
+- **Resolution:** closed by F7's resolution: `dynamic` now has a per-run override role (D10), and its config-side
+  equivalence to absence stays recorded in D5.
+- **Resolved by:** user input
+- **Affected decisions:** D10, D5
+- **Changed in spec:** Outcome, Alternate Flows and States
+
+### F9: The "all eight resolve identically" guarantee rested on an unstated assumption
+
+- **Agent:** junior-developer
+- **Finding:** all eight skills carry the config probe, but reading the file and resolving a new scalar into a band
+  are different steps; nothing stated where the uniformity comes from.
+- **Resolution:** the uniformity comes from defining the setting once in the shared interpretation contract that
+  every skill applies, rather than eight independent rules; stated in the Coordinations row and D9.
+- **Resolved by:** evidence
+- **Affected decisions:** D9
+- **Changed in spec:** Coordinations
+
+### F13: One global band scales cost across eight differently-scoped skills
+
+- **Agent:** junior-developer
+- **Finding:** `large` means different work per skill, and one config line raises agent cost on every sizing-aware
+  run; the operator-facing docs said nothing about the aggregate cost.
+- **Resolution:** the configuration guide's example gains a note that one configured band applies to all eight
+  sizing-aware skills and scales their agent cost together; captured in D9 and User Interactions.
+- **Resolved by:** evidence
+- **Affected decisions:** D9
+- **Changed in spec:** User Interactions, Coordinations
+
+## Minor edits
+
+- F5: The motivating need was never stated in the spec — junior-developer — Outcome (added the operator-described
+  need; recorded in D1).
+- F10: Primary Flow implied the intervening chain sources could supply a size — junior-developer — Primary Flow
+  (now states they define no swarm size; recorded in D3).
+- F11: No testable definition of done — junior-developer — Open Items (added OI-1: extend the manual test plan across
+  the eight skills, following the prior config feature's precedent).
+- F12: Summary claimed 0 open items while review was pending — junior-developer — Summary (counts and consulted
+  agents now reflect the completed review).

--- a/docs/plans/config-default-swarm-size/feature-specification.md
+++ b/docs/plans/config-default-swarm-size/feature-specification.md
@@ -1,0 +1,166 @@
+# Feature Specification: Project-Configured Default Swarm Size
+
+A project can set a default swarm size for Han's sizing-aware skills by adding one `default-swarm-size` setting to the
+frontmatter of `.han/config.md`. The setting accepts `small`, `medium`, `large`, or `dynamic`; when it is absent, the
+skills behave exactly as they do today, classifying the size themselves.
+
+## Outcome
+
+A project operator writes one line of configuration once. Every sizing-aware Han skill in that project then starts at
+the configured swarm size on every run, without the operator passing a size argument each time.
+
+The need is operator-described. Today the only way to hold a project at a chosen band is to pass the size argument on
+every single invocation. A project that wants a standing default has no home for it
+([D1](artifacts/decision-log.md#trivial-decisions)).
+
+A value of `small`, `medium`, or `large` fixes the band the same way an explicit size argument does today
+([D4](artifacts/decision-log.md#d4-a-configured-band-is-forced-exactly-like-an-explicit-size-argument)). A value of
+`dynamic`, or no setting at all, leaves the skills classifying the size themselves from the work's signals, which is
+today's behavior ([D5](artifacts/decision-log.md#trivial-decisions)). `dynamic` is also accepted as an explicit per-run
+size, so a user can ask any single run to auto-classify even when the config fixes a band
+([D10](artifacts/decision-log.md#d10-dynamic-is-a-valid-explicit-per-run-size)).
+
+## Actors and Triggers
+
+- **Actors**: the project operator who authors `.han/config.md`, and the eight sizing-aware skills that consume the
+  setting: `/architectural-analysis`, `/code-overview`, `/code-review`, `/gap-analysis`, `/iterative-plan-review`,
+  `/plan-a-feature`, `/plan-implementation`, and `/research`
+  ([D2](artifacts/decision-log.md#d2-the-setting-applies-to-the-eight-sizing-aware-skills)).
+- **Triggers**: any run of a sizing-aware skill in a directory whose `.han/config.md` carries the setting, whether
+  the user invoked the skill directly or through a wrapper skill.
+- **Preconditions**: none beyond the existing config mechanism: the file lives in the directory the skill runs from,
+  and a missing file changes nothing.
+
+## Primary Flow
+
+1. The project operator adds `default-swarm-size` with one of the four accepted values to the frontmatter of
+   `.han/config.md`, alongside any other settings already there
+   ([D1](artifacts/decision-log.md#trivial-decisions)).
+2. A user runs a sizing-aware skill without passing a size argument.
+3. The skill reads the project config as it does today. It resolves the size through the existing precedence
+   chain: explicit user input first, then the config file, then the skill's own classification. The chain's
+   intervening sources (the project-discovery surfaces) define no swarm size, so for this setting they never supply a
+   value ([D3](artifacts/decision-log.md#d3-the-setting-resolves-through-the-existing-scalar-precedence-chain)).
+4. When the config supplies `small`, `medium`, or `large`, the skill skips its signal-based classification and adopts
+   that band, exactly as if the user had passed it as the size argument
+   ([D4](artifacts/decision-log.md#d4-a-configured-band-is-forced-exactly-like-an-explicit-size-argument)).
+5. The skill announces the chosen band with a one-line justification naming the config as the source, in the same
+   place it announces an auto-classification or an explicit override today
+   ([D6](artifacts/decision-log.md#d6-the-skill-announces-the-config-as-the-size-source)).
+6. Team caps, roster selection, iteration depth, and finding calibration scale to the band under each skill's existing
+   sizing rules. Specialists are still selected by signal; the configured band sets the bound, not the roster.
+
+## Alternate Flows and States
+
+### Explicit size beats the config
+
+- **Entry condition:** the user passes `small`, `medium`, `large`, or `dynamic` as the skill's size argument, or asks
+  for a size conversationally, while the config also carries `default-swarm-size`.
+- **Sequence:** the explicit input wins under the precedence chain; the config value is passed over silently, since
+  nothing about it failed
+  ([D3](artifacts/decision-log.md#d3-the-setting-resolves-through-the-existing-scalar-precedence-chain)). An
+  unrecognized size argument (a typo like `mediun`) supplies no explicit value: it is treated as trailing context, and
+  the chain continues to the config rather than skipping past it
+  ([D3](artifacts/decision-log.md#d3-the-setting-resolves-through-the-existing-scalar-precedence-chain)).
+- **Exit:** the skill announces the band as an explicit override, with no mention of the config.
+
+### The user asks one run to auto-classify
+
+- **Entry condition:** the config fixes a band, and the user passes `dynamic` as the size argument or asks
+  conversationally for auto-classification.
+- **Sequence:** the explicit `dynamic` wins over the configured band, and the skill classifies the size itself from
+  the work's signals for that run only
+  ([D10](artifacts/decision-log.md#d10-dynamic-is-a-valid-explicit-per-run-size)). The config file is untouched.
+- **Exit:** the skill announces the auto-classified band with its signal-based justification.
+
+### The config says `dynamic`
+
+- **Entry condition:** the config carries `default-swarm-size: dynamic`.
+- **Sequence:** the skill classifies the size itself from the work's signals, exactly as when the setting is absent
+  ([D5](artifacts/decision-log.md#trivial-decisions)).
+- **Exit:** the skill announces the auto-classified band with its signal-based justification, with no mention of the
+  config.
+
+### The value cannot be used
+
+- **Entry condition:** the setting is present but its value is blank or is not one of the four accepted values.
+- **Sequence:** the skill ignores the value with the existing one-line degradation note naming what was ignored and
+  why, and falls through the precedence chain to its own classification
+  ([D7](artifacts/decision-log.md#d7-an-unusable-value-degrades-with-the-existing-one-line-note)). Other recognized
+  settings in the same file still apply.
+- **Exit:** the run proceeds at the auto-classified size; the run never fails because of the setting.
+
+## Edge Cases and Failure Modes
+
+| Condition                                                                  | Required Behavior                                                                                                                                     |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Value differs only in case or carries surrounding whitespace (for example `Medium`, `" medium "`) | Accepted; values are trimmed, then matched case-insensitively ([D8](artifacts/decision-log.md#trivial-decisions)).                                       |
+| Value is not an accepted value (for example `huge`)                        | Ignored with the one-line note; the skill classifies the size itself ([D7](artifacts/decision-log.md#d7-an-unusable-value-degrades-with-the-existing-one-line-note)). |
+| Value is blank                                                             | Same degradation: one-line note, fall through to auto-classification.                                                                                   |
+| The user passes an unrecognized size argument while the config fixes a band | The argument supplies no explicit size, so the configured band still applies ([D3](artifacts/decision-log.md#d3-the-setting-resolves-through-the-existing-scalar-precedence-chain)). |
+| The running skill dispatches no agent swarm                                | The setting is ignored silently, per the existing rule for settings that do not apply to the running skill ([D2](artifacts/decision-log.md#d2-the-setting-applies-to-the-eight-sizing-aware-skills)). |
+| The config also carries other settings, one of which is unusable           | Each setting degrades independently; a bad value elsewhere does not affect this one, and the reverse.                                                   |
+| Config sets `large` on trivially small work                                | The band is honored as configured; the roster is still signal-selected within the larger cap, so agents whose domain is untouched are still skipped ([D4](artifacts/decision-log.md#d4-a-configured-band-is-forced-exactly-like-an-explicit-size-argument)). |
+| Config sets `small` on cross-service or security-sensitive work            | The band is honored as configured, with no escalation; the announcement names the config as the source so the narrowed review depth is visible, and a per-run `dynamic` or larger explicit size is the correction ([D4](artifacts/decision-log.md#d4-a-configured-band-is-forced-exactly-like-an-explicit-size-argument), [D6](artifacts/decision-log.md#d6-the-skill-announces-the-config-as-the-size-source), [D10](artifacts/decision-log.md#d10-dynamic-is-a-valid-explicit-per-run-size)). |
+
+## User Interactions
+
+- **Affordances:** one frontmatter line in `.han/config.md`, authored by hand like the file's existing settings. The
+  canonical annotated example in the configuration guide gains the setting, along with a note that one configured band
+  applies to all eight sizing-aware skills and scales their agent cost together
+  ([D9](artifacts/decision-log.md#d9-the-documentation-surfaces-that-change-with-the-feature)).
+- **Feedback:** the skill's existing one-line size announcement names the config as the source when the config decided
+  the band ([D6](artifacts/decision-log.md#d6-the-skill-announces-the-config-as-the-size-source)).
+- **Error states:** the one-line degradation note is the only error surface; a bad value can never fail a run.
+
+## Coordinations
+
+| Coordinating System                                   | Direction | Interaction                                                                                                        | Ordering / Consistency Requirement                                                                 |
+| ----------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| The eight sizing-aware skills                          | outbound  | Each adds the setting to the size resolution it performs before dispatching agents.                                | All eight resolve the same file to the same band under the same precedence and degradation rules; the uniformity comes from defining the setting once in the shared interpretation contract rather than eight independent rules ([D9](artifacts/decision-log.md#d9-the-documentation-surfaces-that-change-with-the-feature)). |
+| Wrapper skills that invoke a sizing-aware skill        | inbound   | A wrapper runs the wrapped skill in the same working directory, so the wrapped skill resolves `default-swarm-size` from the same config as a direct invocation. A size the wrapper forwards is explicit input and wins; when it forwards none, the config applies ([D3](artifacts/decision-log.md#d3-the-setting-resolves-through-the-existing-scalar-precedence-chain)). | The wrapper's forwarded size is the only channel by which explicit input reaches the wrapped skill.  |
+| The shared config interpretation contract              | outbound  | The contract gains the new setting so every skill interprets it identically; every vendored copy stays identical to the canonical one ([D9](artifacts/decision-log.md#d9-the-documentation-surfaces-that-change-with-the-feature)). | The canonical copy changes first; the vendored copies are re-synced in the same change.               |
+| Operator documentation (configuration and sizing guides) | outbound  | The configuration guide's canonical example gains the setting and the cross-skill cost note; the sizing guide's statement that sizing is not project-configurable is revised, its size-override section adds `dynamic` and the unrecognized-argument rule; an ADR records the principle reversal ([D9](artifacts/decision-log.md#d9-the-documentation-surfaces-that-change-with-the-feature)). | The docs and the ADR ship in the same change as the behavior so no surface contradicts another.       |
+
+## Out of Scope
+
+- Changing which specialists are selected, or the caps within each band. The setting picks the band; each skill's
+  sizing rules are untouched.
+- New size bands beyond `small`, `medium`, and `large`.
+- Seeding or writing `.han/config.md` from the plugin side; the operator authors the file, as today.
+- Any change to skills that do not dispatch an agent swarm.
+- Automatic escalation of a configured band when the work's signals disagree with it; the correction is always an
+  explicit per-run size.
+
+## Deferred (YAGNI)
+
+### Per-skill default sizes
+
+- **Why deferred:** evidence test failed. One project-wide default satisfies the stated need; no project has asked for
+  a different default per skill (for example, `large` reviews but `small` research swarms).
+- **Reopen when:** a project using `default-swarm-size` reports needing different defaults for specific skills.
+- **Source:** interview, considered while settling D2.
+
+## Open Items
+
+- **OI-1:** Extend the suite's manual test plan to verify the setting across the eight sizing-aware skills: configured
+  band forced and announced with the config as source, per-run `dynamic` override, unusable value degrading with the
+  one-line note, and `dynamic`/absence auto-classifying. The prior config feature set the precedent of extending the
+  manual test plan alongside the behavior.
+  - **Resolves when:** the manual test plan carries the new cases.
+  - **Blocks implementation:** No. Verification follows the build.
+
+## Summary
+
+- **Outcome delivered:** one config line sets the default swarm size for every sizing-aware skill in a project;
+  `dynamic` (or no setting) preserves auto-classification, and `dynamic` doubles as the per-run escape hatch when a
+  band is configured.
+- **Primary actors:** the project operator authoring `.han/config.md`; the eight sizing-aware skills.
+- **Decisions settled by evidence:** 6, see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Decisions settled by user input:** 4, see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Sub-agents consulted:** han-core:junior-developer, han-core:edge-case-explorer, see
+  [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Key adjustments from review:** the unrecognized-size-argument rule now falls through to the config instead of
+  skipping it; `dynamic` gained its per-run override role; the reversed sizing principle gets an ADR; wrapper-skill
+  and small-on-risky-work cases are now explicit, see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Remaining open items:** 1

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -125,7 +125,8 @@ need the real skill, spend it here.
 4. **[`/architectural-decision-record`](../han-documentation/docs/skills/architectural-decision-record.md)** _(as needed)._ Record
    architectural decisions.
 5. **[`.han/config.md`](./configuration.md)** _(as needed)._ Carry one optional config file to set a base directory for
-   Han's markdown outputs and name extra agents for dispatching skills to consider.
+   Han's markdown outputs, a default swarm size for the sizing-aware skills, and extra agents for dispatching skills
+   to consider.
 
 **You are done when:** you have a `## Project Discovery` section in your AGENTS.md or CLAUDE.md and the docs and
 standards you need to give other skills useful context.

--- a/docs/sizing.md
+++ b/docs/sizing.md
@@ -20,6 +20,9 @@ sizing-aware skills are `/architectural-analysis`, `/code-overview`, `/code-revi
 - **Always overridable.** Pass the size as the first positional argument when invoking the skill (`/code-review medium`,
   `/plan-a-feature small "describe the feature"`, and so on). The skill honors the override and still scales the team
   and round caps to the chosen size.
+- **Project-configurable default.** A project can set a standing default band with the `default-swarm-size` setting in
+  [`.han/config.md`](./configuration.md). A configured band is forced exactly like a passed size argument; an explicit
+  size on the invocation, including `dynamic` to auto-classify one run, always wins over it.
 - **Conservative by design.** Fewer agents producing higher-signal findings is the goal; quantity is not the metric. The
   skill prefers under-dispatching that you can re-run at a larger size to over-dispatching that drowns you in low-signal
   findings.
@@ -85,8 +88,10 @@ Pass the size as the first positional argument when invoking the skill:
 /plan-implementation large docs/features/checkout/feature-specification.md
 ```
 
-Accepted values: `small`, `medium`, `large`. Anything else is treated as part of the trailing context, not as a size,
-and the skill falls back to auto-classification.
+Accepted values: `small`, `medium`, `large`, and `dynamic`. A band forces that size; `dynamic` forces auto-classification
+for that run, which is how you get one signal-classified run in a project whose config sets a default band. Anything
+else is treated as part of the trailing context, not as a size — it supplies no explicit value, so the resolution
+continues down the chain: the config's `default-swarm-size` if the project sets one, and auto-classification otherwise.
 
 When the size is overridden with `$size`:
 
@@ -123,8 +128,12 @@ Read each skill's **Sizing** section for the full per-skill rules.
 - **Sizing scales the team and the brief.** A larger size dispatches more agents _and_ tells each agent that more
   severity bands are in scope and more findings are acceptable. A smaller size narrows both the roster and what each
   agent escalates.
-- **Sizing is overridable, not configurable.** There is no project-level "always run as medium" setting. You opt in to
-  the override on each invocation, when the auto-classification is wrong.
+- **Sizing is overridable, and a project can set the default.** The `default-swarm-size` setting in
+  [`.han/config.md`](./configuration.md) gives a project a standing default band, adopted exactly like a passed size
+  argument and announced with the config named as the source. The per-invocation override still always wins, including
+  `dynamic` to auto-classify a single run. This revises the original principle that sizing was overridable but never
+  project-configurable;
+  [ADR 0001](./adr/0001-project-configurable-default-swarm-size.md) records that reversal and explains why.
 
 ## Related reading
 

--- a/han-atlassian/references/config-rule.md
+++ b/han-atlassian/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-coding/references/config-rule.md
+++ b/han-coding/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-coding/skills/architectural-analysis/SKILL.md
+++ b/han-coding/skills/architectural-analysis/SKILL.md
@@ -9,7 +9,7 @@ description:
   options, prior art, or how something works — use research. Not for writing documentation or architectural decision
   records."
 arguments: size
-argument-hint: "[size: small | medium | large] [focus area: module, directory, or feature to analyze]"
+argument-hint: "[size: small | medium | large | dynamic] [focus area: module, directory, or feature to analyze]"
 allowed-tools: Read, Glob, Grep, Agent, Bash(find *)
 ---
 
@@ -66,8 +66,9 @@ Read these before dispatching anything. They constrain every step below.
 
 ## Step 1: Validate the Focus Area and Resolve Project Context
 
-**Bind `$size`.** If the user passed `small`, `medium`, or `large` as the first positional argument, bind `$size` to it.
-Anything else is part of the focus-area context, not a size; bind `$size` to the literal `none provided`.
+**Bind `$size`.** If the user passed `small`, `medium`, `large`, or `dynamic` as the first positional argument, bind
+`$size` to it. Anything else is part of the focus-area context, not a size; bind `$size` to the literal
+`none provided`.
 
 **Resolve the focus area.** Take the remaining argument and conversation context as the focus area. Confirm it resolves
 to real files using `Glob` and `Read`. Identify the boundary: which files and directories the focus area includes, and
@@ -116,9 +117,13 @@ borderline, stay at the smaller band.
 - **Large** — more than roughly a dozen files across multiple subsystems, OR two or more cross-cutting concerns present
   together, OR a system-seam signal is present, OR `$size` is `large`.
 
-**Apply the size override.** If `$size` is not `none provided`, use it as the band and skip the signal-based
-classification above — but still select specialists by signal (a `large` override does not dispatch agents whose domain
-the code never touches). A conversational override ("run this large") is equivalent to `$size`.
+**Apply the size override.** If `$size` is not `none provided`, use it: a band value is the band and skips the
+signal-based classification above, while `dynamic` forces the signal-based classification even when the project config
+sets a default band. If `$size` is `none provided` and the project config supplies a band via `default-swarm-size`
+(per the config rule in [../../references/config-rule.md](../../references/config-rule.md)), use that band, skip the
+signal-based classification, and announce the config as the source. In every case still select specialists by signal
+(a `large` band does not dispatch agents whose domain the code never touches). A conversational override ("run this
+large") is equivalent to `$size`.
 
 ## Step 3: Build the Roster and Announce It
 

--- a/han-coding/skills/code-overview/SKILL.md
+++ b/han-coding/skills/code-overview/SKILL.md
@@ -11,7 +11,7 @@ description: >
   use architectural-analysis. Does not diagnose bugs or root-cause failures — use investigate.
 arguments: size
 argument-hint:
-  "[size: small | medium | large] [target: file, directory, symbol, or PR reference — defaults to the current branch's
+  "[size: small | medium | large | dynamic] [target: file, directory, symbol, or PR reference — defaults to the current branch's
   changes]"
 allowed-tools: Read, Glob, Grep, Agent, Write, Bash(git *), Bash(gh *), Bash(find *)
 ---
@@ -94,8 +94,8 @@ Read these before doing anything. They constrain every step below.
 
 ## Step 1: Resolve the Target and Select the Mode
 
-**Bind `$size`.** If the user passed `small`, `medium`, or `large` as the first positional argument, bind `$size` to it.
-Anything else is part of the target, not a size; bind `$size` to the literal `none provided`.
+**Bind `$size`.** If the user passed `small`, `medium`, `large`, or `dynamic` as the first positional argument, bind
+`$size` to it. Anything else is part of the target, not a size; bind `$size` to the literal `none provided`.
 
 **Note tool availability.** Read `git installed` and `gh installed` from Project Context. If `git installed` is empty or
 reads `not installed`, git is unavailable — see the degraded paths below.
@@ -133,8 +133,12 @@ signal is borderline.
 - **Medium** — a directory or module, or a moderate change set (several files across one or two adjacent subsystems).
 - **Large** — multiple subsystems, or a large change set (many files across several subsystems).
 
-**Apply the size override.** If `$size` is not `none provided`, use it as the band and skip the signal-based
-classification; a conversational override ("give me a large overview") is equivalent.
+**Apply the size override.** If `$size` is not `none provided`, use it: a band value is the band and skips the
+signal-based classification, while `dynamic` forces the signal-based classification even when the project config sets
+a default band. If `$size` is `none provided` and the project config supplies a band via `default-swarm-size` (per the
+config rule in [../../references/config-rule.md](../../references/config-rule.md)), use that band, skip the
+signal-based classification, and name the config as the source in the announcement below. A conversational override
+("give me a large overview") is equivalent.
 
 **Announce the chosen mode and size in one line before dispatching any exploration** — for example,
 `Code mode, size medium: directory \`src/auth/\` spanning the session and token

--- a/han-coding/skills/code-review/SKILL.md
+++ b/han-coding/skills/code-review/SKILL.md
@@ -7,7 +7,7 @@ description:
   architectural-analysis for that. Does not explain code or a PR to build understanding before reviewing — use
   code-overview for that. Does not capture feedback on Han''s own skills — use han-feedback for that.'
 arguments: size
-argument-hint: "[size: small | medium | large] [optional context about changes or areas to focus on]"
+argument-hint: "[size: small | medium | large | dynamic] [optional context about changes or areas to focus on]"
 allowed-tools: Bash(git *), Bash(gh *), Bash(make *), Bash(npm *), Read, Grep, Glob, Agent
 ---
 
@@ -204,12 +204,16 @@ clearly require it. When a signal is borderline, stay at the smaller band. Use t
 - **Large** — more than 10 files, multiple subsystems, architectural changes, security or data implications,
   multi-service coordination, or the user explicitly requests full agent review.
 
-**Size override.** If `$size` is non-empty (the user passed `small`, `medium`, or `large` as the first argument), use
-that value as the size and skip the signal-based classification. If `$size` is empty, classify from the signals above.
-Anywhere else in this skill body that mentions a "user override" of size, this argument is the override.
+**Size override.** If `$size` is non-empty (the user passed `small`, `medium`, `large`, or `dynamic` as the first
+argument), use it: a band value is the size and skips the signal-based classification, while `dynamic` forces the
+signal-based classification even when the project config sets a default band. If `$size` is empty and the project
+config supplies a band via `default-swarm-size` (per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md)), use that band and skip the signal-based
+classification. Otherwise classify from the signals above. Anywhere else in this skill body that mentions a "user
+override" of size, this argument is the override.
 
 State the chosen size in one line with the justification (e.g., "Medium: 6 files touched, adds one index and a query for
-it" or "Medium: passed via `$size`"). Also draft a one-line summary of what the change does — this is reused in agent
+it", "Medium: passed via `$size`", or "Medium: from `.han/config.md` `default-swarm-size`"). Also draft a one-line summary of what the change does — this is reused in agent
 briefs below.
 
 **This step is the authoritative source for `{size}`.** Every later consumer reads `{size}` from here: the Review

--- a/han-communication/references/config-rule.md
+++ b/han-communication/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-core/references/config-rule.md
+++ b/han-core/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-documentation/references/config-rule.md
+++ b/han-documentation/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-feedback/references/config-rule.md
+++ b/han-feedback/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-github/references/config-rule.md
+++ b/han-github/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-linear/references/config-rule.md
+++ b/han-linear/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-planning/references/config-rule.md
+++ b/han-planning/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-planning/skills/iterative-plan-review/SKILL.md
+++ b/han-planning/skills/iterative-plan-review/SKILL.md
@@ -7,7 +7,7 @@ description: >
   feasibility of an approach. Does not implement plan steps, write test plans, review code, or investigate bugs, and
   does not generate new plans from scratch — use plan-a-feature for a new plan.
 arguments: size
-argument-hint: "[size: small | medium | large] [context or path to plan file]"
+argument-hint: "[size: small | medium | large | dynamic] [context or path to plan file]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *)
 ---
 
@@ -157,9 +157,13 @@ The size determines:
 | Medium | team        | 3–4                    | 2         |
 | Large  | team        | 4–5                    | 3         |
 
-**Size override.** If `$size` is non-empty (the user passed `small`, `medium`, or `large` as the first argument), use
-that value as the size and skip the signal-based classification above. State the chosen size and mode to the user in one
-line with the justification (e.g., "Medium: 4 files, one auth surface" or "Medium: passed via `$size`"). If the user
+**Size override.** If `$size` is non-empty (the user passed `small`, `medium`, `large`, or `dynamic` as the first
+argument), use it: a band value is the size and skips the signal-based classification above, while `dynamic` forces the
+signal-based classification even when the project config sets a default band. If `$size` is empty and the project
+config supplies a band via `default-swarm-size` (per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md)), use that band and skip the signal-based
+classification. State the chosen size and mode to the user in one line with the justification (e.g., "Medium: 4 files,
+one auth surface", "Medium: passed via `$size`", or "Medium: from `.han/config.md` `default-swarm-size`"). If the user
 asked for team review on a plan that would otherwise be small, honor the request and treat it as medium-or-larger. If
 the user explicitly names a size in conversation, accept the override.
 

--- a/han-planning/skills/plan-a-feature/SKILL.md
+++ b/han-planning/skills/plan-a-feature/SKILL.md
@@ -8,7 +8,7 @@ description: >
   iterative-plan-review. Does not document already-built features — use project-documentation. Does not research
   open-ended options before there is a feature to specify — use research.
 arguments: size
-argument-hint: "[size: small | medium | large] [feature description, optional: output folder path]"
+argument-hint: "[size: small | medium | large | dynamic] [feature description, optional: output folder path]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(mkdir *)
 ---
 
@@ -307,10 +307,14 @@ This size drives the team-size cap in Step 6:
 | Medium | 3 to 4                                              | Typical default; the historical cap.                           |
 | Large  | 4 to 5                                              | Reserved for plans where missed coverage is expensive.         |
 
-**Size override.** If `$size` is non-empty (the user passed `small`, `medium`, or `large` as the first argument), use
-that value as the size and skip the signal-based classification above; the team cap still scales to the chosen size.
-State the chosen size, the recommended specialists, and the reason for the size choice to the user in one short message
-before launching agents (e.g., "Medium: two subsystems, small auth surface" or "Medium: passed via `$size`"). If the
+**Size override.** If `$size` is non-empty (the user passed `small`, `medium`, `large`, or `dynamic` as the first
+argument), use it: a band value is the size and skips the signal-based classification above, while `dynamic` forces the
+signal-based classification even when the project config sets a default band. If `$size` is empty and the project
+config supplies a band via `default-swarm-size` (per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md)), use that band and skip the signal-based
+classification. The team cap still scales to the chosen size. State the chosen size, the recommended specialists, and
+the reason for the size choice to the user in one short message before launching agents (e.g., "Medium: two subsystems,
+small auth surface", "Medium: passed via `$size`", or "Medium: from `.han/config.md` `default-swarm-size`"). If the
 user disagrees, accept their override (size, specific specialists, or both) and proceed.
 
 ## Step 6: Dispatch the Review Team

--- a/han-planning/skills/plan-implementation/SKILL.md
+++ b/han-planning/skills/plan-implementation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   feature that has already been specified. Does not specify what the feature should do — use plan-a-feature first. Does
   not refine or stress-test an already-written plan — use iterative-plan-review.
 arguments: size
-argument-hint: "[size: small | medium | large] [feature specification path, optional: additional context]"
+argument-hint: "[size: small | medium | large | dynamic] [feature specification path, optional: additional context]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Agent, Bash(find *), Bash(git *)
 ---
 
@@ -161,10 +161,15 @@ security/PII surface, integration boundaries, and the user's framing:
   explicitly requests full team. Team cap: **6 to 8** (han-core:project-manager + han-core:junior-developer + 4–6 chosen
   specialists). Round cap: **3.**
 
-**Size override.** If `$size` is non-empty (the user passed `small`, `medium`, or `large` as the first argument), use
-that value as the size and skip the signal-based classification above; the team cap and round cap still scale to the
-chosen size. State the chosen size, the recommended team, and the reason for the size choice to the user in one short
-message before launching agents (e.g., "Medium: two subsystems, small auth surface" or "Medium: passed via `$size`"). If
+**Size override.** If `$size` is non-empty (the user passed `small`, `medium`, `large`, or `dynamic` as the first
+argument), use it: a band value is the size and skips the signal-based classification above, while `dynamic` forces the
+signal-based classification even when the project config sets a default band. If `$size` is empty and the project
+config supplies a band via `default-swarm-size` (per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md)), use that band and skip the signal-based
+classification. The team cap and round cap still scale to the chosen size. State the chosen size, the recommended team,
+and the reason for the size choice to the user in one short message before launching agents (e.g., "Medium: two
+subsystems, small auth surface", "Medium: passed via `$size`", or "Medium: from `.han/config.md`
+`default-swarm-size`"). If
 the user disagrees, accept the override (size, specific specialists, or both) and proceed.
 
 The team **always includes**:

--- a/han-plugin-builder/references/config-rule.md
+++ b/han-plugin-builder/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-reporting/references/config-rule.md
+++ b/han-reporting/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-research/references/config-rule.md
+++ b/han-research/references/config-rule.md
@@ -12,6 +12,16 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
 - `output-directory` (frontmatter key): a base path, relative to the working directory, under which the skill writes
   its markdown deliverables while keeping its own folder and file structure beneath it. Create the directory on first
   write when it does not exist.
+- `default-swarm-size` (frontmatter key): the default size band for skills that classify a swarm or team size before
+  dispatching agents. Accepted values, trimmed of surrounding whitespace and matched case-insensitively: `small`,
+  `medium`, `large`, `dynamic`. A value of `small`, `medium`, or `large` is adopted exactly as if the user had passed
+  it as the skill's size argument: the skill skips its signal-based classification, scales its caps to the band, and
+  announces the band with the config named as the source. Specialists are still selected by signal within the band's
+  caps. `dynamic`, or an absent setting, leaves the skill classifying the size itself from the work's signals, with no
+  mention of the config. Explicit user input outranks the setting per the precedence chain, and `dynamic` is also a
+  valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
+  typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
+  ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 

--- a/han-research/skills/gap-analysis/SKILL.md
+++ b/han-research/skills/gap-analysis/SKILL.md
@@ -8,7 +8,7 @@ description: >
   to compare against — use research.
 arguments: size
 argument-hint:
-  "[size: small | medium | large] [current state artifact, desired state artifact, optional: scope and modes]"
+  "[size: small | medium | large | dynamic] [current state artifact, desired state artifact, optional: scope and modes]"
 allowed-tools: Read, Write, Glob, Grep, Agent, Bash(find *), Bash(git *)
 ---
 
@@ -201,10 +201,14 @@ example:
 > - `han-core:adversarial-security-analyst` — three gaps touch session-token handling.
 > - `han-core:project-manager` — required at medium; consolidates swarm output into Section 4.
 
-**Size override.** If `$size` is non-empty (the user passed `small`, `medium`, or `large` as the first argument), use
-that value as the size and skip the signal-based classification above; the swarm composition still scales to the chosen
-size. If the user named specific specialists, honor those. If the user requested a different size in conversation rather
-than via `$size`, accept the override.
+**Size override.** If `$size` is non-empty (the user passed `small`, `medium`, `large`, or `dynamic` as the first
+argument), use it: a band value is the size and skips the signal-based classification above, while `dynamic` forces the
+signal-based classification even when the project config sets a default band. If `$size` is empty and the project
+config supplies a band via `default-swarm-size` (per the config rule in
+[../../references/config-rule.md](../../references/config-rule.md)), use that band, skip the signal-based
+classification, and announce the config as the source. The swarm composition still scales to the chosen size. If the
+user named specific specialists, honor those. If the user requested a different size in conversation rather than via
+`$size`, accept the override.
 
 ## Step 4: Confirm Swarm and Technical-Detail Modes
 

--- a/han-research/skills/research/SKILL.md
+++ b/han-research/skills/research/SKILL.md
@@ -11,7 +11,7 @@ description:
   han-feedback."
 arguments: size
 argument-hint:
-  '[size: small | medium | large] [the open-ended question to research] [optional output path] [optional: "evidence
+  '[size: small | medium | large | dynamic] [the open-ended question to research] [optional output path] [optional: "evidence
   optional" / "exploratory" to relax the evidence requirement]'
 allowed-tools: Read, Glob, Grep, Agent, WebSearch, WebFetch, Bash(find *)
 ---
@@ -79,8 +79,8 @@ Read these before dispatching anything. They constrain every step below.
 
 ## Step 1: Capture the Question and Resolve Context
 
-**Bind `$size`.** If the user passed `small`, `medium`, or `large` as the first positional argument, bind `$size` to it.
-Anything else is part of the question, not a size; bind `$size` to the literal `none provided`.
+**Bind `$size`.** If the user passed `small`, `medium`, `large`, or `dynamic` as the first positional argument, bind
+`$size` to it. Anything else is part of the question, not a size; bind `$size` to the literal `none provided`.
 
 **Capture the question and output path.** Take the remaining argument and conversation context as the question to
 research. If the user supplied an output path and a report already exists there, ask whether to overwrite it or write
@@ -134,10 +134,13 @@ smaller.
 - **Medium** — two to three domains, several competing options, or codebase-plus-web reach.
 - **Large** — many options across multiple domains, or an explicit request for full breadth, or `$size` is `large`.
 
-**Apply the size override.** If `$size` is not `none provided`, use it as the band and skip the signal-based
-classification — but still pick angles by signal (a `large` override does not run a codebase angle when there is no
-codebase, or an option-comparison angle when there are no options). A conversational override ("research this broadly")
-is equivalent to `$size`.
+**Apply the size override.** If `$size` is not `none provided`, use it: a band value is the band and skips the
+signal-based classification, while `dynamic` forces the signal-based classification even when the project config sets
+a default band. If `$size` is `none provided` and the project config supplies a band via `default-swarm-size` (per the
+config rule in [../../references/config-rule.md](../../references/config-rule.md)), use that band, skip the
+signal-based classification, and announce the config as the source. In every case still pick angles by signal (a
+`large` band does not run a codebase angle when there is no codebase, or an option-comparison angle when there are no
+options). A conversational override ("research this broadly") is equivalent to `$size`.
 
 ## Step 4: Build the Roster and Announce It
 


### PR DESCRIPTION
## What

Adds the feature specification for a new `.han/config.md` frontmatter setting, `default-swarm-size` (`small` | `medium` | `large` | `dynamic`, absent = `dynamic`), which sets a standing default band for the eight sizing-aware skills.

Planning artifacts (spec, decision log, team findings) live in `docs/plans/config-default-swarm-size/`.

## Key behaviors specified

- A configured `small`/`medium`/`large` forces the band exactly like an explicit size argument; explicit user input still wins under the existing config precedence chain.
- `dynamic` (or no setting) keeps today's auto-classification, and `dynamic` is also accepted as an explicit per-run size to override a configured band for one run.
- An unrecognized size argument (typo) falls through to the config instead of silently bypassing it.
- Unusable values degrade with the existing one-line note; a bad config never fails a run.
- Doc surfaces in scope: config-rule.md (canonical + vendored copies), docs/configuration.md, docs/sizing.md, plus an ADR recording the reversal of the "sizing is overridable, not configurable" principle.

## Review

Reviewed at size Small by han-core:junior-developer and han-core:edge-case-explorer; 13 findings recorded and resolved in `artifacts/team-findings.md`. One open item: extend the manual test plan (does not block implementation).