### PR TITLE
chore(deps): bump the dev-tooling group with 4 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.3
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: lts/*
           cache: npm
       - name: Cache prek hook environments
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.cache/prek
           key: prek-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -41,8 +41,8 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.3
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: lts/*
           cache: npm

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
 
   # Lint shell scripts. prek builds the environment; no Docker, no global install.
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
 


### PR DESCRIPTION
Recreates Dependabot PR #125 on the **v5.0.0-alpha** line.

`main` is frozen until v5, and #125 targets `main` from a branch on `testdouble/han` that a non-maintainer cannot re-base onto the alpha branch. This PR reapplies the same bumps on top of `han-v5.0.0-alpha-1` from a fork branch instead, so #125 can be closed in favor of this one.

Same version targets as #125:

- `actions/checkout` 4 → 6.0.3
- `actions/setup-node` 4 → 6.4.0
- `actions/cache` 4 → 5.0.5
- `shellcheck-py` 0.10.0.1 → 0.11.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)