### PR TITLE
feature(config): add writing-voice override to .han/config.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,8 @@
 # Project-Local Configuration
 
 A project that uses Han can carry one optional file, `.han/config.md`, to adjust how Han skills behave in that project.
-The file controls three things: where skills write their markdown deliverables, which extra agents dispatching skills
-consider, and the default swarm size the sizing-aware skills start at. Every Han skill reads the file on every run, so
+The file controls where skills write their markdown deliverables, which extra agents dispatching skills consider, the
+default swarm size the sizing-aware skills start at, and the writing-voice profile the readability skills apply. Every Han skill reads the file on every run, so
 the overrides take effect without depending on the model remembering to look. A project without the file sees no
 change of any kind.
 
@@ -14,9 +14,10 @@ change of any kind.
 - **You write the file; Han cannot.** Han cannot ship or seed a project-level config from the plugin side. You create
   `.han/config.md` by hand in a `.han/` folder at your project root, and it travels through version control like any
   other file. The annotated example below is the canonical source to author from.
-- **Three overrides ship.** `output-directory` sets one base directory for every skill's markdown deliverables.
-  `default-swarm-size` sets the size band every sizing-aware skill starts at. `## Extra Agents` names project-defined
-  or third-party agents that Han's dispatching skills consider alongside their built-in rosters.
+- **These overrides ship.** `output-directory` sets one base directory for every skill's markdown deliverables.
+  `default-swarm-size` sets the size band every sizing-aware skill starts at. `writing-voice` points the readability
+  skills at a project-supplied writing-voice profile in place of the built-in Han voice. `## Extra Agents` names
+  project-defined or third-party agents that Han's dispatching skills consider alongside their built-in rosters.
 - **A bad config can never fail a skill run.** The worst it can do is be ignored, with a one-line note naming what was
   ignored. A missing or empty file changes nothing and says nothing.
 - **The interpretation contract lives in
@@ -26,7 +27,7 @@ change of any kind.
 
 ## The file, annotated
 
-Create `.han/config.md` in the directory you run Han skills from. This is the one canonical example; both settings are
+Create `.han/config.md` in the directory you run Han skills from. This is the one canonical example; every setting is
 optional, and everything unrecognized is ignored.
 
 ```markdown
@@ -44,6 +45,14 @@ output-directory: docs/han
 # lets each skill classify the size itself. Passing a size on an invocation,
 # including "dynamic" to auto-classify one run, always wins over this default.
 default-swarm-size: dynamic
+
+# Writing-voice profile for the readability skills, as a file path relative to
+# this project's root. When set and the file exists, it replaces the built-in
+# Han voice (han-communication's writing-voice.md) for the run. When set and
+# the file is missing, the skill warns you and asks whether to use the built-in
+# voice or skip the writing voice entirely. Omit the line to keep the built-in
+# voice.
+writing-voice: docs/our-writing-voice.md
 ---
 
 ## Extra Agents
@@ -85,6 +94,22 @@ a `large` research swarm cost different work), so a global `large` raises agent 
 per-run correction never needs a file edit: passing a size on the invocation always wins, and passing `dynamic`
 auto-classifies that run. See [Sizing](./sizing.md) for the bands and per-skill caps.
 
+### `writing-voice`
+
+The readability surfaces in `han-communication` ([`/readability-guidance`](../han-communication/docs/skills/readability-guidance.md),
+[`/edit-for-readability`](../han-communication/docs/skills/edit-for-readability.md), and the
+[`readability-editor`](../han-communication/docs/agents/readability-editor.md) agent they feed) read their
+writing-voice profile from this setting. The value is a file path, relative to the project root, naming a
+writing-voice profile of your own. When the file exists, it replaces the built-in profile at
+[`han-communication/references/writing-voice.md`](../han-communication/references/writing-voice.md) wholesale,
+including the vocabulary blocklist the readability rule enforces, so every prose-producing Han skill drafts in your
+project's voice instead of Han's.
+
+When the setting names a file that does not exist, the skill does not degrade silently: it warns you that the file was
+not found and asks whether to use the built-in Han voice or skip the writing voice entirely for that run. Skipping
+applies the readability rule with no voice profile and no vocabulary blocklist. Omitting the setting keeps the
+built-in Han voice with no mention of the config.
+
 ### `## Extra Agents`
 
 Skills that select among candidate agents (for example [`/code-review`](../han-coding/docs/skills/code-review.md),
@@ -122,6 +147,10 @@ rule: a one-line note appears only when content that attempts a recognized overr
 frontmatter, an unrecognized setting name, a blank value, an out-of-bounds `output-directory`, or an unresolvable agent
 name. Content the suite has no use for (plain prose in the file) is passed over silently, and when everything applies
 cleanly the skills say nothing about the config at all.
+
+`writing-voice` naming a missing file is the one exception to the note-and-move-on rule: because the wrong fallback
+would silently change the voice of everything a run writes, the skill asks you whether to use the built-in Han voice
+or skip the writing voice, instead of picking for you.
 
 ## Keeping the file visible
 

--- a/han-atlassian/references/config-rule.md
+++ b/han-atlassian/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.

--- a/han-coding/references/config-rule.md
+++ b/han-coding/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.

--- a/han-communication/agents/readability-editor.md
+++ b/han-communication/agents/readability-editor.md
@@ -22,6 +22,12 @@ first, then the draft. If the dispatching skill names a specific reader (an engi
 reviewer, a non-technical stakeholder), edit for that reader instead of the default frame, and keep the technical
 specifics that reader needs.
 
+The dispatching skill may also name a writing-voice profile file. When it does, read that file and apply it in place of
+the built-in writing-voice profile, including as the vocabulary blocklist criterion 5 enforces. When the skill says the
+writing voice is skipped for this run, apply criterion 5 with no voice profile and no vocabulary blocklist: keep the
+common-words and plain-diction rules, drop only the blocklist enforcement. When the dispatch says nothing about the
+voice, the built-in profile co-located with the readability rule applies.
+
 **Your posture is adversarial toward the draft, never toward its author.** Assume it opens with throat-clearing instead
 of the answer, gives a paragraph two ideas, labels a heading "Analysis," and runs a forty-word sentence where two short
 ones would read. Prove otherwise or fix it.

--- a/han-communication/docs/agents/readability-editor.md
+++ b/han-communication/docs/agents/readability-editor.md
@@ -53,6 +53,10 @@ Give it:
    pull-request reviewer, a non-technical stakeholder), so the agent edits for the right audience and keeps the
    technical specifics that reader needs.
 3. **An output path (optional).** When the draft is a file, the agent rewrites it in place; name the path.
+4. **A writing-voice profile (optional).** When `.han/config.md` sets `writing-voice` to a file that exists, the
+   dispatching skill names that file and the agent applies it in place of the built-in voice profile; the skill can
+   instead say the writing voice is skipped, and the agent drops only the blocklist enforcement. Left unsaid, the
+   built-in profile applies.
 
 Example prompts:
 

--- a/han-communication/docs/skills/edit-for-readability.md
+++ b/han-communication/docs/skills/edit-for-readability.md
@@ -114,8 +114,10 @@ The skill runs a short, four-step process:
    dispatching, because the in-place rewrite is the one action that changes a file you own. Scratch copies of pasted
    text or a conversation draft skip the gate, because the original is untouched.
 3. **Dispatch the readability-editor.** One `Agent` call hands the editor the target path and the reader frame, with the
-   instruction to operate on prose regions only and preserve every fact. The editor reads its own co-located canonical
-   rule and owns the rubric.
+   instruction to operate on prose regions only and preserve every fact. When `.han/config.md` sets `writing-voice` to
+   a file that exists, the dispatch also names that file so the editor applies it in place of the built-in voice
+   profile; when the configured file is missing, the skill warns you and asks whether to use the built-in Han voice or
+   skip the writing voice before dispatching. The editor reads its own co-located canonical rule and owns the rubric.
 4. **Deliver the result.** Report the rewrite with the editor's rubric verdict, fact-preservation ledger, and untouched
    regions. If the ledger flags a fact that could not be preserved while satisfying a criterion, the skill relays it
    rather than presenting the result as clean.
@@ -135,7 +137,9 @@ properties, staged application, and fidelity guard.
 ### The writing-voice profile
 
 The word-level blocklist the standard reuses lives in
-[`han-communication/references/writing-voice.md`](../../references/writing-voice.md).
+[`han-communication/references/writing-voice.md`](../../references/writing-voice.md). A project can replace it with
+its own profile through the `writing-voice` setting in `.han/config.md`; see
+[Configuration](../../../docs/configuration.md).
 
 ## Related documentation
 

--- a/han-communication/docs/skills/readability-guidance.md
+++ b/han-communication/docs/skills/readability-guidance.md
@@ -44,10 +44,12 @@ and _how_ the skill is used. For what the skill does internally, read the skill 
 
 ## How it works
 
-The skill reads its own two canonical reference files (the readability rule and the writing-voice profile) so their
-content enters the caller's context, then instructs the caller to hold the audience frame, draft into its template, run
-the standardized self-check, and (for a synthesis skill) dispatch the editor. It closes by telling the caller to return
-to the workflow that invoked it.
+The skill first resolves which writing-voice profile the run uses: the project's own file when `.han/config.md` sets
+`writing-voice` and the file exists, otherwise the built-in profile. When the configured file is missing, it warns you
+and asks whether to fall back to the built-in Han voice or skip the writing voice entirely. It then reads the
+readability rule and the resolved voice profile so their content enters the caller's context, and instructs the caller
+to hold the audience frame, draft into its template, run the standardized self-check, and (for a synthesis skill)
+dispatch the editor. It closes by telling the caller to return to the workflow that invoked it.
 
 ## Cost and latency
 

--- a/han-communication/references/config-rule.md
+++ b/han-communication/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.

--- a/han-communication/skills/edit-for-readability/SKILL.md
+++ b/han-communication/skills/edit-for-readability/SKILL.md
@@ -71,6 +71,13 @@ Also settle the reader frame: default to a capable reader who did not do this wo
 the user names a specific reader (an engineer implementing a fix, a PR reviewer, a non-technical stakeholder), carry
 that reader to the editor instead so the technical specifics that reader needs are kept.
 
+Finally, resolve the writing-voice source. When the `.han/config.md` probe supplied a `writing-voice` value, treat it
+as a file path relative to the working directory and check that the file exists. When it exists, that file replaces
+the built-in writing-voice profile for this run. When it does not exist, warn the user that the configured
+writing-voice file was not found, and ask whether to use the built-in Han voice or skip the writing voice entirely for
+this run; honor the answer. When no `writing-voice` value is configured, the editor's own co-located built-in profile
+applies and you pass nothing about the voice.
+
 ## Step 2: Confirm before rewriting a file in place
 
 If the target is a file on disk (not a scratch copy of pasted text or a conversation draft), tell the user which file
@@ -91,6 +98,10 @@ Dispatch `han-communication:readability-editor` with one `Agent` call
 - The reader frame from Step 1: the default capable-reader frame, or the specific reader the user named.
 - The instruction to operate on prose regions only — never inside code fences, diagram bodies, rendered markup, or
   citation identifiers, which survive unchanged — and to apply its rewrite to the file in place, preserving every fact.
+- The writing-voice resolution from Step 1, when it differs from the default: the path to the configured
+  writing-voice file the editor uses in place of the built-in profile, or the instruction that the writing voice is
+  skipped for this run. When no `writing-voice` is configured, say nothing about the voice; the editor's built-in
+  profile applies.
 
 Do not paraphrase the standard into the prompt or list its criteria yourself; the editor reads the rule and owns the
 rubric. If the dispatch fails or the editor is unavailable, tell the user the readability pass could not run rather than

--- a/han-communication/skills/readability-guidance/SKILL.md
+++ b/han-communication/skills/readability-guidance/SKILL.md
@@ -35,17 +35,30 @@ human reads it end to end — to approve it, follow it, or build from it — eve
 an artifact consumed purely as a pipeline input, with no human reading it end to end, falls outside the standard. If a
 human reads your deliverable end to end, apply the standard to it.
 
-## Step 1: Read the canonical standard
+## Step 1: Resolve the writing-voice source, then read the standard
 
-Read both canonical reference files, in this order, so their full content enters your context:
+First resolve which writing-voice profile this run uses:
+
+- When the `.han/config.md` probe supplied a `writing-voice` value, treat the value as a file path relative to the
+  working directory and check that the file exists.
+  - When the file exists, it is the writing-voice profile for this run, used in place of the built-in profile.
+  - When the file does not exist, warn the user that the configured writing-voice file was not found, and ask whether
+    to use the built-in Han voice or skip the writing voice entirely for this run. Honor the answer: fall back to the
+    built-in profile, or proceed with no voice profile at all.
+- When the probe supplied no `writing-voice` value, the built-in profile at
+  `${CLAUDE_PLUGIN_ROOT}/references/writing-voice.md` applies.
+
+Then read the reference files, in this order, so their full content enters your context:
 
 1. `${CLAUDE_PLUGIN_ROOT}/references/readability-rule.md` — the Human-Readable Output Standard: the audience frame, the
    output properties, the length guidance, the prose-only and fidelity rules, and the standardized self-check.
-2. `${CLAUDE_PLUGIN_ROOT}/references/writing-voice.md` — the writing-voice profile, whose "Avoided words and phrases"
-   and "AI slop to avoid" sections are the authoritative vocabulary blocklist the rule points to.
+2. The resolved writing-voice profile — the configured file, or the built-in
+   `${CLAUDE_PLUGIN_ROOT}/references/writing-voice.md`, whose "Avoided words and phrases" and "AI slop to avoid"
+   sections are the authoritative vocabulary blocklist the rule points to. A configured profile stands in for the
+   built-in one wholesale: apply whatever voice and vocabulary guidance it carries. When the user chose to skip the
+   writing voice, read only the readability rule and apply it with no voice profile and no vocabulary blocklist.
 
-Read them from this plugin's own `references/` directory. Do not paraphrase or summarize them in place of reading them —
-the surfaced content is the point.
+Do not paraphrase or summarize the files in place of reading them — the surfaced content is the point.
 
 ## Step 2: Hold the audience frame while you draft
 

--- a/han-core/references/config-rule.md
+++ b/han-core/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.

--- a/han-documentation/references/config-rule.md
+++ b/han-documentation/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.

--- a/han-feedback/references/config-rule.md
+++ b/han-feedback/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.

--- a/han-github/references/config-rule.md
+++ b/han-github/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.

--- a/han-linear/references/config-rule.md
+++ b/han-linear/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.

--- a/han-planning/references/config-rule.md
+++ b/han-planning/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.

--- a/han-plugin-builder/references/config-rule.md
+++ b/han-plugin-builder/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.

--- a/han-reporting/references/config-rule.md
+++ b/han-reporting/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.

--- a/han-research/references/config-rule.md
+++ b/han-research/references/config-rule.md
@@ -22,6 +22,14 @@ The file is markdown: optional YAML frontmatter for scalar settings, then named 
   valid explicit size input that forces signal-based classification for that run. An unrecognized size argument (a
   typo) supplies no explicit value, so the configured band still applies. A skill that dispatches no agent swarm
   ignores the setting silently.
+- `writing-voice` (frontmatter key): a file path, relative to the working directory, naming the writing-voice profile
+  the readability skills apply in place of the built-in profile at
+  `han-communication/references/writing-voice.md`. An absent or blank setting keeps the built-in profile. When a value
+  is present, verify the file exists before using it. When it exists, that file is the writing-voice profile for the
+  run, including the vocabulary blocklist the readability rule points to. When it does not exist, do not degrade
+  silently: warn the user that the configured writing-voice file was not found, and ask whether to use the built-in Han
+  voice or skip the writing voice entirely for the run. Skipping means the run applies the readability rule with no
+  voice profile and no vocabulary blocklist. A skill that produces no prose deliverable ignores the setting silently.
 - `## Extra Agents` (section heading): one agent per list line, in qualified `plugin:agent` form or bare-name form.
   Match names case-insensitively against the agents available in the session.
 
@@ -62,7 +70,9 @@ to a dispatchable agent is skipped with the one-line note naming it.
 ## Degradation and the one-line note
 
 A bad config can never fail a skill run; the worst it can do is be ignored. Show a one-line note only when content
-that attempts a recognized override cannot be used; pass over everything else silently.
+that attempts a recognized override cannot be used; pass over everything else silently. A `writing-voice` value naming
+a file that does not exist is the one exception: per its definition above, it asks the user which fallback to take
+instead of degrading with a note.
 
 - Malformed frontmatter, or a file unreadable as text: ignore the unusable portion, resolve those settings from the
   rest of the precedence chain, and note what was ignored.


### PR DESCRIPTION
## Summary

Adds a new `writing-voice` frontmatter key to the `.han/config.md` project config, letting a consuming project point Han's readability surfaces at its own writing-voice profile instead of the built-in Han voice.

## Behavior

- **Absent or blank**: the built-in profile at `han-communication/references/writing-voice.md` applies, with no mention of the config.
- **Set to a file that exists** (path relative to the working directory): that file replaces the built-in profile wholesale for the run, including the vocabulary blocklist the readability rule enforces.
- **Set to a file that does not exist**: the skill warns the user and asks whether to use the built-in Han voice or skip the writing voice entirely for the run. Skipping applies the readability rule with no voice profile and no blocklist. This is an explicit, documented exception to the config rule's silent note-and-degrade behavior.

## Changes

- `han-core/references/config-rule.md` (canonical): defines the `writing-voice` key and names the ask-instead-of-note exception in the degradation section. All vendored copies re-synced byte-identical.
- `han-communication:readability-guidance`: Step 1 now resolves the voice source (configured file, warn-and-ask fallback, or built-in) before reading the standard, so every prose-producing consumer picks the override up automatically.
- `han-communication:edit-for-readability`: resolves the voice in Step 1 and carries the outcome (file path, skip instruction, or nothing) into the readability-editor dispatch.
- `readability-editor` agent: accepts a named voice-profile file in place of the built-in profile, or a skip instruction that drops only blocklist enforcement.
- Docs: `docs/configuration.md` annotated example and new `writing-voice` section (overview made count-free), plus matching updates to the long-form docs for both skills and the agent.