### PR TITLE
chore(test): relocate Bats tests next to the scripts they cover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,3 +264,13 @@ such as Claude, should be referenced here.
   `han-communication/agents/`, and `han-research/agents/` (long-form docs in `{plugin}/docs/agents/`, indexed in
   `docs/agents/README.md`). Verify the indexes list every entity when editing them, rather than tracking a running
   total.
+
+## Project Discovery
+
+- Default branch: `main`
+- Language: Markdown (skill, agent, and doc content) and Bash (skill `scripts/`)
+- Package manager: npm. The root `package.json` manages dev tooling only; there is no application build or dev server.
+- Install: `npm install` installs prek, Prettier, and Bats locally, with nothing on the global PATH.
+- Lint: `npm run lint` runs `prek run --all-files` (Prettier, ShellCheck, and file-hygiene hooks).
+- Test: `npm test` runs Bats over every `*.bats` file in the repo outside `node_modules`; a script's tests sit beside
+  it in the same directory, and harness-level checks live in `test/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,8 +80,9 @@ How Prettier treats your files:
   `han-reporting/skills/html-summary/assets/`, are left untouched (`.prettierignore`).
 
 Shell scripts are linted with ShellCheck. A script's tests sit next to it as a `*.bats` file in the same directory
-(for example `scripts/detect-git-context.sh` is covered by `scripts/detect-git-context.bats`); harness-level checks
-that aren't tied to one script live in `test/`. `npm test` discovers every `*.bats` file in the repo outside
+(for example `han-coding/skills/code-review/scripts/detect-review-context.sh` is covered by
+`detect-review-context.bats` in that same directory); harness-level checks that aren't tied to one script live in
+`test/`. `npm test` discovers every `*.bats` file in the repo outside
 `node_modules`. Tests run in CI rather than on commit; run them locally with `npm test`.
 
 ## Which plugin does the change belong in?

--- a/han-coding/skills/automated-test-planning/scripts/detect-test-context.bats
+++ b/han-coding/skills/automated-test-planning/scripts/detect-test-context.bats
@@ -8,7 +8,7 @@
 # detector's tests.
 
 setup() {
-  SRC="$BATS_TEST_DIRNAME/../han-coding/skills/automated-test-planning/scripts/detect-test-context.sh"
+  SRC="$BATS_TEST_DIRNAME/detect-test-context.sh"
   TMP="$(mktemp -d)"
 }
 

--- a/han-coding/skills/code-review/scripts/detect-review-context.bats
+++ b/han-coding/skills/code-review/scripts/detect-review-context.bats
@@ -8,7 +8,7 @@
 # detector's tests.
 
 setup() {
-  SRC="$BATS_TEST_DIRNAME/../han-coding/skills/code-review/scripts/detect-review-context.sh"
+  SRC="$BATS_TEST_DIRNAME/detect-review-context.sh"
   TMP="$(mktemp -d)"
 }
 

--- a/test/sanity.bats
+++ b/test/sanity.bats
@@ -1,7 +1,9 @@
 #!/usr/bin/env bats
 #
 # Sanity check: proves the Bats harness and the CI test job actually run.
-# Real script tests land as their own test/*.bats files.
+# Real script tests sit next to the script they cover (e.g.
+# scripts/foo.sh alongside scripts/foo.bats); test/ keeps only
+# harness-level checks like this one.
 
 @test "sanity: arithmetic works (2 + 2 == 4)" {
   result=$((2 + 2))


### PR DESCRIPTION
## What

Follow-up to #132. That PR switched `npm test` to discover every `*.bats` file repo-wide (outside `node_modules`) and documented the intent that a script's tests should sit next to the script they cover. This PR is the relocation it promised.

Move the two detector tests out of `test/` so they sit beside the scripts they cover:

- `test/detect-review-context.bats` → `han-coding/skills/code-review/scripts/detect-review-context.bats`
- `test/detect-test-context.bats` → `han-coding/skills/automated-test-planning/scripts/detect-test-context.bats`

`test/` now holds only harness-level checks (`sanity.bats`).

## Changes

- **Relocate both detector tests** next to their scripts (git-tracked as renames, 99% similarity).
- **Collapse each test's `SRC` path** from a `$BATS_TEST_DIRNAME/../han-coding/skills/.../scripts/<name>.sh` walk to a plain sibling `$BATS_TEST_DIRNAME/<name>.sh`.
- **Refresh the `test/sanity.bats` comment**, which previously claimed script tests land as their own `test/*.bats` files.
- **Point the CONTRIBUTING example** at a file that now exists on this branch (`detect-review-context`) instead of the forward-referenced `detect-git-context`.
- **Record the lint/test commands** in CLAUDE.md's `## Project Discovery` section (there was none before).

## Verification

`npm test` discovers the relocated files repo-wide and stays green:

```
1..35
```

(17 tests per detector + the `sanity.bats` check.) `npx prettier --check` passes on both edited Markdown files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01277Q2Dx2xhgnBJiYM8mgcg
