### PR TITLE
feat(code-review, code-overview): answer the reader's questions inside the run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,9 +249,10 @@ test, add it to that list and wire the standard in:
    that reader instead of defaulting. Scope the frame per section so technical specifics the reader needs are not
    simplified away.
 4. **Add the standardized self-check.** Before presenting, the skill runs six behaviorally-anchored yes/no criteria over
-   the prose regions only: main point first, descriptive headings, one idea per paragraph, sentence length, no
-   blocklisted word, every fact preserved. It corrects any failure. Leave code fences, diagram bodies, rendered markup,
-   and citation identifiers unevaluated and unchanged.
+   the prose regions only: main point first, descriptive headings, one idea per paragraph, sentence length, common
+   words with no blocklisted word and an explanation for every term the reader cannot look up, every fact preserved. It
+   corrects any failure. Leave code fences, diagram bodies, rendered markup, and citation identifiers unevaluated and
+   unchanged.
 5. **Wire the rewrite pass only if the skill synthesizes.** If the skill has a synthesis or editor step (a distinct
    pass, after the full draft exists, that reviews or consolidates the whole draft before presenting it), dispatch the
    [`readability-editor`](./han-communication/docs/agents/readability-editor.md) agent after the draft is written and

--- a/docs/plans/code-review-overview-language-corrections/artifacts/decision-log.md
+++ b/docs/plans/code-review-overview-language-corrections/artifacts/decision-log.md
@@ -7,6 +7,17 @@ rejected alternatives.
 
 The boundary these decisions were settled inside is recorded in [scope-boundary.md](./scope-boundary.md).
 
+Every decision below was classified once, after the review round returned, as full or trivial. The D# numbers were
+assigned while drafting and did not change in that pass, so every inline link in the specification still resolves.
+
+## Trivial decisions
+
+- D4: Both skills source the explanation standard before they write for a non-implementer — each skill sources Han's
+  standard for explaining work to a non-implementer before drafting the content that reader sees: the review before its
+  finding explanations, the overview before its closing restatement, and both before their closing message (considered
+  restating the standard inline in each skill; rejected because the repository keeps one canonical copy of a shared
+  standard and sources it). — Referenced in spec: Primary Flow; Coordinations.
+
 ## Full decisions
 
 ### D1: Who the second explanation on a finding is written for
@@ -44,9 +55,9 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   bookkeeping. Both are fixed here, by D7 and D8. Growing each finding was weighed against that score and accepted,
   bounded by the simpler-version rewrite above and by D16, which keeps the growth out of the surface a person scans.
 - **Linked technical notes:** —
-- **Driven by findings:** F1, F12, F13
+- **Driven by findings:** F1, F4, F12, F13
 - **Dependent decisions:** D2, D3, D4, D15, D16
-- **Referenced in spec:** Outcome; Primary Flow; Edge Cases and Failure Modes
+- **Referenced in spec:** Outcome; Primary Flow; Edge Cases and Failure Modes; Open Items
 
 ### D2: Which findings carry the second explanation
 
@@ -70,7 +81,7 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Linked technical notes:** —
 - **Driven by findings:** F3, F2
 - **Dependent decisions:** D15
-- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
+- **Referenced in spec:** Outcome; Primary Flow
 
 ### D3: Publishing the reachability reasoning instead of discarding it
 
@@ -105,28 +116,7 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Linked technical notes:** —
 - **Driven by findings:** F11
 - **Dependent decisions:** —
-- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
-
-### D4: Both skills source the explanation standard before they write for a non-implementer
-
-- **Question:** What makes the new register consistent across runs rather than left to chance?
-- **Decision:** Each skill sources Han's explanation standard before drafting the content a non-implementer reads: the
-  review before it drafts finding explanations, the overview before it writes its closing restatement. Both also source
-  it before writing their closing message.
-- **Rationale:** The standard exists, defines this exact reader, and is sourced the same way the readability standard
-  already is. Neither skill invokes it today, which is the gap rather than a model shortcoming.
-- **Evidence:** Issue 170, improvement 1: "Invoke `han-communication:explanation-guidance` before drafting findings; the
-  standard for this reader already exists and neither skill uses it." The standard is at
-  `han-communication/references/explanation-rule.md`; its stated application point is "before writing an escalation, a
-  confirmation turn, a stop, or any summary a non-implementer reads" (lines 78-83). The parallel readability sourcing is
-  at `han-coding/skills/code-review/SKILL.md:457` and `han-coding/skills/code-overview/SKILL.md:211`.
-- **Rejected alternatives:**
-  - Restate the standard inline in each skill — rejected because the repository keeps one canonical copy of a shared
-    standard and sources it, per the conventions in `CLAUDE.md`.
-- **Linked technical notes:** —
-- **Driven by findings:** —
-- **Dependent decisions:** —
-- **Referenced in spec:** Primary Flow; Coordinations
+- **Referenced in spec:** Primary Flow; Alternate Flows and States; Out of Scope
 
 ### D5: Where the report and the overview are written
 
@@ -140,8 +130,8 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   separate commitment: the overview is an orientation aid, not documentation, and must not be committed. Honoring
   configuration when it exists satisfies the evidence with the smaller change.
 - **Evidence:** Issue 170, improvement 2 and finding 1. The configured setting has existed in the operator's personal
-  configuration since 2026-07-30 and is a recognized key per `han-core/references/config-rule.md:44`. Only the three
-  Atlassian skills consume it today, confirmed by grep across every `SKILL.md`. The overview's out-of-repository
+  configuration since 2026-07-30 and is a recognized key per `han-core/references/config-rule.md:44`. Only the Atlassian
+  skills consume it today, confirmed by grep across every `SKILL.md`. The overview's out-of-repository
   prescription is at `han-coding/skills/code-overview/SKILL.md:265-269`; its ephemerality commitment is a separate
   operating principle at lines 82-84. The review has no output-location step at all.
 - **Rejected alternatives:**
@@ -159,9 +149,9 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   its closing message that it did, naming the destination it could not use. It does not fail the run: everything the run
   produced is already finished by the time it writes, and losing all of it to a missing directory is the worse outcome.
 - **Linked technical notes:** —
-- **Driven by findings:** F7, F8
-- **Dependent decisions:** D6, D17
-- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes; Coordinations; User Interactions
+- **Driven by findings:** F7, F8, F18
+- **Dependent decisions:** D6
+- **Referenced in spec:** Outcome; Primary Flow; Edge Cases and Failure Modes; Coordinations; User Interactions
 
 ### D6: How the review report file is named
 
@@ -219,7 +209,7 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Linked technical notes:** —
 - **Driven by findings:** F6
 - **Dependent decisions:** D8
-- **Referenced in spec:** Primary Flow; User Interactions; Edge Cases and Failure Modes
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes; User Interactions
 
 ### D8: What leads the closing message in both skills
 
@@ -241,7 +231,7 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Linked technical notes:** —
 - **Driven by findings:** —
 - **Dependent decisions:** —
-- **Referenced in spec:** Primary Flow; User Interactions
+- **Referenced in spec:** Outcome; Primary Flow; Edge Cases and Failure Modes
 
 ### D9: Who owns diagram legibility
 
@@ -269,7 +259,7 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Linked technical notes:** —
 - **Driven by findings:** —
 - **Dependent decisions:** —
-- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes; Out of Scope; Deferred (YAGNI)
 
 ### D10: Where the extended gloss rule lives
 
@@ -285,8 +275,8 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Evidence:** User input, this session. Corroborating detail from issue 170, improvement 4 and finding 6: four
   questions across two sessions, each quoting the overview's own words back at it, covering a language runtime, a
   statistical method, and two coined compound nouns. All four passed the current rule at
-  `han-communication/references/readability-rule.md:51`. Twenty-six skills source that rule, confirmed by grep across
-  every `SKILL.md`. The rewriting agent's rule source is `han-communication/agents/readability-editor.md`.
+  `han-communication/references/readability-rule.md:51`. Skills across the suite source that rule, confirmed by grep
+  across every `SKILL.md`. The rewriting agent's rule source is `han-communication/agents/readability-editor.md`.
 - **Rejected alternatives:**
   - Put the rule in the overview's template only — rejected by the operator. It matches where all four complaints came
     from, but leaves the rule with no enforcer.
@@ -299,7 +289,7 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   choice, made with the trade-off in front of them, and it belongs in the specification's own scope statements rather
   than only in a coordination row.
 - **Linked technical notes:** —
-- **Driven by findings:** F9
+- **Driven by findings:** F9, F18
 - **Dependent decisions:** —
 - **Referenced in spec:** Outcome; Primary Flow; Coordinations; Out of Scope
 
@@ -344,7 +334,7 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Linked technical notes:** —
 - **Driven by findings:** F2, F4
 - **Dependent decisions:** D15, D16
-- **Referenced in spec:** Primary Flow; Coordinations
+- **Referenced in spec:** Primary Flow; User Interactions; Coordinations
 
 ### D13: What "where to start" gives the reader
 
@@ -373,7 +363,7 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Linked technical notes:** —
 - **Driven by findings:** F15
 - **Dependent decisions:** —
-- **Referenced in spec:** Primary Flow; User Interactions; Edge Cases and Failure Modes
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
 
 ### D14: The overview may report that a change's stated reason is not supported
 
@@ -406,7 +396,7 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Linked technical notes:** —
 - **Driven by findings:** F16
 - **Dependent decisions:** —
-- **Referenced in spec:** Primary Flow; Alternate Flows and States
+- **Referenced in spec:** Alternate Flows and States; Out of Scope
 
 ### D15: Security findings carry the plain-language explanation but not a separate fix route
 
@@ -430,7 +420,7 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Linked technical notes:** —
 - **Driven by findings:** F2
 - **Dependent decisions:** —
-- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
+- **Referenced in spec:** Primary Flow
 
 ### D16: The likelihood and the fix route reach the surface a person scans
 
@@ -441,23 +431,35 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   the fix route beside the brief description.
 - **Rationale:** The complaint this feature descends from is comparative, not additive. The work item says a probable
   no-op "read as a behavior change at the same visual weight as the two findings beside it". Answering that with a
-  longer finding body leaves the weight exactly where it was and adds reading load on top. Two reviewers converged on
-  this independently, and both proposed the same fix: put the cue in the surface the reader already scans, so triage
-  happens before the reading rather than after it.
+  longer finding body leaves the weight exactly where it was and adds reading load on top. The fix is to put the cue in
+  the surface the reader already scans, so triage happens before the reading rather than after it.
+
+  The two halves rest on different evidence, and the record supports them unequally. The may-never-fire cue answers the
+  originating complaint directly, which is quoted above. The fix route in the row rests on the same reviewer's second
+  observation, that the report's only index gains nothing while the body it indexes roughly doubles, plus improvement
+  5's evidence that the person asks which skill to reach for anyway. One reviewer raised both halves, in two findings;
+  an earlier version of this rationale credited two reviewers converging independently, which the merged record does not
+  support.
 - **Evidence:** Issue 170, finding 4 and its accuracy rationale: "a finding can be accurate and still mislead by
   weight". The summary table and its brief-description cell are at
   `han-coding/skills/code-review/references/template.md:26-40`. The severity-ordered row order is specified there and is
-  unchanged by this decision.
+  unchanged by this decision. This decision adds content inside existing rows: it changes no severity band, no row
+  order, and no finding identifier, which is what the Out of Scope statements protect.
 - **Rejected alternatives:**
   - Add a separate section or a second table for conditional findings — rejected because it splits one finding list into
     two and the reader would have to reconcile them.
   - Reorder findings so probable no-ops sort last — rejected because the row order is severity-ordered by design and the
     finding identifiers are worked as a queue; changing the order changes an artifact the work item praises.
   - Leave the index unchanged — rejected because that is the state the complaint describes.
+  - Put the may-never-fire cue in the row and leave the fix route in the finding body — considered at synthesis, because
+    the cue carries the stronger evidence of the two. Rejected because it makes the row answer one triage question and
+    not the other, so a person still opens each finding to learn how it gets fixed, which is the question improvement 5
+    records them asking after every review.
 - **Linked technical notes:** —
 - **Driven by findings:** F4
 - **Dependent decisions:** —
-- **Referenced in spec:** Outcome; Primary Flow; User Interactions
+- **Referenced in spec:** Outcome; Primary Flow; Alternate Flows and States; User Interactions; Out of Scope;
+  Deferred (YAGNI)
 
 ### D17: Each skill checks that the new required content is present before it presents
 
@@ -470,9 +472,10 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Rationale:** A requirement with nothing checking it is a preference, and the failure mode is silent: the run
   produces the output it produces today and nobody notices. The overview already carries a check for one of these rules
   and not the others, which is the inconsistency review found.
-- **Evidence:** Review finding. The overview's existing self-check and the review's verification step both already exist
-  as places for this to live, at `han-coding/skills/code-overview/SKILL.md:317-326` and
-  `han-coding/skills/code-review/SKILL.md:491-495`.
+- **Evidence:** Review finding F10, raised by `han-core:junior-developer` as JD-007: of everything this feature
+  requires, only the diagram rule carried a stated check. The overview's existing self-check and the review's
+  verification step both already exist as places for this to live, at
+  `han-coding/skills/code-overview/SKILL.md:317-326` and `han-coding/skills/code-review/SKILL.md:491-495`.
 - **Rejected alternatives:**
   - Rely on the agent that rewrites drafts for readability to enforce it — rejected because that agent is barred from
     changing facts and from touching diagram bodies, so most of this is outside what it may do.

--- a/docs/plans/code-review-overview-language-corrections/artifacts/decision-log.md
+++ b/docs/plans/code-review-overview-language-corrections/artifacts/decision-log.md
@@ -14,8 +14,10 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Question:** A review finding today carries one prose slot, written for someone who will open the file. Who is the
   new required explanation written for?
 - **Decision:** The reader who will not open the file. Every corrective finding carries a plain-language explanation
-  giving the observable consequence, the preconditions that must all hold for it to happen, and an honest likelihood,
-  including saying outright when the finding may be a no-op.
+  answering three questions: what goes wrong that someone could observe, what has to be true for it to happen, and how
+  likely that is, including saying outright when the finding may be a no-op. The explanation answers all three; it does
+  not print three fixed slots. Where an answer is not in doubt, it is a clause rather than a sentence. The explanation
+  leads the finding, ahead of the register written for the person who will open the file.
 - **Rationale:** This is the most-repeated request in the reviewed corpus and it is a request for a register, not for
   more facts. One session spent four consecutive turns asking for exactly this, finding by finding. The capability is
   already demonstrated in those follow-up answers; it is simply not in the report.
@@ -28,11 +30,22 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   - Rewrite the existing prose slot to serve both readers — rejected because the two registers need different things:
     the author needs the location and the mechanism, the non-author needs the consequence and the likelihood. Collapsing
     them loses one.
-  - Produce the plain-language register on request rather than in the report — rejected because that is the current
+  - Produce the plain-language explanation on request rather than in the report — rejected because that is the current
     behavior and it is what the issue measures as the cost.
+  - Require all three answers at full length on every finding regardless of doubt — rejected on the simpler-version test
+    after review. On a finding whose failure is certain and unconditional, the preconditions and likelihood both collapse
+    to "always", and printing them at length is the symmetry pattern the YAGNI rule names. Requiring the questions to be
+    answered keeps the whole of the evidence; requiring three sentences does not.
+  - Let the two explanations appear in either order — rejected after review. The reader this one is written for would
+    otherwise have to read past prose addressed to someone else to reach their own, which is the same argument already
+    accepted for the closing message.
+- **A note on where the length went.** The work item scores the current output poorly on length, and its own stated
+  reason for that score is the review pasting itself into the conversation and both closing messages opening with
+  bookkeeping. Both are fixed here, by D7 and D8. Growing each finding was weighed against that score and accepted,
+  bounded by the simpler-version rewrite above and by D16, which keeps the growth out of the surface a person scans.
 - **Linked technical notes:** —
-- **Driven by findings:** —
-- **Dependent decisions:** D2, D3, D4
+- **Driven by findings:** F1, F12, F13
+- **Dependent decisions:** D2, D3, D4, D15, D16
 - **Referenced in spec:** Outcome; Primary Flow; Edge Cases and Failure Modes
 
 ### D2: Which findings carry the second explanation
@@ -50,29 +63,47 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Rejected alternatives:**
   - Require it on every finding including advisory ones — rejected because it duplicates the reopen trigger and lengthens
     a section the issue already praises for being short.
+- **Naming, after review.** "Corrective" and "advisory" are the words this specification uses; they are not words a
+  reader of a report sees. In the report, corrective means the critical, warning, suggestion, and security findings, and
+  advisory means the findings the report already states will not be corrected unless asked for. Both skills state the
+  mapping in the reader's own vocabulary rather than adopting this specification's shorthand.
 - **Linked technical notes:** —
-- **Driven by findings:** —
-- **Dependent decisions:** —
+- **Driven by findings:** F3, F2
+- **Dependent decisions:** D15
 - **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
 
 ### D3: Publishing the reachability reasoning instead of discarding it
 
 - **Question:** The review already works out whether a finding's failure mode can be reached, uses that to set severity,
   and then throws the reasoning away. Where does that reasoning go?
-- **Decision:** Into the finding's plain-language explanation, as the preconditions and likelihood it already computed.
-  When the review demotes a finding for being unreachable, the reason it demoted is what the reader sees.
+- **Decision:** Into the finding's plain-language explanation, as the preconditions and likelihood. When the review has
+  already lowered a finding's severity for being unreachable, the reason it lowered is what the reader sees. Where the
+  review holds no such reasoning, the writer derives the answers from the finding's own evidence at drafting time.
+- **What that derivation is and is not.** It is writing work. The reasoning is read out of evidence the finding already
+  carries, and it never feeds back into the finding's severity, whether it is found or dropped. The severity was already
+  set by passes this feature leaves untouched, and a finding whose explanation turns out to read "this may be a no-op"
+  keeps the severity those passes gave it.
 - **Rationale:** The corpus contains the exact question this answers: a user asked whether a suggestion described a real
   error condition, and the honest answer was that three conditions had to hold at once and the population where all
-  three held was probably empty. Everything in that answer was available at review time. Reusing the reasoning costs
-  nothing and removes a question class.
+  three held was probably empty. Everything in that answer was available at review time.
+
+  Review corrected an earlier version of this rationale, which claimed the review already holds this reasoning for every
+  finding. It does not. The gate that lowers severity for an unreachable failure mode matches a fixed list of phrases in
+  the producing specialist's own words, and says of itself that the phrase list is its only signal. So it produces
+  reasoning worth publishing on the findings it matches and nothing at all on the rest. Publishing what it does produce
+  still removes a question class at no cost; the rest is derived at drafting time, from evidence the finding already
+  carries.
 - **Evidence:** Issue 170, improvement 1 and finding 4. Quoted user turn from session 2d405303: "i don't understand
   SUGG-001. is there an actual error condition that can be caused by this?" The demotion gate that computes and discards
   the reasoning is at `han-coding/skills/code-review/SKILL.md:355-381`.
 - **Rejected alternatives:**
   - Publish the reasoning as a separate audit section — rejected because it separates the reasoning from the finding it
     qualifies, and the reader's question is always about a specific finding.
+  - Require the explanation only on findings the gate matched — rejected. It would restrict the answer to the findings
+    whose specialist happened to use one of eight words, which is not the same population as the findings a reader
+    cannot judge.
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F11
 - **Dependent decisions:** —
 - **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
 
@@ -120,17 +151,31 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   - Have the review default outside the repository to match the overview — rejected because the review already resolves
     an in-repository directory for its specialists' reports, and splitting the report from those reports makes the run's
     output harder to find, not easier.
+- **A configured destination inside the repository, after review.** Configuration wins, and the run says nothing about
+  it. The person who configured a destination inside the repository chose it, which is the same treatment the canonical
+  configuration rule already gives a destination outside the working directory. The overview's commitment not to be
+  committed is a commitment the skill makes about its own default, not a veto over what a person configures.
+- **A destination that cannot be written, after review.** The run writes to the unconfigured default instead and says in
+  its closing message that it did, naming the destination it could not use. It does not fail the run: everything the run
+  produced is already finished by the time it writes, and losing all of it to a missing directory is the worse outcome.
 - **Linked technical notes:** —
-- **Driven by findings:** —
-- **Dependent decisions:** D6
-- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes; Coordinations
+- **Driven by findings:** F7, F8
+- **Dependent decisions:** D6, D17
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes; Coordinations; User Interactions
 
 ### D6: How the review report file is named
 
 - **Question:** Consecutive reviews overwrite each other because the report carries a fixed name. What distinguishes one
   run's report from the next?
-- **Decision:** The report is named from the branch or ticket the review covers. When the run has neither, it is named
-  from the target that was reviewed.
+- **Decision:** The report is named from the branch or ticket the review covers. When the branch does not distinguish
+  the run, because the review is running against the default branch or against a scope with no branch at all, the report
+  is named from what was reviewed: the single file, directory, or symbol when there is one, and the common parent of the
+  reviewed files when there is not.
+- **When a report already exists at that name.** The run replaces it and says so in its closing message, naming the
+  report it replaced. Review raised this as the case D6's own quoted evidence describes: a person re-reviewing a branch
+  after acting on the first report. Keeping both would leave two reports for one branch with nothing in their names to
+  say which is current, which is the confusion the naming change exists to remove. Saying so is what protects a person
+  still working the earlier report as a queue.
 - **Rationale:** The fixed name is a real collision, visible in a session where the invocation itself had to work around
   it. Branch and ticket are the identifiers a person recognizes, and one of them is available in every mode that has
   git. The fallback matters because the review runs against a plain directory when git is absent, and a run with no
@@ -144,8 +189,10 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
     three files learns nothing from the names.
   - Change the overview's naming too — rejected because the overview's target slug already distinguishes its runs, so
     there is no collision to fix.
+  - Distinguish the second review of a branch rather than replacing the first — rejected as above: two reports for one
+    branch, neither named as current.
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F5
 - **Dependent decisions:** —
 - **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
 
@@ -155,6 +202,11 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   instead?
 - **Decision:** The review closes with a short message carrying the recommendation, the finding count by severity, and
   the path the report was written to. The full report is not pasted into the conversation.
+- **When the only findings are advisory.** The recommendation is still that the code can be approved, because the
+  advisory class is non-correcting by construction and never blocks a merge. The message says the corrective count is
+  zero and names the advisory count separately, so the person is not told "no findings" about a report whose body lists
+  items. Review raised this as an ordinary state rather than an exotic one: the advisory pass runs on every change
+  regardless of size.
 - **Rationale:** The overview already does this and the issue names it as the behavior the review is missing. The one
   fact a person needed after a review, the path, was absent from a message long enough to contain everything else.
 - **Evidence:** Issue 170, improvement 2 and finding 2. Quoted user turn from session 2c2aefa2 immediately after a
@@ -165,9 +217,9 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   - Keep pasting the review and add the path — rejected because the length is itself a defect: the path was already
     recoverable from a long message and the person still had to ask.
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F6
 - **Dependent decisions:** D8
-- **Referenced in spec:** Primary Flow; User Interactions
+- **Referenced in spec:** Primary Flow; User Interactions; Edge Cases and Failure Modes
 
 ### D8: What leads the closing message in both skills
 
@@ -241,17 +293,24 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   - Split it, with coined terms in the shared standard and external technologies local to the overview — rejected by the
     operator. It splits one rule across two homes, and a reader meeting an unglossed runtime name in a specification has
     the same problem they had in an overview.
+- **The reach of this decision is stated, after review.** This is the one change in the feature that reaches past the
+  two skills the work item names. Every skill that sources the shared standard inherits the rule, and the agent that
+  rewrites finished drafts starts enforcing it on documents this work item never examined. That is the operator's
+  choice, made with the trade-off in front of them, and it belongs in the specification's own scope statements rather
+  than only in a coordination row.
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F9
 - **Dependent decisions:** —
-- **Referenced in spec:** Primary Flow; Coordinations
+- **Referenced in spec:** Outcome; Primary Flow; Coordinations; Out of Scope
 
 ### D11: The overview's closing restatement
 
 - **Question:** The reliable next action after an overview is to paste a plain-language paragraph somewhere else. Does
   the overview produce it?
 - **Decision:** Yes. The overview ends with three or four sentences a non-author could read aloud, carrying no file
-  paths and no type names.
+  paths and no type names. Those sentences are the canonical text, and the run's closing message carries them rather
+  than writing its own version. Review raised the risk that two independently written restatements of the same thing
+  drift apart, and that the person reads the shorter one in the terminal and never opens the document.
 - **Rationale:** The overview already holds every fact that paragraph needs. The corpus shows the person either
   paraphrasing it themselves and asking whether the paraphrase holds, or asking for it outright so they can put it in a
   pull request description or a comment to a reviewer.
@@ -262,8 +321,10 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   - Put the restatement at the top instead — rejected because the lead section already answers why the code exists for a
     reader of the document. The restatement is written to be lifted out and pasted elsewhere, which is a different
     artifact serving a different reader.
+  - Let the closing message write its own version — rejected after review. Two texts saying the same thing in different
+    words teach the reader to distrust the shorter one.
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F14
 - **Dependent decisions:** —
 - **Referenced in spec:** Primary Flow; User Interactions
 
@@ -281,8 +342,8 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
     section by that name reserved for security findings, and a second one would collide with it. The route belongs on
     the finding a person is looking at.
 - **Linked technical notes:** —
-- **Driven by findings:** —
-- **Dependent decisions:** —
+- **Driven by findings:** F2, F4
+- **Dependent decisions:** D15, D16
 - **Referenced in spec:** Primary Flow; Coordinations
 
 ### D13: What "where to start" gives the reader
@@ -290,7 +351,13 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Question:** The overview lists the right entry points and the person still asks which file to open first. What is
   missing?
 - **Decision:** An order. The entry points are numbered in reading order, each with one line on what the reader learns
-  there. When the target is an interface other code calls, the section also carries one runnable example call.
+  there. When one of those entry points is an interface other code calls, that entry point carries one runnable example
+  call.
+- **Why the example call attaches to the entry point, not the target.** Review pointed out that the session this came
+  from is not a clean case of one or the other. The person asked which file to open first to start tracing a path, and
+  what an actual call would look like, about the same target: an interface with substantial flow behind it. Directory
+  and change-set targets are routinely both. Attaching the rule to the entry point covers the mixed case without a rule
+  for it.
 - **Rationale:** A set is not a sequence. The person asked which file to open first even though the right files were all
   listed, and then asked what an actual call would look like, which is the first useful artifact when the target is an
   interface rather than a flow.
@@ -300,13 +367,13 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
   concrete entry points without an order, at
   `han-coding/skills/code-overview/references/overview-template.md:38-40` and lines 101-104.
 - **Rejected alternatives:**
-  - Include an example call for every target — rejected under the simpler-version test. The request came from an
-    interface target, where a call is the way in. For a flow target the entry point is a file, and an invented example
-    call would be noise.
+  - Include an example call for every entry point — rejected under the simpler-version test. Where the entry point is a
+    file in a flow, an invented example call would be noise.
+  - Decide it per target rather than per entry point — rejected after review, as above.
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F15
 - **Dependent decisions:** —
-- **Referenced in spec:** Primary Flow; User Interactions
+- **Referenced in spec:** Primary Flow; User Interactions; Edge Cases and Failure Modes
 
 ### D14: The overview may report that a change's stated reason is not supported
 
@@ -315,6 +382,11 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
 - **Decision:** Yes, in the section that states the reason, as a fact about the reason. It says the code already
   satisfies the stated motivation, or that the code does not support the reason given. It raises no finding, assigns no
   severity, and recommends no change.
+- **Only a checked contradiction qualifies.** Review separated two states this decision had collapsed. Saying the code
+  contradicts the stated reason is a claim the overview must have checked and found to be true. Finding no evidence
+  either way is a different state, and it already has its own handling: the overview marks the reason as inferred. An
+  overview that reports a contradiction it did not find would be making a stronger claim than its evidence supports,
+  which is the exact failure the skill's accuracy commitment exists to prevent.
 - **Rationale:** This is a fact about the stated reason, which the overview already owns and already validates for
   accuracy against the code. It is not a judgment about the code's quality, which stays out of the skill. The
   distinction holds because the claim under test is the document's own leading claim, not the code.
@@ -329,7 +401,84 @@ The boundary these decisions were settled inside is recorded in [scope-boundary.
     the change's stated purpose holds. Neither skill would say it, which is the current state.
   - Say it in the navigational section on where the change is hardest to follow — rejected because that section is
     navigational by construction, and an unsupported reason belongs beside the reason it qualifies.
+  - Treat a reason the code says nothing about as unsupported — rejected after review. It is a stronger claim than the
+    evidence carries, and the skill already has a weaker and more honest one.
 - **Linked technical notes:** —
-- **Driven by findings:** —
+- **Driven by findings:** F16
 - **Dependent decisions:** —
 - **Referenced in spec:** Primary Flow; Alternate Flows and States
+
+### D15: Security findings carry the plain-language explanation but not a separate fix route
+
+- **Question:** Security findings are corrective, sit in their own section with their own shape, and are deliberately
+  exempt from the pass that lowers severity for unreachable failure modes. Do they gain the new content?
+- **Decision:** They carry the plain-language explanation, on the same terms as every other corrective finding. They do
+  not gain a separately-labelled fix route, because their section already ends with a remediation note naming what to
+  do.
+- **Rationale:** Two reviewers raised this independently, and both observed that a security finding is the one a
+  non-implementer can least evaluate unaided, so it is the last finding that should silently skip the explanation. The
+  exemption from the severity gate is not a reason to skip it: the exemption exists because the security evidence bar is
+  already higher, not because the reader needs less. Adding a second route label beside the existing remediation note
+  would put two answers to the same question in one block.
+- **Evidence:** The security section, its shape, and its remediation note are at
+  `han-coding/skills/code-review/references/template.md:95-111`. The gate exemption and its stated reason are at
+  `han-coding/skills/code-review/SKILL.md:380-382`. D12's own rejected alternative already names the collision risk.
+- **Rejected alternatives:**
+  - Exclude security findings from the explanation — rejected because the exemption they carry is about evidence
+    standards, not about the reader.
+  - Add the fix route to security findings too — rejected as a duplicate of content the block already carries.
+- **Linked technical notes:** —
+- **Driven by findings:** F2
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
+
+### D16: The likelihood and the fix route reach the surface a person scans
+
+- **Question:** The report's index is a summary row per finding. Every corrective finding is about to grow. Does the
+  index grow with it?
+- **Decision:** Yes, in two specific ways. Where the review has established that a finding's failure mode may not be
+  reachable, that fact appears on the finding's own opening line and in its summary row. Each summary row also carries
+  the fix route beside the brief description.
+- **Rationale:** The complaint this feature descends from is comparative, not additive. The work item says a probable
+  no-op "read as a behavior change at the same visual weight as the two findings beside it". Answering that with a
+  longer finding body leaves the weight exactly where it was and adds reading load on top. Two reviewers converged on
+  this independently, and both proposed the same fix: put the cue in the surface the reader already scans, so triage
+  happens before the reading rather than after it.
+- **Evidence:** Issue 170, finding 4 and its accuracy rationale: "a finding can be accurate and still mislead by
+  weight". The summary table and its brief-description cell are at
+  `han-coding/skills/code-review/references/template.md:26-40`. The severity-ordered row order is specified there and is
+  unchanged by this decision.
+- **Rejected alternatives:**
+  - Add a separate section or a second table for conditional findings — rejected because it splits one finding list into
+    two and the reader would have to reconcile them.
+  - Reorder findings so probable no-ops sort last — rejected because the row order is severity-ordered by design and the
+    finding identifiers are worked as a queue; changing the order changes an artifact the work item praises.
+  - Leave the index unchanged — rejected because that is the state the complaint describes.
+- **Linked technical notes:** —
+- **Driven by findings:** F4
+- **Dependent decisions:** —
+- **Referenced in spec:** Outcome; Primary Flow; User Interactions
+
+### D17: Each skill checks that the new required content is present before it presents
+
+- **Question:** Almost everything this feature adds is content that must be there. What confirms it is?
+- **Decision:** Each skill checks its own output before presenting: the review that every corrective finding carries the
+  plain-language explanation and a fix route, and that the summary rows carry the route and any conditional cue; the
+  overview that its diagrams follow the legibility rule, that its starting points are ordered, that terms a reader
+  cannot look up are explained, and that the closing restatement is present and free of file paths and type names. A
+  check that fails is fixed before presenting.
+- **Rationale:** A requirement with nothing checking it is a preference, and the failure mode is silent: the run
+  produces the output it produces today and nobody notices. The overview already carries a check for one of these rules
+  and not the others, which is the inconsistency review found.
+- **Evidence:** Review finding. The overview's existing self-check and the review's verification step both already exist
+  as places for this to live, at `han-coding/skills/code-overview/SKILL.md:317-326` and
+  `han-coding/skills/code-review/SKILL.md:491-495`.
+- **Rejected alternatives:**
+  - Rely on the agent that rewrites drafts for readability to enforce it — rejected because that agent is barred from
+    changing facts and from touching diagram bodies, so most of this is outside what it may do.
+  - Add a separate verification pass — rejected under the simpler-version test. Both skills already have a place where a
+    check like this belongs.
+- **Linked technical notes:** —
+- **Driven by findings:** F10
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow

--- a/docs/plans/code-review-overview-language-corrections/artifacts/decision-log.md
+++ b/docs/plans/code-review-overview-language-corrections/artifacts/decision-log.md
@@ -1,0 +1,335 @@
+# Decision Log: Understandable and Usable Output from Code Review and Code Overview
+
+This file records every decision settled while specifying the corrections to the reader-facing output of the
+`code-review` and `code-overview` skills. Behavioral statements live in
+[../feature-specification.md](../feature-specification.md); this file carries the history, rationale, evidence, and
+rejected alternatives.
+
+The boundary these decisions were settled inside is recorded in [scope-boundary.md](./scope-boundary.md).
+
+## Full decisions
+
+### D1: Who the second explanation on a finding is written for
+
+- **Question:** A review finding today carries one prose slot, written for someone who will open the file. Who is the
+  new required explanation written for?
+- **Decision:** The reader who will not open the file. Every corrective finding carries a plain-language explanation
+  giving the observable consequence, the preconditions that must all hold for it to happen, and an honest likelihood,
+  including saying outright when the finding may be a no-op.
+- **Rationale:** This is the most-repeated request in the reviewed corpus and it is a request for a register, not for
+  more facts. One session spent four consecutive turns asking for exactly this, finding by finding. The capability is
+  already demonstrated in those follow-up answers; it is simply not in the report.
+- **Evidence:** Issue 170, improvement 1 and finding 3. Quoted user turns: "explain sugg-001 in plain language, no
+  technical details" repeated across four findings in session 70cc4998; "give me a brief description of how and why the
+  two queries in sugg-002, diverge" in session 2c2aefa2. The finding template's single prose slot is at
+  `han-coding/skills/code-review/references/template.md:78-82`. Han's standard for this reader already exists at
+  `han-communication/references/explanation-rule.md` and neither skill invokes it.
+- **Rejected alternatives:**
+  - Rewrite the existing prose slot to serve both readers — rejected because the two registers need different things:
+    the author needs the location and the mechanism, the non-author needs the consequence and the likelihood. Collapsing
+    them loses one.
+  - Produce the plain-language register on request rather than in the report — rejected because that is the current
+    behavior and it is what the issue measures as the cost.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** D2, D3, D4
+- **Referenced in spec:** Outcome; Primary Flow; Edge Cases and Failure Modes
+
+### D2: Which findings carry the second explanation
+
+- **Question:** Does the required plain-language explanation apply to advisory findings as well as corrective ones?
+- **Decision:** Corrective findings only. Critical, warning, and suggestion findings each carry it. Advisory findings do
+  not.
+- **Rationale:** The advisory class already answers the same question in a different form. Each advisory finding carries
+  a stated trigger describing the concrete circumstance that would justify keeping the code, which is the preconditions
+  and likelihood the new explanation exists to supply. Requiring both would print the same content twice.
+- **Evidence:** Issue 170's improvement 1 names warnings, suggestions, and critical findings and does not name the
+  advisory class. The advisory section's existing reopen-trigger requirement is at
+  `han-coding/skills/code-review/references/template.md:89-93`. The advisory class is explicitly non-correcting per
+  `han-coding/skills/code-review/SKILL.md:54-61`.
+- **Rejected alternatives:**
+  - Require it on every finding including advisory ones — rejected because it duplicates the reopen trigger and lengthens
+    a section the issue already praises for being short.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
+
+### D3: Publishing the reachability reasoning instead of discarding it
+
+- **Question:** The review already works out whether a finding's failure mode can be reached, uses that to set severity,
+  and then throws the reasoning away. Where does that reasoning go?
+- **Decision:** Into the finding's plain-language explanation, as the preconditions and likelihood it already computed.
+  When the review demotes a finding for being unreachable, the reason it demoted is what the reader sees.
+- **Rationale:** The corpus contains the exact question this answers: a user asked whether a suggestion described a real
+  error condition, and the honest answer was that three conditions had to hold at once and the population where all
+  three held was probably empty. Everything in that answer was available at review time. Reusing the reasoning costs
+  nothing and removes a question class.
+- **Evidence:** Issue 170, improvement 1 and finding 4. Quoted user turn from session 2d405303: "i don't understand
+  SUGG-001. is there an actual error condition that can be caused by this?" The demotion gate that computes and discards
+  the reasoning is at `han-coding/skills/code-review/SKILL.md:355-381`.
+- **Rejected alternatives:**
+  - Publish the reasoning as a separate audit section — rejected because it separates the reasoning from the finding it
+    qualifies, and the reader's question is always about a specific finding.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
+
+### D4: Both skills source the explanation standard before they write for a non-implementer
+
+- **Question:** What makes the new register consistent across runs rather than left to chance?
+- **Decision:** Each skill sources Han's explanation standard before drafting the content a non-implementer reads: the
+  review before it drafts finding explanations, the overview before it writes its closing restatement. Both also source
+  it before writing their closing message.
+- **Rationale:** The standard exists, defines this exact reader, and is sourced the same way the readability standard
+  already is. Neither skill invokes it today, which is the gap rather than a model shortcoming.
+- **Evidence:** Issue 170, improvement 1: "Invoke `han-communication:explanation-guidance` before drafting findings; the
+  standard for this reader already exists and neither skill uses it." The standard is at
+  `han-communication/references/explanation-rule.md`; its stated application point is "before writing an escalation, a
+  confirmation turn, a stop, or any summary a non-implementer reads" (lines 78-83). The parallel readability sourcing is
+  at `han-coding/skills/code-review/SKILL.md:457` and `han-coding/skills/code-overview/SKILL.md:211`.
+- **Rejected alternatives:**
+  - Restate the standard inline in each skill — rejected because the repository keeps one canonical copy of a shared
+    standard and sources it, per the conventions in `CLAUDE.md`.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; Coordinations
+
+### D5: Where the report and the overview are written
+
+- **Question:** Both skills ignore the configured destination, so someone types it into nineteen of twenty invocations.
+  How does the destination resolve?
+- **Decision:** Both skills resolve their destination through Han's configuration precedence chain, so a configured base
+  directory is honored. Absent any configuration, each keeps the destination it has today: the review lands beside the
+  reports its specialists already write, and the overview lands outside the repository.
+- **Rationale:** The configured destination being ignored is the whole defect. Removing each skill's default as well
+  would change behavior the issue does not complain about, and the overview's out-of-repository default carries a
+  separate commitment: the overview is an orientation aid, not documentation, and must not be committed. Honoring
+  configuration when it exists satisfies the evidence with the smaller change.
+- **Evidence:** Issue 170, improvement 2 and finding 1. The configured setting has existed in the operator's personal
+  configuration since 2026-07-30 and is a recognized key per `han-core/references/config-rule.md:44`. Only the three
+  Atlassian skills consume it today, confirmed by grep across every `SKILL.md`. The overview's out-of-repository
+  prescription is at `han-coding/skills/code-overview/SKILL.md:265-269`; its ephemerality commitment is a separate
+  operating principle at lines 82-84. The review has no output-location step at all.
+- **Rejected alternatives:**
+  - Drop the out-of-repository prescription entirely, as improvement 2's wording suggests — rejected because the
+    prescription is both a default and an override, and only the override is the defect. Dropping both would let an
+    unconfigured overview land in the repository, against the skill's own ephemerality principle.
+  - Have the review default outside the repository to match the overview — rejected because the review already resolves
+    an in-repository directory for its specialists' reports, and splitting the report from those reports makes the run's
+    output harder to find, not easier.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** D6
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes; Coordinations
+
+### D6: How the review report file is named
+
+- **Question:** Consecutive reviews overwrite each other because the report carries a fixed name. What distinguishes one
+  run's report from the next?
+- **Decision:** The report is named from the branch or ticket the review covers. When the run has neither, it is named
+  from the target that was reviewed.
+- **Rationale:** The fixed name is a real collision, visible in a session where the invocation itself had to work around
+  it. Branch and ticket are the identifiers a person recognizes, and one of them is available in every mode that has
+  git. The fallback matters because the review runs against a plain directory when git is absent, and a run with no
+  distinguishing name is exactly the case the collision comes from.
+- **Evidence:** Issue 170, improvement 2 and finding 2. Quoted invocation from session ce765d64: "delete the existing
+  review for this in .scratch/ and write a new review file in .scratch/". The three review modes, including the no-git
+  mode, are at `han-coding/skills/code-review/SKILL.md:108-131`. The overview already names its file from a target slug
+  at `han-coding/skills/code-overview/SKILL.md:267-268`.
+- **Rejected alternatives:**
+  - Add a timestamp — rejected because it distinguishes runs without saying what they cover, so a person choosing among
+    three files learns nothing from the names.
+  - Change the overview's naming too — rejected because the overview's target slug already distinguishes its runs, so
+    there is no collision to fix.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
+
+### D7: What the review says when it finishes
+
+- **Question:** The review currently ends by pasting itself into the conversation with no path in it. What does it say
+  instead?
+- **Decision:** The review closes with a short message carrying the recommendation, the finding count by severity, and
+  the path the report was written to. The full report is not pasted into the conversation.
+- **Rationale:** The overview already does this and the issue names it as the behavior the review is missing. The one
+  fact a person needed after a review, the path, was absent from a message long enough to contain everything else.
+- **Evidence:** Issue 170, improvement 2 and finding 2. Quoted user turn from session 2c2aefa2 immediately after a
+  review: "where was that output written?" The overview's equivalent step is at
+  `han-coding/skills/code-overview/SKILL.md:328-332`; the review's process ends at verification,
+  `han-coding/skills/code-review/SKILL.md:491-495`.
+- **Rejected alternatives:**
+  - Keep pasting the review and add the path — rejected because the length is itself a defect: the path was already
+    recoverable from a long message and the person still had to ask.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** D8
+- **Referenced in spec:** Primary Flow; User Interactions
+
+### D8: What leads the closing message in both skills
+
+- **Question:** Both closing messages open with bookkeeping about the run. What leads instead?
+- **Decision:** The answer leads. For the review, that is the recommendation and the counts by severity. For the
+  overview, that is why the code or change exists and any divergence from its stated purpose. Facts about how the run
+  was conducted come last or not at all.
+- **Rationale:** Both reports are already held to a standard that puts the main point first, and the closing message is
+  the part a person actually reads first. Applying the standard to the report but not to the message inverts the
+  intended order at the one place it matters most.
+- **Evidence:** Issue 170, improvement 8 and finding 10. Quoted opening line from session 2c2aefa2: "Verification
+  complete: task IDs are sequential, all findings trace to dispatched agents or manual passes, no contradictory pairs,
+  no empty sections, and the readability self-check passes." Session 34a5fc56 led with a production block above the two
+  facts that mattered. The overview's current closing content is specified at
+  `han-coding/skills/code-overview/SKILL.md:330`.
+- **Rejected alternatives:**
+  - Drop the run bookkeeping entirely — rejected because a coverage gap and a size that under-covered the target are
+    facts a person needs in order to decide whether to re-run. Demoting them is enough; removing them loses signal.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; User Interactions
+
+### D9: Who owns diagram legibility
+
+- **Question:** The pass that rewrites the overview for readability is barred from touching diagrams, so nothing checks
+  whether a diagram can be read. Who checks?
+- **Decision:** The overview skill checks it against a stated rule: a diagram's boxes name components and boundaries,
+  not fields, types, or annotations, and the detail belongs in the prose beneath the diagram. The rewrite pass stays out
+  of diagram bodies.
+- **Rationale:** This is the only formatting complaint that recurred, it arrived twice, and both times the fix was the
+  same. The exemption is right for accuracy, because a rewrite that edits a diagram body can silently change what the
+  diagram claims, and it is wrong for reading load. Naming the rule and giving the skill the check separates the two.
+- **Evidence:** Issue 170, improvement 3 and finding 5. Quoted user turns: "reduce the details in the mermaid diagram.
+  it's too difficult to read right now" (session 34a5fc56); "take the technical details out of the diagram blocks. the
+  rendered blocks are difficult to read with all the detailed descriptions and technical references. i want high level
+  (mobile, web, graphql, shared engine, etc)" (session 435c664e). The confirmation that the fix worked, same session:
+  "ok, this is good. i understand the over-all flow now." The exemption is at
+  `han-coding/skills/code-overview/SKILL.md:306` and again at line 318. The template's only current diagram rule is the
+  scope label, `han-coding/skills/code-overview/references/overview-template.md:41-42`.
+- **Rejected alternatives:**
+  - Let the rewrite pass edit diagram bodies — rejected because that pass optimizes for reading and would be free to
+    reword a box in a way that changes what the diagram asserts about the code. The accuracy pass runs before it and
+    would not see the change.
+  - Leave legibility to the reader to request — rejected because that is the current behavior and it is what the two
+    complaints cost.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; Edge Cases and Failure Modes
+
+### D10: Where the extended gloss rule lives
+
+- **Question:** A reader cannot look up a term the document invented. Requiring a gloss at first use is agreed; the
+  question is whether that requirement binds every Han document or only the overview.
+- **Decision:** It goes in Han's shared writing standard, so every document Han produces glosses a term the reader
+  cannot resolve: external technologies and language runtimes, named statistical or numerical methods, and compound
+  nouns the document coins for its own convenience.
+- **Rationale:** The operator chose this after being shown the trade-off. The reason that argued for it: the agent that
+  rewrites finished drafts reads only the shared standard, so a rule kept local to the overview would have nothing
+  enforcing it beyond the overview's own self-check. Putting the rule where the enforcer already looks is what makes it
+  hold.
+- **Evidence:** User input, this session. Corroborating detail from issue 170, improvement 4 and finding 6: four
+  questions across two sessions, each quoting the overview's own words back at it, covering a language runtime, a
+  statistical method, and two coined compound nouns. All four passed the current rule at
+  `han-communication/references/readability-rule.md:51`. Twenty-six skills source that rule, confirmed by grep across
+  every `SKILL.md`. The rewriting agent's rule source is `han-communication/agents/readability-editor.md`.
+- **Rejected alternatives:**
+  - Put the rule in the overview's template only — rejected by the operator. It matches where all four complaints came
+    from, but leaves the rule with no enforcer.
+  - Split it, with coined terms in the shared standard and external technologies local to the overview — rejected by the
+    operator. It splits one rule across two homes, and a reader meeting an unglossed runtime name in a specification has
+    the same problem they had in an overview.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; Coordinations
+
+### D11: The overview's closing restatement
+
+- **Question:** The reliable next action after an overview is to paste a plain-language paragraph somewhere else. Does
+  the overview produce it?
+- **Decision:** Yes. The overview ends with three or four sentences a non-author could read aloud, carrying no file
+  paths and no type names.
+- **Rationale:** The overview already holds every fact that paragraph needs. The corpus shows the person either
+  paraphrasing it themselves and asking whether the paraphrase holds, or asking for it outright so they can put it in a
+  pull request description or a comment to a reviewer.
+- **Evidence:** Issue 170, improvement 5 and finding 7. Quoted user turns: "is this accurate for me to say? …" (session
+  435c664e); "update pr description. keep it plain language, concise, no technical details" (session 34a5fc56); "give me
+  a plain language summary, no technical details, of the [handler function] differences" (session de1c6647).
+- **Rejected alternatives:**
+  - Put the restatement at the top instead — rejected because the lead section already answers why the code exists for a
+    reader of the document. The restatement is written to be lifted out and pasted elsewhere, which is a different
+    artifact serving a different reader.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; User Interactions
+
+### D12: Each finding names how it gets fixed
+
+- **Question:** After a review, the person asks which Han skill to reach for on a given finding. Does the finding say?
+- **Decision:** Yes. Each corrective finding names its remediation route: writing the behavior test-first for a missing
+  behavior, restructuring for a design change, or by hand for a small edit.
+- **Rationale:** They ask anyway, and the finding already contains what decides the answer. Naming it costs a clause.
+- **Evidence:** Issue 170, improvement 5. Quoted user turns: "would `/tdd` or `/refactor` be better for sugg-003?" and
+  "would /refactor or /tdd be better suited for this?" The finding-ID scheme these questions address findings by is at
+  `han-coding/skills/code-review/SKILL.md:76-86`.
+- **Rejected alternatives:**
+  - Add a remediation section listing routes for all findings at once — rejected because the report already has a
+    section by that name reserved for security findings, and a second one would collide with it. The route belongs on
+    the finding a person is looking at.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; Coordinations
+
+### D13: What "where to start" gives the reader
+
+- **Question:** The overview lists the right entry points and the person still asks which file to open first. What is
+  missing?
+- **Decision:** An order. The entry points are numbered in reading order, each with one line on what the reader learns
+  there. When the target is an interface other code calls, the section also carries one runnable example call.
+- **Rationale:** A set is not a sequence. The person asked which file to open first even though the right files were all
+  listed, and then asked what an actual call would look like, which is the first useful artifact when the target is an
+  interface rather than a flow.
+- **Evidence:** Issue 170, improvement 6 and finding 8. Quoted user turns from session 435c664e: "what graphql file do i
+  need to look at first, to start tracing this path through the code?" and "what would an actual graphql query look
+  like, if i wanted to use the existing workaround for re-calculating an existing [record]?" The current requirement is
+  concrete entry points without an order, at
+  `han-coding/skills/code-overview/references/overview-template.md:38-40` and lines 101-104.
+- **Rejected alternatives:**
+  - Include an example call for every target — rejected under the simpler-version test. The request came from an
+    interface target, where a call is the way in. For a flow target the entry point is a file, and an invented example
+    call would be noise.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; User Interactions
+
+### D14: The overview may report that a change's stated reason is not supported
+
+- **Question:** The overview reports the stated reason for a change faithfully and never checks it against the code, so
+  it can correctly describe the motivation for a change the code shows to be unnecessary. May it say so?
+- **Decision:** Yes, in the section that states the reason, as a fact about the reason. It says the code already
+  satisfies the stated motivation, or that the code does not support the reason given. It raises no finding, assigns no
+  severity, and recommends no change.
+- **Rationale:** This is a fact about the stated reason, which the overview already owns and already validates for
+  accuracy against the code. It is not a judgment about the code's quality, which stays out of the skill. The
+  distinction holds because the claim under test is the document's own leading claim, not the code.
+- **Evidence:** Issue 170, improvement 7 and finding 9. Quoted user turns from session 435c664e: "given all of this new
+  information, are the changes we planned in this branch still necessary? why or why not?" and "given all of this, what
+  is the actual problem that this proposed solution would solve?" The skill's no-quality-judgment boundary is at
+  `han-coding/skills/code-overview/SKILL.md:69-72`, and the accuracy pass that already re-reads the code to test the
+  stated reason is at lines 276-293. The issue's own constraint: "Keep the quality boundary; this is not a finding about
+  the code's quality."
+- **Rejected alternatives:**
+  - Leave it to the review skill — rejected because the review judges the code, and this is a statement about whether
+    the change's stated purpose holds. Neither skill would say it, which is the current state.
+  - Say it in the navigational section on where the change is hardest to follow — rejected because that section is
+    navigational by construction, and an unsupported reason belongs beside the reason it qualifies.
+- **Linked technical notes:** —
+- **Driven by findings:** —
+- **Dependent decisions:** —
+- **Referenced in spec:** Primary Flow; Alternate Flows and States

--- a/docs/plans/code-review-overview-language-corrections/artifacts/scope-boundary.md
+++ b/docs/plans/code-review-overview-language-corrections/artifacts/scope-boundary.md
@@ -1,0 +1,101 @@
+# Scope Boundary: code-review and code-overview reader-facing corrections
+
+## Work Item
+
+GitHub issue <https://github.com/testdouble/han/issues/170>, "Han Feedback: code-review-code-overview (2026-08-03)",
+read with `gh issue view 170`. It is a `han-feedback` retrospective across roughly twenty `code-review` and
+`code-overview` runs from 2026-07-06 through 2026-08-03. The issue body is quoted below rather than paraphrased.
+
+## Stated Scope
+
+The issue's "Suggested improvements" section, quoted word for word, is the stated scope. Eight items, ordered by how
+many follow-up turns each removes:
+
+1. "**Give each finding a second prose slot: what goes wrong, for whom, and whether it can happen.** Add to
+   `template.md` a required plain-language line per WARN and SUGG (and per CRIT), written for a reader who will not open
+   the file, carrying three things: the observable consequence, the preconditions that must all hold, and an honest
+   likelihood — including \"this may be a no-op if X\". Publish Step 7.2's reachability reasoning here instead of
+   discarding it. Invoke `han-communication:explanation-guidance` before drafting findings; the standard for this reader
+   already exists and neither skill uses it. This alone removes the most-repeated request in the corpus."
+
+2. "**Add a Present step to `code-review`, and resolve the output location in both skills.** For `code-review`: write the
+   report, then close with the path, the recommendation, and the count by severity — and stop pasting the full review
+   into the conversation, which `code-overview` already gets right. For both: resolve the destination through the config
+   precedence chain so a configured `output-directory` is honored, and drop `code-overview` Step 6's \"outside the
+   repository\" prescription, which overrides it. Name the file from the branch or ticket
+   (`code-review-{branch-or-ticket}.md`, not `code-review-draft.md`) so consecutive runs stop colliding."
+
+3. "**Let a pass own diagram legibility.** The prose exemption is correct for accuracy and wrong for reading load, and
+   the result is the only formatting complaint that recurred. Add a diagram rule to `overview-template.md`: nodes name
+   components and boundaries, not fields, types, or annotations; detail belongs in the prose beneath. Then have Step 7
+   check node-label length and count against it. Diagram bodies stay exempt from the prose rewrite; legibility stops
+   being nobody's job."
+
+4. "**Extend the gloss rule to cover coined and external terms.** Any term a reader cannot resolve from the target's own
+   code gets a half-sentence gloss at first use — external technologies and language runtimes, statistical or numerical
+   methods, and compound nouns the document invents for its own convenience. Coined phrases matter most: the reader has
+   nowhere to look them up. All four questions in the corpus were of these three kinds and all four passed the current
+   rule."
+
+5. "**End every overview with a plain-language restatement, and name the remediation route for every finding.** The
+   overview should close with three or four sentences a non-author could read aloud, with no file paths or type names,
+   because the user's next action is reliably to paste that somewhere — a PR description, a comment to a reviewer. And
+   each `code-review` finding should name the route to fix it (`tdd` for a missing behavior, `refactor` for
+   restructuring, manual for a one-line change), because the user asks anyway: \"would `/tdd` or `/refactor` be better
+   for sugg-003?\" and \"would /refactor or /tdd be better suited for this?\""
+
+6. "**Make \"Where to start\" an ordered path, and add an example call for API surfaces.** Number the entry points in
+   reading order with one line on what the reader learns at each. When the target is an API surface — GraphQL, REST, a
+   public interface — include one runnable example call. Both were asked for explicitly after an overview that already
+   listed the right files."
+
+7. "**Let PR mode report an unsupported why.** When the code shows the stated motivation is already satisfied, or shows
+   the change is not needed for the reason given, say so in the why section as a fact about the why. Keep the quality
+   boundary; this is not a finding about the code's quality, and it is the highest-value sentence such an overview could
+   carry."
+
+8. "**Apply main-point-first to the closing message in both skills.** Lead with the answer: the recommendation and
+   severity counts for a review, the why and any divergence from the ticket for an overview. Mode, size, validator
+   reconciliation, and self-check results go last or into the file. The report is held to progressive disclosure; the
+   message the user reads first should be too."
+
+The issue also carries a "What worked well" section naming behavior that must survive unchanged: the
+`han-core:adversarial-validator` pass and its counter-evidence bar for dropping a finding, the stable `CRIT-/WARN-/SUGG-`
+task-ID scheme the user works as a queue, `code-overview`'s refusal to paste itself into the conversation, and the
+lazy-section rule that keeps clean reviews short.
+
+## Stated Exclusions
+
+`None stated`. The issue rules nothing out in words. Two boundaries are stated as constraints on how a change may be
+made rather than as exclusions, and both are recorded here as scope conditions:
+
+- On improvement 3: "Diagram bodies stay exempt from the prose rewrite."
+- On improvement 7: "Keep the quality boundary; this is not a finding about the code's quality."
+
+## Operator-Stated Scope
+
+Quoted from the invocation and the follow-up turn:
+
+- "https://github.com/testdouble/han/issues/170 commit and push as you go"
+- "open draft mode pr against han-v5.0.0-alpha-1 as the merge target"
+
+Both statements govern how the work is delivered rather than what it covers. The operator named no scope narrowing or
+widening beyond the issue.
+
+## Direction of Travel
+
+`Unanswered`. Asked in the opening confirmation turn: whether `code-review`, `code-overview`, their template files, or
+the Mermaid-body exemption in the readability rewrite are being deprecated, replaced, or migrated away from.
+
+## Visual Material Received
+
+`None received`.
+
+| Item | What state it depicts | Kept at |
+| ---- | --------------------- | ------- |
+| —    | —                     | —       |
+
+## Record Provenance
+
+Established by `han-planning:plan-a-feature` on 2026-08-03. Not inherited from another folder. No conflicting record was
+found at this path.

--- a/docs/plans/code-review-overview-language-corrections/artifacts/scope-boundary.md
+++ b/docs/plans/code-review-overview-language-corrections/artifacts/scope-boundary.md
@@ -84,8 +84,11 @@ widening beyond the issue.
 
 ## Direction of Travel
 
-`Unanswered`. Asked in the opening confirmation turn: whether `code-review`, `code-overview`, their template files, or
-the Mermaid-body exemption in the readability rewrite are being deprecated, replaced, or migrated away from.
+Asked in the opening confirmation turn: whether `code-review`, `code-overview`, their template files, or the
+Mermaid-body exemption in the readability rewrite are being deprecated, replaced, or migrated away from. The operator
+answered: "all four stay. we're correcting the output so it's understandable and usable."
+
+Nothing in scope is on its way out. The work is corrective on the output of two skills that keep their current shape.
 
 ## Visual Material Received
 

--- a/docs/plans/code-review-overview-language-corrections/artifacts/team-findings.md
+++ b/docs/plans/code-review-overview-language-corrections/artifacts/team-findings.md
@@ -6,15 +6,307 @@ outcomes live in [../feature-specification.md](../feature-specification.md); dec
 spec relies on is discoverable from the repository, so no note qualified.
 
 **Review team.** `han-core:junior-developer`, `han-core:user-experience-designer`, `han-core:edge-case-explorer`.
-Feature size: medium.
+Feature size: medium. Every finding below was resolved from evidence; none required escalating to the operator.
+
+**Merged records.** Several findings arrived from two reviewers in different words and are recorded once, carrying each
+reviewer's own identifier.
 
 ## Major findings
 
-<!-- Populated after the review round returns. -->
+### F1: The explanation is required in full even where two of its three answers are certain
+
+- **Agent:** han-core:junior-developer, han-core:user-experience-designer
+- **Reviewer identifiers:** JD-009, UX-008
+- **Finding:** `Category: YAGNI candidate`, simpler-version available. The work item asks for "a required plain-language
+  line"; the draft turned that into three required components with no bound. On a finding whose failure is certain and
+  unconditional, the preconditions and likelihood both collapse to "always", and printing them at length is the
+  symmetry pattern the YAGNI rule names. It also compounds the length pressure raised in F4 and F12.
+- **Resolution:** Accepted. The explanation must answer all three questions; it does not print three fixed slots, and an
+  answer not in doubt is a clause rather than a sentence. The requirement itself was not made optional, which would
+  reintroduce the original defect.
+- **Resolved by:** evidence
+- **Affected decisions:** D1
+- **Changed in spec:** Primary Flow; Edge Cases and Failure Modes
+
+### F2: Security findings were left unclassified against the new rules
+
+- **Agent:** han-core:junior-developer, han-core:user-experience-designer
+- **Reviewer identifiers:** JD-005, UX-003
+- **Finding:** Security findings are corrective, are deliberately exempt from the pass that lowers severity for
+  unreachable failure modes, and sit in their own section that already ends with a remediation note. The draft's rules
+  named critical, warning, and suggestion findings and said nothing about them, so two reasonable implementations would
+  produce different reports. Both reviewers observed that a security finding is the one a non-implementer can least
+  evaluate unaided.
+- **Resolution:** Settled as a new decision. Security findings carry the plain-language explanation on the same terms as
+  every other finding a reader is expected to act on. They do not gain a separately-labelled fix route, because their
+  section already carries remediation content and a second answer to the same question would collide with it.
+- **Resolved by:** evidence
+- **Affected decisions:** D15 (new), D2, D12
+- **Changed in spec:** Primary Flow; Edge Cases and Failure Modes
+
+### F3: The specification used vocabulary its own reader cannot resolve
+
+- **Agent:** han-core:user-experience-designer, han-core:junior-developer
+- **Reviewer identifiers:** UX-003, JD-010
+- **Finding:** "Corrective", "advisory", and "register" are terms the specification coined or borrowed and never
+  explained, and none of them appears in a report a person reads. The classes a report shows are critical, warning,
+  suggestion, security, and the advisory class. This is the specification failing the exact rule it is writing in D10.
+- **Resolution:** Accepted. The specification now states the mapping in the reader's own vocabulary, uses "a finding the
+  reader is expected to act on" in place of the coined shorthand, and records in D2 that both skills use the report's
+  vocabulary rather than this document's.
+- **Resolved by:** evidence
+- **Affected decisions:** D2
+- **Changed in spec:** Outcome; Primary Flow; Edge Cases and Failure Modes; User Interactions; Coordinations
+
+### F4: The complaint about visual weight was answered with more words at the same weight
+
+- **Agent:** han-core:user-experience-designer
+- **Reviewer identifiers:** UX-001, UX-002
+- **Finding:** The sharpest finding of the round. The originating complaint is comparative: a probable no-op "read as a
+  behavior change at the same visual weight as the two findings beside it". The draft's answer was additive. The finding
+  kept its severity, its position, and its summary row, and gained a paragraph, so a person triaging thirty findings had
+  to read the new explanation on every finding to discover which ones did not need reading. The report's only index, its
+  summary table, gained nothing while the body it indexes roughly doubled.
+- **Unverified:** rests in part on a density estimate the reviewer could not confirm against a rendered report, because
+  no example output or visual material was supplied to this run. The structural half of the claim was verified directly:
+  the draft did not mention the summary table anywhere.
+- **Resolution:** Accepted, in the form both reviewers proposed. A new decision puts the may-never-fire cue on the
+  finding's opening line and in its summary row, and the fix route in the summary row beside the brief description, so
+  triage happens before the reading rather than after it. The severity scheme, the row order, and the finding
+  identifiers are untouched, and are now named in Out of Scope.
+- **Resolved by:** evidence
+- **Affected decisions:** D16 (new), D1, D12
+- **Changed in spec:** Outcome; Primary Flow; Alternate Flows and States; User Interactions; Out of Scope
+
+### F5: The naming fix did not cover the collision its own evidence describes
+
+- **Agent:** han-core:junior-developer, han-core:edge-case-explorer
+- **Reviewer identifiers:** JD-003, EC1
+- **Finding:** Two parts. First, the session quoted as evidence for naming the report from the branch is a person
+  re-reviewing the same branch, and the draft had no behavior for a report already existing at the derived name, so a
+  report someone was working as a queue could be silently destroyed. Second, the draft folded the two review modes that
+  have no branch diff into one fallback that fits neither: one of them has a branch name that may be the default branch
+  and therefore distinguishes nothing, and the other can have a multi-file scope with no single name.
+- **Resolution:** Both accepted. The run replaces an existing report and names the replaced report in its closing
+  message. A branch name that does not distinguish the run is not used; the report is named from the single file,
+  directory, or symbol reviewed, or the common parent of the reviewed files.
+- **Resolved by:** evidence
+- **Affected decisions:** D6
+- **Changed in spec:** Edge Cases and Failure Modes
+
+### F6: A review whose only findings are advisory had no defined closing message
+
+- **Agent:** han-core:edge-case-explorer
+- **Reviewer identifiers:** EC4
+- **Finding:** Rated the reviewer's highest-priority gap. The advisory pass runs on every change regardless of size, so
+  a run with no corrective findings and some advisory ones is ordinary rather than exotic. The draft's rules did not
+  compose: the "finds nothing" row said the message reports approval, while the report body would list advisory items
+  the message never mentioned.
+- **Resolution:** Accepted. The recommendation stays approval, because advisory findings never block a merge. The
+  message reports the count a person must act on as zero and names the advisory count separately, so nobody is told "no
+  findings" about a report whose body lists items.
+- **Resolved by:** evidence
+- **Affected decisions:** D7
+- **Changed in spec:** Edge Cases and Failure Modes
+
+### F7: A destination that cannot be written had no behavior, and the spec claimed no new error states
+
+- **Agent:** han-core:edge-case-explorer, han-core:user-experience-designer
+- **Reviewer identifiers:** EC2, UX-010
+- **Finding:** The draft covered a configured destination that points outside the working directory and not one that
+  cannot be written: absent, read-only, or out of space. The canonical configuration rule covers configuration that is
+  unusable as configuration, not a directory absent on disk. Meanwhile the draft asserted "Error states: None new",
+  which forecloses the case rather than answering it. Without a stated fallback the run could report a path to a file
+  that does not exist, which is the same class of wasted turn this feature exists to remove.
+- **Resolution:** Accepted. The run writes to the unconfigured default and says so in its closing message, naming the
+  destination it could not use. The run is not abandoned, because everything it produced is finished by the time it
+  writes. The "no new error states" claim was replaced with the one error state the feature actually introduces.
+- **Resolved by:** evidence
+- **Affected decisions:** D5
+- **Changed in spec:** Edge Cases and Failure Modes; User Interactions
+
+### F8: A configured destination inside the repository conflicted with the overview's own commitment
+
+- **Agent:** han-core:junior-developer
+- **Reviewer identifiers:** JD-006
+- **Finding:** D5's rationale leans on the overview's commitment not to be committed as the reason for keeping its
+  out-of-repository default, then honors a configured destination that may well be inside the repository, and says
+  nothing about the tension.
+- **Resolution:** Accepted and stated. Configuration wins and the run says nothing, which is the treatment the canonical
+  configuration rule already gives a destination outside the working directory. The commitment governs the skill's own
+  default, not what a person configures.
+- **Resolved by:** evidence
+- **Affected decisions:** D5
+- **Changed in spec:** Edge Cases and Failure Modes
+
+### F9: The widest-reaching change in the feature was visible only in a table cell
+
+- **Agent:** han-core:junior-developer
+- **Reviewer identifiers:** JD-004
+- **Finding:** The scope statements frame this as a two-skill change while the coordination table commits every document
+  Han produces, through a standard many skills source. Anyone sizing implementation from the Outcome would under-size
+  it, and nothing said whether the other documents are checked.
+- **Resolution:** Accepted. The reach is now stated in the Outcome as a paragraph of its own, and Out of Scope says
+  plainly that auditing the documents that inherit the rule is not part of this work. The placement itself was the
+  operator's decision and was not reopened.
+- **Resolved by:** evidence
+- **Affected decisions:** D10
+- **Changed in spec:** Outcome; Out of Scope
+
+### F10: Nothing confirmed the new required content actually appears
+
+- **Agent:** han-core:junior-developer
+- **Reviewer identifiers:** JD-007
+- **Finding:** Only the diagram rule carried a stated check. The explanation, the fix route, the ordered starting points,
+  the closing restatement's constraints, and the extended glosses all carried the word "required" and nothing checking
+  it. A requirement with nothing checking it is a preference, and the failure mode is silent: the run produces today's
+  output and nobody notices.
+- **Resolution:** Accepted as a new decision. Each skill checks its own output before presenting, in the place each
+  already has for a check like this, and fixes a failure before presenting. A separate verification pass was rejected
+  under the simpler-version test.
+- **Resolved by:** evidence
+- **Affected decisions:** D17 (new), D9
+- **Changed in spec:** Primary Flow
+
+### F11: The explanation was specified as republished reasoning the review does not actually hold
+
+- **Agent:** han-core:junior-developer
+- **Reviewer identifiers:** JD-001
+- **Finding:** Rated a decision-blocker. The draft said the explanation states reasoning the review already worked out.
+  The pass it cited matches a fixed list of phrases in the producing specialist's own words and says of itself that the
+  phrase list is its only signal, so it produces reasoning worth publishing on the findings it matches and nothing at
+  all on the rest. The draft therefore assumed analysis that does not exist, and if the writer must derive it, that
+  looked like it crossed the line Out of Scope draws around changing how findings are challenged.
+- **Unverified:** the reviewer could not read the session transcripts the work item quotes, because they are not in this
+  repository, so the claim about what those sessions wanted rests on the work item's own verbatim quotes. The core of
+  the finding was verified directly against the skill definition and stands on its own.
+- **Resolution:** Accepted, and the rationale corrected rather than the behavior changed. The explanation publishes the
+  reasoning where it exists and derives the answers from the finding's own evidence where it does not. Deriving them is
+  writing work and never feeds back into the finding's severity, which is now stated in the decision and in Out of
+  Scope. Restricting the explanation to findings the phrase gate matched was rejected: that is not the same population
+  as the findings a reader cannot judge.
+- **Resolved by:** evidence
+- **Affected decisions:** D3
+- **Changed in spec:** Primary Flow; Out of Scope
+
+### F13: Nothing fixed the order of the two explanations inside a finding
+
+- **Agent:** han-core:user-experience-designer
+- **Reviewer identifiers:** UX-004
+- **Finding:** The draft accepted a main-point-first argument for the closing message and did not make the same argument
+  where the density actually landed. The reader the new explanation is written for would have to read past prose
+  addressed to someone else to reach their own, and the order would vary run to run.
+- **Resolution:** Accepted. The plain-language explanation leads the finding; the existing register follows it.
+- **Resolved by:** evidence
+- **Affected decisions:** D1
+- **Changed in spec:** Primary Flow
+
+### F14: Two plain-language restatements of the same thing, with no stated relationship
+
+- **Agent:** han-core:user-experience-designer
+- **Reviewer identifiers:** UX-006
+- **Finding:** The overview's closing document paragraph and its closing terminal message both restate why the code
+  exists, both drafted against the same standard, with nothing saying whether one reuses the other. Left unstated the
+  two texts drift and the reader learns to distrust the shorter one. The reviewer also noted that the person's next
+  action is to paste plain language somewhere, and pasting from the terminal is the cheaper path.
+- **Resolution:** Accepted, in the simpler form the reviewer proposed. The document's closing sentences are the
+  canonical text and the closing message carries them rather than writing its own version.
+- **Resolved by:** evidence
+- **Affected decisions:** D11
+- **Changed in spec:** Primary Flow; User Interactions
+
+### F15: The example-call rule belongs to the entry point, not the target
+
+- **Agent:** han-core:user-experience-designer, han-core:edge-case-explorer
+- **Reviewer identifiers:** UX-007, EC6
+- **Finding:** The draft treated "interface" and "flow" as exclusive properties of a target. The session the requirement
+  came from was not exclusive: the person asked which file to open first to trace a path, and what an actual call would
+  look like, about the same target. Directory and change-set targets routinely contain both.
+- **Resolution:** Accepted. The rule attaches to the entry point: any starting point that is an interface other code
+  calls carries one example call, and flow entry points do not. This covers the mixed case with no rule for it.
+- **Resolved by:** evidence
+- **Affected decisions:** D13
+- **Changed in spec:** Primary Flow; Edge Cases and Failure Modes
+
+### F16: A contradicted reason and an unrecoverable reason were collapsed into one flow
+
+- **Agent:** han-core:edge-case-explorer
+- **Reviewer identifiers:** EC5
+- **Finding:** Saying the code does not support a stated reason is a checked claim. Finding no evidence either way is a
+  different state, and the overview already handles it by marking the reason as inferred. The draft's alternate flow
+  read as if every reason mismatch were the first case, which risks the overview asserting a contradiction it never
+  found — a stronger claim than its evidence supports, and the exact failure the skill's accuracy commitment exists to
+  prevent.
+- **Resolution:** Accepted. The alternate flow's entry condition now requires that the overview checked and found the
+  contradiction, and the flow carries an explicit statement that a reason the code says nothing about is the other case
+  and stays there.
+- **Resolved by:** evidence
+- **Affected decisions:** D14
+- **Changed in spec:** Alternate Flows and States
+
+### F19: The Open Items section was omitted while the summary asserted none
+
+- **Agent:** han-core:junior-developer
+- **Reviewer identifiers:** JD-008
+- **Finding:** The draft claimed zero open items while two summary fields were explicitly incomplete and four of the
+  reviewer's own findings named decisions implementation could not make on its own. The count is what a downstream
+  planning run reads to decide whether it can proceed.
+- **Unverified:** the reviewer noted it could not see the other reviewers' findings, because this record was unpopulated
+  when it ran, so some of its open questions might already be raised elsewhere. They were: all four were resolved in
+  this pass.
+- **Resolution:** Accepted. Every question the reviewer raised was settled from evidence in this pass and is recorded
+  above. One genuine open item remains, and the section now carries it with what would resolve it and whether it blocks
+  implementation.
+- **Resolved by:** evidence
+- **Affected decisions:** —
+- **Changed in spec:** Open Items; Summary
+
+### F20: Concurrent runs writing to one destination
+
+- **Agent:** han-core:edge-case-explorer
+- **Reviewer identifiers:** EC3
+- **Finding:** Naming the report from the branch means two people reviewing the same branch at once produce the same
+  filename in the same configured directory. The reviewer flagged this for awareness rather than recommending new
+  behavior, and noted its own evidence-test failure: nothing in the corpus reports it.
+- **Resolution:** Deferred under the YAGNI rule with a reopening trigger, in the spec's deferral section. The reviewer's
+  own recommendation was that one line beats silence, which the deferral supplies.
+- **Resolved by:** evidence
+- **Affected decisions:** —
+- **Changed in spec:** Deferred (YAGNI)
+
+### F21: Counting conditional findings in the review's closing message
+
+- **Agent:** han-core:user-experience-designer
+- **Reviewer identifiers:** UX-005
+- **Finding:** Severity counts remain the closing message's whole triage signal, while the feature itself establishes
+  that a finding at any severity may never fire. The person decides whether to open the report on a number the
+  specification just qualified.
+- **Resolution:** Deferred with a reopening trigger, on the reviewer's own recommendation and on the simpler-version
+  test: F4's resolution already puts the fact in the surface a person triages from, and a second signal for the same
+  fact before the first has been seen in use is not yet earned.
+- **Resolved by:** evidence
+- **Affected decisions:** —
+- **Changed in spec:** Deferred (YAGNI)
 
 ## Minor edits
 
-<!-- Populated after the review round returns. -->
+- F12: The trade between per-finding growth and the work item's own length score was never recorded, so a reader could
+  not tell a considered trade from an oversight — han-core:junior-developer — recorded in D1 rather than the spec, plus
+  an open item.
+- F17: The edge-case row for a configured location outside the working directory restated a rule the canonical
+  configuration rule already owns, creating a second home that can drift — han-core:user-experience-designer — row
+  removed from Edge Cases and Failure Modes.
+- F18: A hardcoded count of how many skills consume the configured output location, against the repository's
+  count-free convention — han-core:junior-developer — rephrased without the count in Cut for Scope.
+
+## Unaudited evidence classes
+
+- The session transcripts the work item quotes, supporting D1, D3, D5, D6, D7, D8, D9, D11, D12, D13, and D14. No
+  reviewer received them, because they are session artifacts outside this repository. Every quotation used as evidence
+  comes from the work item's own verbatim text, which two reviewers independently read from the live issue and found to
+  match the boundary record.
+- A rendered example report or overview under the new rules, bearing on F4. No reviewer received one, because none
+  exists yet. This is what open item OI-1 exists to resolve.
 
 ## Escalation register
 
@@ -22,5 +314,5 @@ Feature size: medium.
 
 - **Answer:** "go with first" — put it in Han's shared writing standard, so every Han document gains the rule and the
   agent that rewrites finished drafts enforces it.
-- **Landed in:** [D10](decision-log.md#d10-where-the-extended-gloss-rule-lives), and the Primary Flow and Coordinations
-  sections of the specification.
+- **Landed in:** [D10](decision-log.md#d10-where-the-extended-gloss-rule-lives), and the Outcome, Primary Flow,
+  Coordinations, and Out of Scope sections of the specification.

--- a/docs/plans/code-review-overview-language-corrections/artifacts/team-findings.md
+++ b/docs/plans/code-review-overview-language-corrections/artifacts/team-findings.md
@@ -42,7 +42,7 @@ reviewer's own identifier.
   section already carries remediation content and a second answer to the same question would collide with it.
 - **Resolved by:** evidence
 - **Affected decisions:** D15 (new), D2, D12
-- **Changed in spec:** Primary Flow; Edge Cases and Failure Modes
+- **Changed in spec:** Primary Flow
 
 ### F3: The specification used vocabulary its own reader cannot resolve
 
@@ -70,10 +70,12 @@ reviewer's own identifier.
 - **Unverified:** rests in part on a density estimate the reviewer could not confirm against a rendered report, because
   no example output or visual material was supplied to this run. The structural half of the claim was verified directly:
   the draft did not mention the summary table anywhere.
-- **Resolution:** Accepted, in the form both reviewers proposed. A new decision puts the may-never-fire cue on the
-  finding's opening line and in its summary row, and the fix route in the summary row beside the brief description, so
-  triage happens before the reading rather than after it. The severity scheme, the row order, and the finding
-  identifiers are untouched, and are now named in Out of Scope.
+- **Resolution:** Accepted, in the form the reviewer proposed across its two findings. A new decision puts the
+  may-never-fire cue on the finding's opening line and in its summary row, and the fix route in the summary row beside
+  the brief description, so triage happens before the reading rather than after it. The two halves rest on different
+  evidence and D16 records which is which: the cue answers the originating complaint directly, and the route in the row
+  rests on the second finding plus the work item's record of the question being asked after every review. The severity
+  scheme, the row order, and the finding identifiers are untouched, and are now named in Out of Scope.
 - **Resolved by:** evidence
 - **Affected decisions:** D16 (new), D1, D12
 - **Changed in spec:** Outcome; Primary Flow; Alternate Flows and States; User Interactions; Out of Scope
@@ -163,9 +165,10 @@ reviewer's own identifier.
   output and nobody notices.
 - **Resolution:** Accepted as a new decision. Each skill checks its own output before presenting, in the place each
   already has for a check like this, and fixes a failure before presenting. A separate verification pass was rejected
-  under the simpler-version test.
+  under the simpler-version test. D9's existing diagram check was the model for where a check belongs; D9's own text was
+  not changed.
 - **Resolved by:** evidence
-- **Affected decisions:** D17 (new), D9
+- **Affected decisions:** D17 (new)
 - **Changed in spec:** Primary Flow
 
 ### F11: The explanation was specified as republished reasoning the review does not actually hold
@@ -296,8 +299,9 @@ reviewer's own identifier.
 - F17: The edge-case row for a configured location outside the working directory restated a rule the canonical
   configuration rule already owns, creating a second home that can drift — han-core:user-experience-designer — row
   removed from Edge Cases and Failure Modes.
-- F18: A hardcoded count of how many skills consume the configured output location, against the repository's
-  count-free convention — han-core:junior-developer — rephrased without the count in Cut for Scope.
+- F18: Hardcoded suite-wide skill counts, against the repository's count-free convention — han-core:junior-developer —
+  rephrased without the count in Cut for Scope, and in the evidence of D5 and D10, which counted the skills consuming
+  the configured output location and the skills sourcing the shared writing standard.
 
 ## Unaudited evidence classes
 
@@ -307,6 +311,10 @@ reviewer's own identifier.
   match the boundary record.
 - A rendered example report or overview under the new rules, bearing on F4. No reviewer received one, because none
   exists yet. This is what open item OI-1 exists to resolve.
+- The three reviewers' reports in their own words, bearing on every record above. Synthesis received them condensed
+  rather than verbatim, because the three together run several times the length of these artifacts. Attribution in this
+  record was therefore checked against the merged reviewer identifiers rather than against each reviewer's wording; a
+  claim that could only be settled by a reviewer's exact phrasing is not settled here.
 
 ## Escalation register
 

--- a/docs/plans/code-review-overview-language-corrections/artifacts/team-findings.md
+++ b/docs/plans/code-review-overview-language-corrections/artifacts/team-findings.md
@@ -1,0 +1,26 @@
+# Team Findings: Understandable and Usable Output from Code Review and Code Overview
+
+This file records every finding raised by the review team for this feature, and how each was resolved. Behavioral
+outcomes live in [../feature-specification.md](../feature-specification.md); decisions the findings affected live in
+[decision-log.md](decision-log.md). No `feature-technical-notes.md` was created for this feature: every mechanic the
+spec relies on is discoverable from the repository, so no note qualified.
+
+**Review team.** `han-core:junior-developer`, `han-core:user-experience-designer`, `han-core:edge-case-explorer`.
+Feature size: medium.
+
+## Major findings
+
+<!-- Populated after the review round returns. -->
+
+## Minor edits
+
+<!-- Populated after the review round returns. -->
+
+## Escalation register
+
+### E1: Whether the extended gloss rule binds every Han document or only the overview
+
+- **Answer:** "go with first" — put it in Han's shared writing standard, so every Han document gains the rule and the
+  agent that rewrites finished drafts enforces it.
+- **Landed in:** [D10](decision-log.md#d10-where-the-extended-gloss-rule-lives), and the Primary Flow and Coordinations
+  sections of the specification.

--- a/docs/plans/code-review-overview-language-corrections/feature-specification.md
+++ b/docs/plans/code-review-overview-language-corrections/feature-specification.md
@@ -8,11 +8,11 @@ three questions people ask afterwards, so the answers arrive in the report inste
 Someone runs a code review or a code overview and gets everything they need from the run itself.
 
 Three questions account for the most-repeated follow-up turns people spend on these two skills today: where the file
-was written, what a finding actually means for someone who will not open the code, and whether the problem a finding
-describes can really happen. After this change:
+was written, what a finding means for someone who will not open the code, and whether the problem a finding describes
+can really happen. After this change:
 
-- Every finding the reader is expected to act on says what goes wrong, what has to be true for it to happen, and how
-  likely that is, in language a person who will not open the file can act on
+- Every finding the reader is expected to act on answers three questions: what goes wrong, what has to be true for it
+  to happen, and how likely that is. It answers them in language a person who will not open the file can act on
   ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)).
 - A finding the review believes may never fire says so on its opening line and in the table a person scans, not only
   inside its body ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)).
@@ -20,12 +20,12 @@ describes can really happen. After this change:
   ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)).
 - Both closing messages lead with the answer rather than with facts about the run
   ([D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills)).
-- An overview's diagrams are legible, its invented and borrowed terms are explained, its starting points are in reading
-  order, and it ends with a paragraph a person can paste somewhere else.
+- An overview's diagrams are legible, and its invented and borrowed terms are explained. Its starting points are in
+  reading order, and it ends with a paragraph a person can paste somewhere else.
 
 One part of this reaches further than the two skills. The requirement to explain a term the reader cannot look up goes
-into the writing standard every Han document is written against, so documents this work item never examined gain the
-rule too, and the editor that rewrites finished drafts starts enforcing it there
+into the writing standard every Han document is written against. As a result, documents this work item never examined
+gain the rule too, and the editor that rewrites finished drafts starts enforcing it there
 ([D10](artifacts/decision-log.md#d10-where-the-extended-gloss-rule-lives)). That reach was chosen deliberately, because
 it is what gives the rule an enforcer rather than a self-check.
 
@@ -59,8 +59,8 @@ distinction exists here only so the rules below can be stated once
    the resulting findings against the code.
 3. Before drafting any finding, the review sources Han's standard for explaining technical work to someone who will not
    implement it ([D4](artifacts/decision-log.md#trivial-decisions)).
-4. Each finding the reader is expected to act on leads with a plain-language explanation answering three questions: what
-   goes wrong that someone could observe, what has to be true for it to happen, and how likely that is
+4. Each finding the reader is expected to act on leads with a plain-language explanation. It answers three questions:
+   what goes wrong that someone could observe, what has to be true for it to happen, and how likely that is
    ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)). The explanation answers
    all three; where an answer is not in doubt, it is a clause rather than a sentence. The existing register — what to
    do, where, and why, for the person who will open the file — follows it. Security findings carry the explanation and
@@ -69,21 +69,21 @@ distinction exists here only so the rules below can be stated once
    Advisory findings carry neither, because their stated reopen trigger already answers what the explanation would say
    ([D2](artifacts/decision-log.md#d2-which-findings-carry-the-second-explanation)).
 5. Where the review has already worked out that a failure mode cannot be reached, and used that to lower the finding's
-   severity, that reasoning is what the explanation states rather than being discarded. Where it has no such reasoning,
-   the answers are derived from the evidence the finding already carries. Deriving them never changes the finding's
+   severity, the explanation states that reasoning instead of discarding it. Where it has no such reasoning, the
+   answers are derived from the evidence the finding already carries. Deriving them never changes the finding's
    severity ([D3](artifacts/decision-log.md#d3-publishing-the-reachability-reasoning-instead-of-discarding-it)).
 6. Where the review has established that a finding may never fire, that fact appears on the finding's opening line and
-   in its row in the report's summary table, so a person triaging thirty findings sees it before reading any of them
-   ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)).
+   in its row in the report's summary table. That way, a person triaging thirty findings sees it before reading any of
+   them ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)).
 7. Each finding the reader is expected to act on names how it gets fixed: written test-first as a missing behavior,
    restructured as a design change, or edited by hand
    ([D12](artifacts/decision-log.md#d12-each-finding-names-how-it-gets-fixed)). That route also appears in the finding's
    summary row ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)).
 8. The report is written to a filename derived from the branch or ticket under review
    ([D6](artifacts/decision-log.md#d6-how-the-review-report-file-is-named)).
-9. Before presenting, the review checks its own output: that every finding the reader is expected to act on carries the
-   explanation and a fix route, and that the summary rows carry the route and any may-never-fire cue. A failed check is
-   fixed before presenting ([D17](artifacts/decision-log.md#d17-each-skill-checks-that-the-new-required-content-is-present-before-it-presents)).
+9. Before presenting, the review checks its own output. It confirms that every finding the reader is expected to act on
+   carries the explanation and a fix route, and that the summary rows carry the route and any may-never-fire cue. A
+   failed check is fixed before presenting ([D17](artifacts/decision-log.md#d17-each-skill-checks-that-the-new-required-content-is-present-before-it-presents)).
 10. The run closes with a short message that leads with the recommendation and the finding counts, then gives the path
     ([D7](artifacts/decision-log.md#d7-what-the-review-says-when-it-finishes),
     [D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills)). The report itself is not repeated
@@ -107,9 +107,10 @@ distinction exists here only so the rules below can be stated once
    ([D13](artifacts/decision-log.md#d13-what-where-to-start-gives-the-reader)).
 6. The overview closes with three or four sentences a non-author could read aloud, carrying no file paths and no type
    names ([D11](artifacts/decision-log.md#d11-the-overviews-closing-restatement)).
-7. Before presenting, the overview checks its own output: the diagrams against the legibility rule, the starting points
-   for their order, the terms a reader cannot look up for their explanations, and the closing restatement for its
-   presence and for file paths or type names that should not be in it. A failed check is fixed before presenting
+7. Before presenting, the overview checks its own output. It checks the diagrams against the legibility rule, the
+   starting points for their order, the terms a reader cannot look up for their explanations, and the closing
+   restatement for its presence and for file paths or type names that should not be in it. A failed check is fixed
+   before presenting
    ([D17](artifacts/decision-log.md#d17-each-skill-checks-that-the-new-required-content-is-present-before-it-presents)).
 8. The run closes with a short message carrying the closing restatement itself, plus any divergence from the change's
    stated purpose, then the path ([D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills),
@@ -119,7 +120,7 @@ distinction exists here only so the rules below can be stated once
 
 ### The code contradicts the stated reason for a change
 
-- **Entry condition:** An overview is explaining a set of changes, and the overview has checked the stated motivation
+- **Entry condition:** An overview is explaining a set of changes. The overview has checked the stated motivation
   against the code and found that the code already satisfies it, or does not support it.
 - **Sequence:** The overview says so in the section that states the reason, as a fact about that reason
   ([D14](artifacts/decision-log.md#d14-the-overview-may-report-that-a-changes-stated-reason-is-not-supported)). It
@@ -135,7 +136,7 @@ distinction exists here only so the rules below can be stated once
 
 - **Entry condition:** A finding survives to the report, but the conditions required for its failure mode may never hold
   in practice.
-- **Sequence:** The finding's opening line and its summary row both say so, and the explanation names the conditions and
+- **Sequence:** The finding's opening line and its summary row both say so. The explanation names the conditions and
   states that the finding is a no-op if they do not hold
   ([D3](artifacts/decision-log.md#d3-publishing-the-reachability-reasoning-instead-of-discarding-it),
   [D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)).
@@ -152,7 +153,7 @@ distinction exists here only so the rules below can be stated once
 | A review runs against the default branch, or against a scope with no branch at all | The report is named from what was reviewed: the single file, directory, or symbol when there is one, and the common parent of the reviewed files when there is not. A branch name that does not distinguish the run is not used ([D6](artifacts/decision-log.md#d6-how-the-review-report-file-is-named)). |
 | A report already exists at the derived name | The run replaces it and names the replaced report in its closing message ([D6](artifacts/decision-log.md#d6-how-the-review-report-file-is-named)). |
 | A review finds nothing at all | The closing message says the code can be approved and gives the path. No explanations are written, because there are no findings. |
-| A review's only findings are advisory | The recommendation is still that the code can be approved, because advisory findings never block a merge. The message says the count a person must act on is zero and names the advisory count separately, so nobody is told "no findings" about a report whose body lists items ([D7](artifacts/decision-log.md#d7-what-the-review-says-when-it-finishes)). |
+| A review's only findings are advisory | The recommendation is still that the code can be approved, because advisory findings never block a merge. The message says the count a person must act on is zero and names the advisory count separately. That way nobody is told "no findings" about a report whose body lists items ([D7](artifacts/decision-log.md#d7-what-the-review-says-when-it-finishes)). |
 | A finding's failure mode is reachable and its likelihood is not in doubt | The explanation still appears and still answers all three questions, answering the two that are not in doubt in a clause each ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)). |
 | An overview's diagram cannot be simplified without losing a step the flow needs | The step stays and the detail about it moves to the prose beneath. Legibility never removes a step from the flow ([D9](artifacts/decision-log.md#d9-who-owns-diagram-legibility)). |
 | An overview target contains both an interface and the flow behind it | Each starting point is judged on its own. The interface carries an example call; the flow entry points do not ([D13](artifacts/decision-log.md#d13-what-where-to-start-gives-the-reader)). |
@@ -206,8 +207,8 @@ because the recorded boundary already settled it.
 - **What it would have done:** Extended the destination resolution in this feature to every Han skill that writes a
   deliverable, rather than to the two named here.
 - **Why cut:** The recorded boundary in [scope-boundary.md](artifacts/scope-boundary.md) names two skills. Only the
-  Atlassian skills consume the configured output location today, so the same gap likely exists elsewhere, but the work
-  item is a retrospective on code review and code overview and its stated scope covers those two.
+  Atlassian skills consume the configured output location today, so the same gap likely exists elsewhere. But the work
+  item is a retrospective on code review and code overview, and its stated scope covers those two.
 
 ### Fixing the same plain-language gap in the skills the work item quotes as corroboration
 
@@ -215,8 +216,8 @@ because the recorded boundary already settled it.
   rather than to the two named here.
 - **Why cut:** The work item quotes people asking for plain-language summaries from other skills, and offers those
   quotes as evidence that the gap is shared rather than local. They are corroboration for the finding, not items in the
-  stated scope recorded in [scope-boundary.md](artifacts/scope-boundary.md), which names improvements to code review and
-  code overview only.
+  stated scope recorded in [scope-boundary.md](artifacts/scope-boundary.md). That scope names improvements to code
+  review and code overview only.
 
 ## Deferred (YAGNI)
 
@@ -226,8 +227,8 @@ justify revisiting it.
 ### A countable threshold for diagram legibility
 
 - **Why deferred:** Evidence-test failure. Both complaints in the corpus were about what the boxes contained, not about
-  how many there were or how long the labels ran, and both were fixed by taking the technical detail out. A counted
-  limit on box labels or box count is a rule nobody asked for, and a diagram can satisfy a count while still being
+  how many there were or how long the labels ran. Both were fixed by taking the technical detail out. A counted limit
+  on box labels or box count is a rule nobody asked for, and a diagram can satisfy a count while still being
   unreadable.
 - **Reopen when:** A diagram that satisfies the stated rule still draws a legibility complaint.
 - **Source:** Considered while settling
@@ -259,8 +260,8 @@ justify revisiting it.
 
 - **OI-1:** Whether the added length per finding is worth the follow-up turns it removes has not been measured. The work
   item's own length score is attributed to the review pasting itself into the conversation and to bookkeeping-led
-  closing messages, both of which this feature fixes, so the trade was accepted on that basis rather than on evidence
-  about finding bodies ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)).
+  closing messages, both of which this feature fixes. The trade was accepted on that basis, not on evidence about
+  finding bodies ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)).
   - **Resolves when:** A report with a substantial finding list has been produced under these rules and read.
   - **Blocks implementation:** No — the simpler-version bound on the explanation and the summary-row cues are the
     hedges, and both are specified.
@@ -274,9 +275,9 @@ justify revisiting it.
 - **Decisions settled by user input:** 1 — see [artifacts/decision-log.md](artifacts/decision-log.md)
 - **Sub-agents consulted:** `han-core:junior-developer`, `han-core:user-experience-designer`,
   `han-core:edge-case-explorer` — see [artifacts/team-findings.md](artifacts/team-findings.md)
-- **Key adjustments from review:** The likelihood cue and the fix route now reach the summary table rather than only the
-  finding body, which is the comparative problem the originating complaint about visual weight describes; the
-  explanation is bounded to what is in doubt rather than three fixed slots; and security findings, advisory-only reviews, unwritable
-  destinations, replaced reports, and mixed interface-and-flow targets all gained stated behavior — see
-  [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Key adjustments from review:** The likelihood cue and the fix route now reach the summary table rather than only
+  the finding body. This is the comparative problem the originating complaint about visual weight describes. The
+  explanation is bounded to what is in doubt rather than three fixed slots. And security findings, advisory-only
+  reviews, unwritable destinations, replaced reports, and mixed interface-and-flow targets all gained stated behavior
+  — see [artifacts/team-findings.md](artifacts/team-findings.md)
 - **Remaining open items:** 1

--- a/docs/plans/code-review-overview-language-corrections/feature-specification.md
+++ b/docs/plans/code-review-overview-language-corrections/feature-specification.md
@@ -11,8 +11,11 @@ Three questions account for nearly every follow-up turn people spend on these tw
 written, what a finding actually means for someone who will not open the code, and whether the problem a finding
 describes can really happen. After this change:
 
-- Every corrective finding says what goes wrong, what has to be true for it to happen, and how likely that is, in
-  language a person who will not open the file can act on ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)).
+- Every finding the reader is expected to act on says what goes wrong, what has to be true for it to happen, and how
+  likely that is, in language a person who will not open the file can act on
+  ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)).
+- A finding the review believes may never fire says so on its opening line and in the table a person scans, not only
+  inside its body ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)).
 - Both skills write their output where the person configured it to go, and both say where that was
   ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)).
 - Both closing messages lead with the answer rather than with facts about the run
@@ -20,9 +23,21 @@ describes can really happen. After this change:
 - An overview's diagrams are legible, its invented and borrowed terms are explained, its starting points are in reading
   order, and it ends with a paragraph a person can paste somewhere else.
 
+One part of this reaches further than the two skills. The requirement to explain a term the reader cannot look up goes
+into the writing standard every Han document is written against, so documents this work item never examined gain the
+rule too, and the editor that rewrites finished drafts starts enforcing it there
+([D10](artifacts/decision-log.md#d10-where-the-extended-gloss-rule-lives)). That reach was chosen deliberately, because
+it is what gives the rule an enforcer rather than a self-check.
+
 Nothing about the accuracy of either skill changes. The pass that challenges every finding against the code, the rule
-that a finding is only dropped with counter-evidence, the finding identifiers people work as a queue, and the rule that
-keeps clean reviews short all stay exactly as they are.
+that a finding is only dropped with counter-evidence, the severity bands, the order findings appear in, the finding
+identifiers people work as a queue, and the rule that keeps clean reviews short all stay exactly as they are.
+
+**Two words this specification uses that a reader of a report never sees.** A **finding the reader is expected to act
+on** is what the report calls a critical, warning, suggestion, or security finding. An **advisory finding** is one the
+report already states will not be corrected unless someone asks. Both skills use the report's own vocabulary; this
+distinction exists here only so the rules below can be stated once
+([D2](artifacts/decision-log.md#d2-which-findings-carry-the-second-explanation)).
 
 ## Actors and Triggers
 
@@ -44,23 +59,35 @@ keeps clean reviews short all stay exactly as they are.
    the resulting findings against the code.
 3. Before drafting any finding, the review sources Han's standard for explaining technical work to someone who will not
    implement it ([D4](artifacts/decision-log.md#d4-both-skills-source-the-explanation-standard-before-they-write-for-a-non-implementer)).
-4. Each corrective finding is written with two registers. The first is what exists today: what to do, where, and why,
-   for the person who will open the file. The second is new and required: the observable consequence, the conditions
-   that must all hold for it to occur, and an honest likelihood
-   ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)). Advisory findings carry
-   only the first, because their stated reopen trigger already answers what the second would say
+4. Each finding the reader is expected to act on leads with a plain-language explanation answering three questions: what
+   goes wrong that someone could observe, what has to be true for it to happen, and how likely that is
+   ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)). The explanation answers
+   all three; where an answer is not in doubt, it is a clause rather than a sentence. The existing register — what to
+   do, where, and why, for the person who will open the file — follows it. Security findings carry the explanation and
+   keep the remediation note their section already ends with, rather than gaining a second one
+   ([D15](artifacts/decision-log.md#d15-security-findings-carry-the-plain-language-explanation-but-not-a-separate-fix-route)).
+   Advisory findings carry neither, because their stated reopen trigger already answers what the explanation would say
    ([D2](artifacts/decision-log.md#d2-which-findings-carry-the-second-explanation)).
 5. Where the review has already worked out that a failure mode cannot be reached, and used that to lower the finding's
-   severity, that reasoning is what the second register states rather than being discarded
-   ([D3](artifacts/decision-log.md#d3-publishing-the-reachability-reasoning-instead-of-discarding-it)).
-6. Each corrective finding names how it gets fixed: written test-first as a missing behavior, restructured as a design
-   change, or edited by hand ([D12](artifacts/decision-log.md#d12-each-finding-names-how-it-gets-fixed)).
-7. The report is written to a filename derived from the branch or ticket under review
+   severity, that reasoning is what the explanation states rather than being discarded. Where it has no such reasoning,
+   the answers are derived from the evidence the finding already carries. Deriving them never changes the finding's
+   severity ([D3](artifacts/decision-log.md#d3-publishing-the-reachability-reasoning-instead-of-discarding-it)).
+6. Where the review has established that a finding may never fire, that fact appears on the finding's opening line and
+   in its row in the report's summary table, so a person triaging thirty findings sees it before reading any of them
+   ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)).
+7. Each finding the reader is expected to act on names how it gets fixed: written test-first as a missing behavior,
+   restructured as a design change, or edited by hand
+   ([D12](artifacts/decision-log.md#d12-each-finding-names-how-it-gets-fixed)). That route also appears in the finding's
+   summary row ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)).
+8. The report is written to a filename derived from the branch or ticket under review
    ([D6](artifacts/decision-log.md#d6-how-the-review-report-file-is-named)).
-8. The run closes with a short message that leads with the recommendation and the finding counts by severity, then gives
-   the path ([D7](artifacts/decision-log.md#d7-what-the-review-says-when-it-finishes),
-   [D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills)). The report itself is not repeated
-   into the conversation.
+9. Before presenting, the review checks its own output: that every finding the reader is expected to act on carries the
+   explanation and a fix route, and that the summary rows carry the route and any may-never-fire cue. A failed check is
+   fixed before presenting ([D17](artifacts/decision-log.md#d17-each-skill-checks-that-the-new-required-content-is-present-before-it-presents)).
+10. The run closes with a short message that leads with the recommendation and the finding counts, then gives the path
+    ([D7](artifacts/decision-log.md#d7-what-the-review-says-when-it-finishes),
+    [D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills)). The report itself is not repeated
+    into the conversation.
 
 ### A code overview run
 
@@ -69,64 +96,79 @@ keeps clean reviews short all stay exactly as they are.
    ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)).
 2. The overview runs unchanged through exploration and synthesis, leading with why the code or change exists.
 3. Every diagram names components and boundaries in its boxes. Fields, types, and technical annotations stay out of the
-   boxes and go into the prose beneath the diagram. The overview checks its own diagrams against this before presenting
+   boxes and go into the prose beneath the diagram
    ([D9](artifacts/decision-log.md#d9-who-owns-diagram-legibility)).
 4. Any term the reader cannot resolve from the code being described gets a half-sentence explanation the first time it
    appears. This covers outside technologies and language runtimes, named statistical or numerical methods, and
    compound nouns the document coins for its own convenience
    ([D10](artifacts/decision-log.md#d10-where-the-extended-gloss-rule-lives)).
-5. The starting points are numbered in reading order, each with one line on what the reader learns there. When the
-   target is an interface other code calls, the section also carries one runnable example call
+5. The starting points are numbered in reading order, each with one line on what the reader learns there. Any starting
+   point that is an interface other code calls carries one runnable example call
    ([D13](artifacts/decision-log.md#d13-what-where-to-start-gives-the-reader)).
 6. The overview closes with three or four sentences a non-author could read aloud, carrying no file paths and no type
    names ([D11](artifacts/decision-log.md#d11-the-overviews-closing-restatement)).
-7. The run closes with a short message that leads with why the code or change exists and any divergence from its stated
-   purpose, then gives the path ([D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills)).
+7. Before presenting, the overview checks its own output: the diagrams against the legibility rule, the starting points
+   for their order, the terms a reader cannot look up for their explanations, and the closing restatement for its
+   presence and for file paths or type names that should not be in it. A failed check is fixed before presenting
+   ([D17](artifacts/decision-log.md#d17-each-skill-checks-that-the-new-required-content-is-present-before-it-presents)).
+8. The run closes with a short message carrying the closing restatement itself, plus any divergence from the change's
+   stated purpose, then the path ([D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills),
+   [D11](artifacts/decision-log.md#d11-the-overviews-closing-restatement)).
 
 ## Alternate Flows and States
 
-### The stated reason for a change is not supported by the code
+### The code contradicts the stated reason for a change
 
-- **Entry condition:** An overview is explaining a set of changes, and the code shows the stated motivation is already
-  satisfied, or does not support the reason given.
+- **Entry condition:** An overview is explaining a set of changes, and the overview has checked the stated motivation
+  against the code and found that the code already satisfies it, or does not support it.
 - **Sequence:** The overview says so in the section that states the reason, as a fact about that reason
   ([D14](artifacts/decision-log.md#d14-the-overview-may-report-that-a-changes-stated-reason-is-not-supported)). It
   raises no finding, assigns no severity, and recommends no change.
 - **Exit:** The rest of the overview proceeds as normal. The reader gets the discrepancy at the point where the claim it
   qualifies is made.
+- **Not this flow:** A stated reason the code says nothing about either way. That is the overview's existing case for a
+  reason it cannot recover, and it stays there: the reason is marked as inferred and no discrepancy is claimed. Saying
+  the code contradicts a reason is a claim the overview must have checked and found true
+  ([D14](artifacts/decision-log.md#d14-the-overview-may-report-that-a-changes-stated-reason-is-not-supported)).
 
-### A finding may be a no-op
+### A finding may never fire
 
-- **Entry condition:** A review finding survives to the report, but the conditions required for its failure mode may
-  never hold in practice.
-- **Sequence:** The finding's second register says so plainly, naming the conditions and stating that the finding is a
-  no-op if they do not hold
-  ([D3](artifacts/decision-log.md#d3-publishing-the-reachability-reasoning-instead-of-discarding-it)).
-- **Exit:** The finding stays in the report at its assigned severity. Nothing is dropped on this basis; the reader is
-  told what the review already knows.
+- **Entry condition:** A finding survives to the report, but the conditions required for its failure mode may never hold
+  in practice.
+- **Sequence:** The finding's opening line and its summary row both say so, and the explanation names the conditions and
+  states that the finding is a no-op if they do not hold
+  ([D3](artifacts/decision-log.md#d3-publishing-the-reachability-reasoning-instead-of-discarding-it),
+  [D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)).
+- **Exit:** The finding stays in the report at its assigned severity and in its existing position. Nothing is dropped or
+  reordered on this basis; the reader is told what the review already knows, in the place they will see it first.
 
 ## Edge Cases and Failure Modes
 
 | Condition | Required Behavior |
 | --------- | ----------------- |
 | No output location is configured | Each skill writes where it writes today: the review beside the reports its specialists already produce, the overview outside the repository ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)). |
-| A configured output location points outside the working directory | The run honors it without comment. The person who configured it chose that. |
-| A review runs with no branch and no ticket to name the file from | The report is named from the target that was reviewed ([D6](artifacts/decision-log.md#d6-how-the-review-report-file-is-named)). |
-| A review finds nothing | The closing message says the code can be approved and gives the path. No finding registers are written, because there are no findings. |
-| A finding's failure mode is reachable and its likelihood is not in doubt | The second register still appears, saying so directly. It is required on every corrective finding, not only on uncertain ones ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)). |
+| A configured output location sits inside the repository | The run honors it and says nothing about it. The person who configured it chose that; the overview's commitment not to be committed governs its own default, not what a person configures ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)). |
+| The resolved destination cannot be written | The run writes to the unconfigured default instead and says so in its closing message, naming the destination it could not use. The run is not abandoned: everything it produced is finished by then ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)). |
+| A review runs against the default branch, or against a scope with no branch at all | The report is named from what was reviewed: the single file, directory, or symbol when there is one, and the common parent of the reviewed files when there is not. A branch name that does not distinguish the run is not used ([D6](artifacts/decision-log.md#d6-how-the-review-report-file-is-named)). |
+| A report already exists at the derived name | The run replaces it and names the replaced report in its closing message ([D6](artifacts/decision-log.md#d6-how-the-review-report-file-is-named)). |
+| A review finds nothing at all | The closing message says the code can be approved and gives the path. No explanations are written, because there are no findings. |
+| A review's only findings are advisory | The recommendation is still that the code can be approved, because advisory findings never block a merge. The message says the count a person must act on is zero and names the advisory count separately, so nobody is told "no findings" about a report whose body lists items ([D7](artifacts/decision-log.md#d7-what-the-review-says-when-it-finishes)). |
+| A finding's failure mode is reachable and its likelihood is not in doubt | The explanation still appears and still answers all three questions, answering the two that are not in doubt in a clause each ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)). |
 | An overview's diagram cannot be simplified without losing a step the flow needs | The step stays and the detail about it moves to the prose beneath. Legibility never removes a step from the flow ([D9](artifacts/decision-log.md#d9-who-owns-diagram-legibility)). |
-| An overview target is a flow rather than an interface | No example call is produced. The numbered starting points stand alone ([D13](artifacts/decision-log.md#d13-what-where-to-start-gives-the-reader)). |
+| An overview target contains both an interface and the flow behind it | Each starting point is judged on its own. The interface carries an example call; the flow entry points do not ([D13](artifacts/decision-log.md#d13-what-where-to-start-gives-the-reader)). |
 | An overview covers only part of its target | The coverage note stays where it is and is named in the closing message after the answer, not before it ([D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills)). |
 
 ## User Interactions
 
-- **Affordances:** The review's closing message gives the recommendation, the counts by severity, and the path. The
-  overview's closing message gives why the code or change exists, any divergence from its stated purpose, and the path.
-  The overview document itself ends with a paragraph written to be lifted out and pasted into a pull request description
-  or a comment ([D11](artifacts/decision-log.md#d11-the-overviews-closing-restatement)).
-- **Feedback:** Each corrective finding tells the reader whether to care, in terms they can weigh, and names the route
-  to fixing it ([D12](artifacts/decision-log.md#d12-each-finding-names-how-it-gets-fixed)).
-- **Error states:** None new. Neither skill gains a failure mode; both gain content and a destination.
+- **Affordances:** The review's closing message gives the recommendation, the counts, and the path. Its summary table
+  carries the fix route and any may-never-fire cue beside each finding's brief description, so triage happens before
+  reading ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)). The
+  overview's closing message carries the document's own closing restatement, so a person can paste from the terminal
+  without opening the file ([D11](artifacts/decision-log.md#d11-the-overviews-closing-restatement)).
+- **Feedback:** Each finding a reader is expected to act on tells them whether to care, in terms they can weigh, and
+  names the route to fixing it ([D12](artifacts/decision-log.md#d12-each-finding-names-how-it-gets-fixed)).
+- **Error states:** One. A resolved destination that cannot be written falls back to the unconfigured default, and the
+  closing message says so ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)).
 
 ## Coordinations
 
@@ -135,16 +177,21 @@ keeps clean reviews short all stay exactly as they are.
 | Han's configuration | inbound | Supplies the output location both skills resolve against | Read before either skill writes its deliverable ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)) |
 | Han's standard for explaining work to a non-implementer | inbound | Supplies the register for the finding explanations, the overview's closing restatement, and both closing messages | Sourced before that content is drafted, not after ([D4](artifacts/decision-log.md#d4-both-skills-source-the-explanation-standard-before-they-write-for-a-non-implementer)) |
 | Han's shared writing standard | inbound and outbound | Gains the extended requirement to explain a term the reader cannot look up | Every skill that sources the standard inherits the requirement, and the agent that rewrites finished drafts enforces it ([D10](artifacts/decision-log.md#d10-where-the-extended-gloss-rule-lives)) |
-| The skills a finding points to as its fix route | outbound | Named by each corrective finding as the way to address it | The route is named, never invoked ([D12](artifacts/decision-log.md#d12-each-finding-names-how-it-gets-fixed)) |
+| The skills a finding points to as its fix route | outbound | Named by each finding a reader is expected to act on, as the way to address it | The route is named, never invoked ([D12](artifacts/decision-log.md#d12-each-finding-names-how-it-gets-fixed)) |
 
 ## Out of Scope
 
 - **Any change to how findings are discovered, challenged, or dropped.** The specialists, the adversarial pass, the
-  counter-evidence bar for dropping a finding, and the severity bands all stay as they are. This change is about what
-  the output says, not what it finds.
-- **Any change to the finding identifiers.** People work them as a queue across sessions; the scheme stays.
-- **Letting the overview judge the code's quality.** Reporting that a change's stated reason is unsupported is a fact
-  about the reason, not a finding about the code
+  counter-evidence bar for dropping a finding, and the severity bands all stay as they are. Working out a finding's
+  preconditions and likelihood in order to explain it is writing work, and it never feeds back into that finding's
+  severity ([D3](artifacts/decision-log.md#d3-publishing-the-reachability-reasoning-instead-of-discarding-it)).
+- **Any change to the finding identifiers or the order findings appear in.** People work them as a queue across
+  sessions; both stay ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)).
+- **Auditing the documents that inherit the extended gloss rule.** Every skill sourcing the shared writing standard gains
+  the rule, and nothing here checks what that does to their output
+  ([D10](artifacts/decision-log.md#d10-where-the-extended-gloss-rule-lives)).
+- **Letting the overview judge the code's quality.** Reporting that the code contradicts a change's stated reason is a
+  fact about the reason, not a finding about the code
   ([D14](artifacts/decision-log.md#d14-the-overview-may-report-that-a-changes-stated-reason-is-not-supported)).
 - **Letting the rewrite pass edit diagram bodies.** The exemption stays; the check moves to the skill
   ([D9](artifacts/decision-log.md#d9-who-owns-diagram-legibility)).
@@ -156,9 +203,9 @@ because the recorded boundary already settled it.
 
 ### Every other Han skill honoring the configured output location
 
-- **Why cut:** The recorded boundary names two skills. Only three skills in the whole suite consume the configured
-  output location today, so the same gap almost certainly exists elsewhere, but the work item is a retrospective on code
-  review and code overview and its stated scope covers those two.
+- **Why cut:** The recorded boundary names two skills. Only the Atlassian skills consume the configured output location
+  today, so the same gap almost certainly exists elsewhere, but the work item is a retrospective on code review and code
+  overview and its stated scope covers those two.
 
 ### Fixing the same plain-language gap in the skills the work item quotes as corroboration
 
@@ -179,16 +226,51 @@ justify revisiting it.
   unreadable.
 - **Reopen when:** A diagram that satisfies the stated rule still draws a legibility complaint.
 - **Source:** Considered while settling
-  [D9](artifacts/decision-log.md#d9-who-owns-diagram-legibility); the work item's improvement 3 suggests checking "node-label length and count".
+  [D9](artifacts/decision-log.md#d9-who-owns-diagram-legibility); the work item's improvement 3 suggests checking
+  "node-label length and count".
+
+### Distinguishing two runs writing to the same destination at the same time
+
+- **Why deferred:** Evidence-test failure. Nothing in the corpus reports two runs racing to one destination, and the
+  corpus is one person's runs over four weeks. The collision the work item does report is sequential, and the naming
+  change plus the replace-and-say-so rule cover it.
+- **Reopen when:** Two runs are reported to have overwritten each other's output within one session, or the skills are
+  adopted by a team sharing one checkout.
+- **Source:** Review finding [F20](artifacts/team-findings.md), raised by `han-core:edge-case-explorer`, which flagged
+  it for awareness rather than recommending new behavior.
+
+### Counting conditional findings in the review's closing message
+
+- **Why deferred:** Simpler-version test. The likelihood cue reaching the summary table
+  ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)) already puts
+  the fact where a person triages. Adding a count of it to the closing message as well is a second signal for the same
+  fact, before anyone has seen whether the first one is enough.
+- **Reopen when:** Someone acts on a finding the report had already marked as possibly never firing.
+- **Source:** Review finding [F21](artifacts/team-findings.md), raised by `han-core:user-experience-designer`, which
+  recommended deferring it on the same grounds.
+
+## Open Items
+
+- **OI-1:** Whether the added length per finding is worth the follow-up turns it removes has not been measured. The work
+  item's own length score is attributed to the review pasting itself into the conversation and to bookkeeping-led
+  closing messages, both of which this feature fixes, so the trade was accepted on that basis rather than on evidence
+  about finding bodies ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)).
+  - **Resolves when:** A report with a substantial finding list has been produced under these rules and read.
+  - **Blocks implementation:** No — the simpler-version bound on the explanation and the summary-row cues are the
+    hedges, and both are specified.
 
 ## Summary
 
 - **Outcome delivered:** A code review or code overview run answers the three questions people currently spend
   follow-up turns asking, inside the run that produced it.
 - **Primary actors:** The person who invokes either skill, and the reviewer or teammate they hand the output to.
-- **Decisions settled by evidence:** 13 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Decisions settled by evidence:** 16 — see [artifacts/decision-log.md](artifacts/decision-log.md)
 - **Decisions settled by user input:** 1 — see [artifacts/decision-log.md](artifacts/decision-log.md)
-- **Sub-agents consulted:** to be completed after review — see [artifacts/team-findings.md](artifacts/team-findings.md)
-- **Key adjustments from review:** to be completed after review — see
+- **Sub-agents consulted:** `han-core:junior-developer`, `han-core:user-experience-designer`,
+  `han-core:edge-case-explorer` — see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Key adjustments from review:** The likelihood cue and the fix route now reach the summary table rather than only the
+  finding body, which is what the originating complaint about visual weight actually asked for; the explanation is
+  bounded to what is in doubt rather than three fixed slots; and security findings, advisory-only reviews, unwritable
+  destinations, replaced reports, and mixed interface-and-flow targets all gained stated behavior — see
   [artifacts/team-findings.md](artifacts/team-findings.md)
-- **Remaining open items:** 0
+- **Remaining open items:** 1

--- a/docs/plans/code-review-overview-language-corrections/feature-specification.md
+++ b/docs/plans/code-review-overview-language-corrections/feature-specification.md
@@ -1,0 +1,194 @@
+# Feature Specification: Understandable and Usable Output from Code Review and Code Overview
+
+The code review and code overview skills already produce accurate reports. This change makes those reports answer the
+three questions people ask afterwards, so the answers arrive in the report instead of costing a follow-up turn each.
+
+## Outcome
+
+Someone runs a code review or a code overview and gets everything they need from the run itself.
+
+Three questions account for nearly every follow-up turn people spend on these two skills today: where the file was
+written, what a finding actually means for someone who will not open the code, and whether the problem a finding
+describes can really happen. After this change:
+
+- Every corrective finding says what goes wrong, what has to be true for it to happen, and how likely that is, in
+  language a person who will not open the file can act on ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)).
+- Both skills write their output where the person configured it to go, and both say where that was
+  ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)).
+- Both closing messages lead with the answer rather than with facts about the run
+  ([D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills)).
+- An overview's diagrams are legible, its invented and borrowed terms are explained, its starting points are in reading
+  order, and it ends with a paragraph a person can paste somewhere else.
+
+Nothing about the accuracy of either skill changes. The pass that challenges every finding against the code, the rule
+that a finding is only dropped with counter-evidence, the finding identifiers people work as a queue, and the rule that
+keeps clean reviews short all stay exactly as they are.
+
+## Actors and Triggers
+
+- **Actors** — the person who invokes a code review or a code overview, and the people they hand the output to: a
+  reviewer, a pull request audience, a teammate who did not do the work.
+- **Triggers** — a code review run, or a code overview run in either of its modes: explaining code as it is now, or
+  explaining a set of changes.
+- **Preconditions** — none beyond what each skill already requires. Where a person has configured an output location,
+  that configuration is available to the run.
+
+## Primary Flow
+
+### A code review run
+
+1. The review resolves where its report will be written, honoring a configured output location when one exists and
+   falling back to the location it uses today when none does
+   ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)).
+2. The review runs unchanged: it classifies the change, dispatches its specialists, works its checklist, and challenges
+   the resulting findings against the code.
+3. Before drafting any finding, the review sources Han's standard for explaining technical work to someone who will not
+   implement it ([D4](artifacts/decision-log.md#d4-both-skills-source-the-explanation-standard-before-they-write-for-a-non-implementer)).
+4. Each corrective finding is written with two registers. The first is what exists today: what to do, where, and why,
+   for the person who will open the file. The second is new and required: the observable consequence, the conditions
+   that must all hold for it to occur, and an honest likelihood
+   ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)). Advisory findings carry
+   only the first, because their stated reopen trigger already answers what the second would say
+   ([D2](artifacts/decision-log.md#d2-which-findings-carry-the-second-explanation)).
+5. Where the review has already worked out that a failure mode cannot be reached, and used that to lower the finding's
+   severity, that reasoning is what the second register states rather than being discarded
+   ([D3](artifacts/decision-log.md#d3-publishing-the-reachability-reasoning-instead-of-discarding-it)).
+6. Each corrective finding names how it gets fixed: written test-first as a missing behavior, restructured as a design
+   change, or edited by hand ([D12](artifacts/decision-log.md#d12-each-finding-names-how-it-gets-fixed)).
+7. The report is written to a filename derived from the branch or ticket under review
+   ([D6](artifacts/decision-log.md#d6-how-the-review-report-file-is-named)).
+8. The run closes with a short message that leads with the recommendation and the finding counts by severity, then gives
+   the path ([D7](artifacts/decision-log.md#d7-what-the-review-says-when-it-finishes),
+   [D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills)). The report itself is not repeated
+   into the conversation.
+
+### A code overview run
+
+1. The overview resolves where its document will be written, honoring a configured output location when one exists and
+   staying outside the repository when none does
+   ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)).
+2. The overview runs unchanged through exploration and synthesis, leading with why the code or change exists.
+3. Every diagram names components and boundaries in its boxes. Fields, types, and technical annotations stay out of the
+   boxes and go into the prose beneath the diagram. The overview checks its own diagrams against this before presenting
+   ([D9](artifacts/decision-log.md#d9-who-owns-diagram-legibility)).
+4. Any term the reader cannot resolve from the code being described gets a half-sentence explanation the first time it
+   appears. This covers outside technologies and language runtimes, named statistical or numerical methods, and
+   compound nouns the document coins for its own convenience
+   ([D10](artifacts/decision-log.md#d10-where-the-extended-gloss-rule-lives)).
+5. The starting points are numbered in reading order, each with one line on what the reader learns there. When the
+   target is an interface other code calls, the section also carries one runnable example call
+   ([D13](artifacts/decision-log.md#d13-what-where-to-start-gives-the-reader)).
+6. The overview closes with three or four sentences a non-author could read aloud, carrying no file paths and no type
+   names ([D11](artifacts/decision-log.md#d11-the-overviews-closing-restatement)).
+7. The run closes with a short message that leads with why the code or change exists and any divergence from its stated
+   purpose, then gives the path ([D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills)).
+
+## Alternate Flows and States
+
+### The stated reason for a change is not supported by the code
+
+- **Entry condition:** An overview is explaining a set of changes, and the code shows the stated motivation is already
+  satisfied, or does not support the reason given.
+- **Sequence:** The overview says so in the section that states the reason, as a fact about that reason
+  ([D14](artifacts/decision-log.md#d14-the-overview-may-report-that-a-changes-stated-reason-is-not-supported)). It
+  raises no finding, assigns no severity, and recommends no change.
+- **Exit:** The rest of the overview proceeds as normal. The reader gets the discrepancy at the point where the claim it
+  qualifies is made.
+
+### A finding may be a no-op
+
+- **Entry condition:** A review finding survives to the report, but the conditions required for its failure mode may
+  never hold in practice.
+- **Sequence:** The finding's second register says so plainly, naming the conditions and stating that the finding is a
+  no-op if they do not hold
+  ([D3](artifacts/decision-log.md#d3-publishing-the-reachability-reasoning-instead-of-discarding-it)).
+- **Exit:** The finding stays in the report at its assigned severity. Nothing is dropped on this basis; the reader is
+  told what the review already knows.
+
+## Edge Cases and Failure Modes
+
+| Condition | Required Behavior |
+| --------- | ----------------- |
+| No output location is configured | Each skill writes where it writes today: the review beside the reports its specialists already produce, the overview outside the repository ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)). |
+| A configured output location points outside the working directory | The run honors it without comment. The person who configured it chose that. |
+| A review runs with no branch and no ticket to name the file from | The report is named from the target that was reviewed ([D6](artifacts/decision-log.md#d6-how-the-review-report-file-is-named)). |
+| A review finds nothing | The closing message says the code can be approved and gives the path. No finding registers are written, because there are no findings. |
+| A finding's failure mode is reachable and its likelihood is not in doubt | The second register still appears, saying so directly. It is required on every corrective finding, not only on uncertain ones ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)). |
+| An overview's diagram cannot be simplified without losing a step the flow needs | The step stays and the detail about it moves to the prose beneath. Legibility never removes a step from the flow ([D9](artifacts/decision-log.md#d9-who-owns-diagram-legibility)). |
+| An overview target is a flow rather than an interface | No example call is produced. The numbered starting points stand alone ([D13](artifacts/decision-log.md#d13-what-where-to-start-gives-the-reader)). |
+| An overview covers only part of its target | The coverage note stays where it is and is named in the closing message after the answer, not before it ([D8](artifacts/decision-log.md#d8-what-leads-the-closing-message-in-both-skills)). |
+
+## User Interactions
+
+- **Affordances:** The review's closing message gives the recommendation, the counts by severity, and the path. The
+  overview's closing message gives why the code or change exists, any divergence from its stated purpose, and the path.
+  The overview document itself ends with a paragraph written to be lifted out and pasted into a pull request description
+  or a comment ([D11](artifacts/decision-log.md#d11-the-overviews-closing-restatement)).
+- **Feedback:** Each corrective finding tells the reader whether to care, in terms they can weigh, and names the route
+  to fixing it ([D12](artifacts/decision-log.md#d12-each-finding-names-how-it-gets-fixed)).
+- **Error states:** None new. Neither skill gains a failure mode; both gain content and a destination.
+
+## Coordinations
+
+| Coordinating System | Direction | Interaction | Ordering / Consistency Requirement |
+| ------------------- | --------- | ----------- | ---------------------------------- |
+| Han's configuration | inbound | Supplies the output location both skills resolve against | Read before either skill writes its deliverable ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)) |
+| Han's standard for explaining work to a non-implementer | inbound | Supplies the register for the finding explanations, the overview's closing restatement, and both closing messages | Sourced before that content is drafted, not after ([D4](artifacts/decision-log.md#d4-both-skills-source-the-explanation-standard-before-they-write-for-a-non-implementer)) |
+| Han's shared writing standard | inbound and outbound | Gains the extended requirement to explain a term the reader cannot look up | Every skill that sources the standard inherits the requirement, and the agent that rewrites finished drafts enforces it ([D10](artifacts/decision-log.md#d10-where-the-extended-gloss-rule-lives)) |
+| The skills a finding points to as its fix route | outbound | Named by each corrective finding as the way to address it | The route is named, never invoked ([D12](artifacts/decision-log.md#d12-each-finding-names-how-it-gets-fixed)) |
+
+## Out of Scope
+
+- **Any change to how findings are discovered, challenged, or dropped.** The specialists, the adversarial pass, the
+  counter-evidence bar for dropping a finding, and the severity bands all stay as they are. This change is about what
+  the output says, not what it finds.
+- **Any change to the finding identifiers.** People work them as a queue across sessions; the scheme stays.
+- **Letting the overview judge the code's quality.** Reporting that a change's stated reason is unsupported is a fact
+  about the reason, not a finding about the code
+  ([D14](artifacts/decision-log.md#d14-the-overview-may-report-that-a-changes-stated-reason-is-not-supported)).
+- **Letting the rewrite pass edit diagram bodies.** The exemption stays; the check moves to the skill
+  ([D9](artifacts/decision-log.md#d9-who-owns-diagram-legibility)).
+
+## Cut for Scope
+
+This is work the work item excludes, not work deferred for lack of evidence. Nothing here carries a reopening trigger,
+because the recorded boundary already settled it.
+
+### Every other Han skill honoring the configured output location
+
+- **Why cut:** The recorded boundary names two skills. Only three skills in the whole suite consume the configured
+  output location today, so the same gap almost certainly exists elsewhere, but the work item is a retrospective on code
+  review and code overview and its stated scope covers those two.
+
+### Fixing the same plain-language gap in the skills the work item quotes as corroboration
+
+- **Why cut:** The work item quotes people asking for plain-language summaries from three other skills, and offers those
+  quotes as evidence that the gap is shared rather than local. They are corroboration for the finding, not items in the
+  stated scope, which names improvements to code review and code overview only.
+
+## Deferred (YAGNI)
+
+This is work no evidence supports yet, not work the work item excludes. Every entry carries the trigger that would
+justify revisiting it.
+
+### A countable threshold for diagram legibility
+
+- **Why deferred:** Evidence-test failure. Both complaints in the corpus were about what the boxes contained, not about
+  how many there were or how long the labels ran, and both were fixed by taking the technical detail out. A counted
+  limit on box labels or box count is a rule nobody asked for, and a diagram can satisfy a count while still being
+  unreadable.
+- **Reopen when:** A diagram that satisfies the stated rule still draws a legibility complaint.
+- **Source:** Considered while settling
+  [D9](artifacts/decision-log.md#d9-who-owns-diagram-legibility); the work item's improvement 3 suggests checking "node-label length and count".
+
+## Summary
+
+- **Outcome delivered:** A code review or code overview run answers the three questions people currently spend
+  follow-up turns asking, inside the run that produced it.
+- **Primary actors:** The person who invokes either skill, and the reviewer or teammate they hand the output to.
+- **Decisions settled by evidence:** 13 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Decisions settled by user input:** 1 — see [artifacts/decision-log.md](artifacts/decision-log.md)
+- **Sub-agents consulted:** to be completed after review — see [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Key adjustments from review:** to be completed after review — see
+  [artifacts/team-findings.md](artifacts/team-findings.md)
+- **Remaining open items:** 0

--- a/docs/plans/code-review-overview-language-corrections/feature-specification.md
+++ b/docs/plans/code-review-overview-language-corrections/feature-specification.md
@@ -7,8 +7,8 @@ three questions people ask afterwards, so the answers arrive in the report inste
 
 Someone runs a code review or a code overview and gets everything they need from the run itself.
 
-Three questions account for nearly every follow-up turn people spend on these two skills today: where the file was
-written, what a finding actually means for someone who will not open the code, and whether the problem a finding
+Three questions account for the most-repeated follow-up turns people spend on these two skills today: where the file
+was written, what a finding actually means for someone who will not open the code, and whether the problem a finding
 describes can really happen. After this change:
 
 - Every finding the reader is expected to act on says what goes wrong, what has to be true for it to happen, and how
@@ -58,7 +58,7 @@ distinction exists here only so the rules below can be stated once
 2. The review runs unchanged: it classifies the change, dispatches its specialists, works its checklist, and challenges
    the resulting findings against the code.
 3. Before drafting any finding, the review sources Han's standard for explaining technical work to someone who will not
-   implement it ([D4](artifacts/decision-log.md#d4-both-skills-source-the-explanation-standard-before-they-write-for-a-non-implementer)).
+   implement it ([D4](artifacts/decision-log.md#trivial-decisions)).
 4. Each finding the reader is expected to act on leads with a plain-language explanation answering three questions: what
    goes wrong that someone could observe, what has to be true for it to happen, and how likely that is
    ([D1](artifacts/decision-log.md#d1-who-the-second-explanation-on-a-finding-is-written-for)). The explanation answers
@@ -160,9 +160,9 @@ distinction exists here only so the rules below can be stated once
 
 ## User Interactions
 
-- **Affordances:** The review's closing message gives the recommendation, the counts, and the path. Its summary table
-  carries the fix route and any may-never-fire cue beside each finding's brief description, so triage happens before
-  reading ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)). The
+- **Affordances:** The review's closing message gives the recommendation, the counts, and the path
+  ([D7](artifacts/decision-log.md#d7-what-the-review-says-when-it-finishes)). Its summary table carries the fix route
+  and any may-never-fire cue beside each finding's brief description, so triage happens before reading ([D16](artifacts/decision-log.md#d16-the-likelihood-and-the-fix-route-reach-the-surface-a-person-scans)). The
   overview's closing message carries the document's own closing restatement, so a person can paste from the terminal
   without opening the file ([D11](artifacts/decision-log.md#d11-the-overviews-closing-restatement)).
 - **Feedback:** Each finding a reader is expected to act on tells them whether to care, in terms they can weigh, and
@@ -175,7 +175,7 @@ distinction exists here only so the rules below can be stated once
 | Coordinating System | Direction | Interaction | Ordering / Consistency Requirement |
 | ------------------- | --------- | ----------- | ---------------------------------- |
 | Han's configuration | inbound | Supplies the output location both skills resolve against | Read before either skill writes its deliverable ([D5](artifacts/decision-log.md#d5-where-the-report-and-the-overview-are-written)) |
-| Han's standard for explaining work to a non-implementer | inbound | Supplies the register for the finding explanations, the overview's closing restatement, and both closing messages | Sourced before that content is drafted, not after ([D4](artifacts/decision-log.md#d4-both-skills-source-the-explanation-standard-before-they-write-for-a-non-implementer)) |
+| Han's standard for explaining work to a non-implementer | inbound | Supplies the register for the finding explanations, the overview's closing restatement, and both closing messages | Sourced before that content is drafted, not after ([D4](artifacts/decision-log.md#trivial-decisions)) |
 | Han's shared writing standard | inbound and outbound | Gains the extended requirement to explain a term the reader cannot look up | Every skill that sources the standard inherits the requirement, and the agent that rewrites finished drafts enforces it ([D10](artifacts/decision-log.md#d10-where-the-extended-gloss-rule-lives)) |
 | The skills a finding points to as its fix route | outbound | Named by each finding a reader is expected to act on, as the way to address it | The route is named, never invoked ([D12](artifacts/decision-log.md#d12-each-finding-names-how-it-gets-fixed)) |
 
@@ -203,15 +203,20 @@ because the recorded boundary already settled it.
 
 ### Every other Han skill honoring the configured output location
 
-- **Why cut:** The recorded boundary names two skills. Only the Atlassian skills consume the configured output location
-  today, so the same gap almost certainly exists elsewhere, but the work item is a retrospective on code review and code
-  overview and its stated scope covers those two.
+- **What it would have done:** Extended the destination resolution in this feature to every Han skill that writes a
+  deliverable, rather than to the two named here.
+- **Why cut:** The recorded boundary in [scope-boundary.md](artifacts/scope-boundary.md) names two skills. Only the
+  Atlassian skills consume the configured output location today, so the same gap likely exists elsewhere, but the work
+  item is a retrospective on code review and code overview and its stated scope covers those two.
 
 ### Fixing the same plain-language gap in the skills the work item quotes as corroboration
 
-- **Why cut:** The work item quotes people asking for plain-language summaries from three other skills, and offers those
+- **What it would have done:** Applied the same plain-language requirement to the other skills the work item quotes,
+  rather than to the two named here.
+- **Why cut:** The work item quotes people asking for plain-language summaries from other skills, and offers those
   quotes as evidence that the gap is shared rather than local. They are corroboration for the finding, not items in the
-  stated scope, which names improvements to code review and code overview only.
+  stated scope recorded in [scope-boundary.md](artifacts/scope-boundary.md), which names improvements to code review and
+  code overview only.
 
 ## Deferred (YAGNI)
 
@@ -236,8 +241,8 @@ justify revisiting it.
   change plus the replace-and-say-so rule cover it.
 - **Reopen when:** Two runs are reported to have overwritten each other's output within one session, or the skills are
   adopted by a team sharing one checkout.
-- **Source:** Review finding [F20](artifacts/team-findings.md), raised by `han-core:edge-case-explorer`, which flagged
-  it for awareness rather than recommending new behavior.
+- **Source:** Review finding [F20](artifacts/team-findings.md#f20-concurrent-runs-writing-to-one-destination), raised
+  by `han-core:edge-case-explorer`, which flagged it for awareness rather than recommending new behavior.
 
 ### Counting conditional findings in the review's closing message
 
@@ -246,8 +251,9 @@ justify revisiting it.
   the fact where a person triages. Adding a count of it to the closing message as well is a second signal for the same
   fact, before anyone has seen whether the first one is enough.
 - **Reopen when:** Someone acts on a finding the report had already marked as possibly never firing.
-- **Source:** Review finding [F21](artifacts/team-findings.md), raised by `han-core:user-experience-designer`, which
-  recommended deferring it on the same grounds.
+- **Source:** Review finding
+  [F21](artifacts/team-findings.md#f21-counting-conditional-findings-in-the-reviews-closing-message), raised by
+  `han-core:user-experience-designer`, which recommended deferring it on the same grounds.
 
 ## Open Items
 
@@ -269,8 +275,8 @@ justify revisiting it.
 - **Sub-agents consulted:** `han-core:junior-developer`, `han-core:user-experience-designer`,
   `han-core:edge-case-explorer` — see [artifacts/team-findings.md](artifacts/team-findings.md)
 - **Key adjustments from review:** The likelihood cue and the fix route now reach the summary table rather than only the
-  finding body, which is what the originating complaint about visual weight actually asked for; the explanation is
-  bounded to what is in doubt rather than three fixed slots; and security findings, advisory-only reviews, unwritable
+  finding body, which is the comparative problem the originating complaint about visual weight describes; the
+  explanation is bounded to what is in doubt rather than three fixed slots; and security findings, advisory-only reviews, unwritable
   destinations, replaced reports, and mixed interface-and-flow targets all gained stated behavior — see
   [artifacts/team-findings.md](artifacts/team-findings.md)
 - **Remaining open items:** 1

--- a/docs/plans/code-review-overview-language-corrections/work-items.md
+++ b/docs/plans/code-review-overview-language-corrections/work-items.md
@@ -1,0 +1,675 @@
+# Work Items — Understandable and Usable Output from Code Review and Code Overview
+
+These work items break down [feature-specification.md](feature-specification.md), which corrects the reader-facing
+output of the `code-review` and `code-overview` skills so a run answers the three questions people currently spend
+follow-up turns asking.
+
+Work items are numbered `W-N` for cross-reference only. `Depends on` lines refer to other work items in this file.
+
+## Shared reference artifacts
+
+These artifacts apply to more than one work item below. Each work item's own `**References.**` block points into this
+list by name rather than repeating the link.
+
+- [feature-specification.md](feature-specification.md) — the behavior every work item here realizes. Each work item
+  names the sections it descends from.
+- [artifacts/scope-boundary.md](artifacts/scope-boundary.md) — the recorded boundary this work descends from: the issue,
+  its eight quoted improvements, the two constraints on how a change may be made, and the operator's answer that nothing
+  in scope is being deprecated.
+- [han-core/references/config-rule.md](../../../han-core/references/config-rule.md) — the precedence chain, path
+  resolution, and degradation rules a skill honors when it resolves a configured output location. Read by W-2 and W-8.
+- [han-communication/references/explanation-rule.md](../../../han-communication/references/explanation-rule.md) — the
+  standard for explaining technical work to a reader who will not implement it. Read by W-3, W-4, and W-11.
+- [han-communication/references/readability-rule.md](../../../han-communication/references/readability-rule.md) — the
+  shared writing standard, including the prose-only rule that exempts diagram bodies. Read by W-1, W-9, and W-13.
+- [CLAUDE.md](../../../CLAUDE.md) — the repository's documentation conventions: one canonical source per concept, a
+  long-form doc for every skill and agent, and indexes that stay complete.
+
+## W-1 — Extend the shared writing standard to cover coined and borrowed terms
+
+**Summary.** Readers keep asking what a word in a Han document means. The standard today asks a writer to define a term
+only when they could not avoid it. It says nothing about outside technology names, named statistical methods, or phrases
+a document invents for its own convenience. Those are the words readers got stuck on. This work puts the wider
+requirement into the shared standard, where the editor that rewrites finished drafts will enforce it.
+
+**Work to be done.**
+
+- Widen the standard's rule about defining a term, so it covers a term the reader cannot look up rather than a term the
+  writer could not avoid.
+  - Canonical file: `han-communication/references/readability-rule.md`. The standard has no vendored copies, so this is
+    the only edit site for the rule text.
+  - The rule declares its self-check enumerated at six criteria and kept small on purpose. Fold the requirement into the
+    existing check rather than growing the list, or say in the rule why the list changed.
+- Bring the rewriting editor's rubric into line with the widened rule, so the pass that audits a finished draft tests for
+  the same thing.
+  - Touch point: `han-communication/agents/readability-editor.md`, the rubric criterion covering common words and
+    defining an unavoidable term.
+- Update the surfaces that restate the standard's wording so none of them contradicts it.
+  - Touch points: `docs/readability.md`, and the long-form docs under `han-communication/docs/` that restate the rule or
+    the editor's rubric.
+
+**Note on the reach of this work item.** This is the one item in the file that reaches past the two skills. Every skill
+that sources the shared standard inherits the requirement, and the editor starts enforcing it on documents nobody here
+examined. The specification records that reach as deliberate, because it is what gives the rule an enforcer instead of a
+self-check.
+
+**Justification.** Improvement 4 of the issue's quoted "Suggested improvements", recorded in the boundary record:
+"Extend the gloss rule to cover coined and external terms."
+
+**References.**
+
+- **Plan decisions**
+  - **D10** — the requirement to explain a term the reader cannot look up lives in Han's shared writing standard rather
+    than in either skill, so the editor that rewrites finished drafts enforces it.
+- **Spec sections** — [Outcome](feature-specification.md#outcome) for the stated reach,
+  [A code overview run](feature-specification.md#a-code-overview-run) step 4 for what the requirement covers, and
+  [Out of Scope](feature-specification.md#out-of-scope) for the exclusion of auditing the documents that inherit it.
+- **Rule file** — `han-communication/references/readability-rule.md`, the canonical standard this work item edits. See
+  Shared reference artifacts.
+- **Agent definition** — `han-communication/agents/readability-editor.md`, the agent whose rubric enforces the standard
+  over a finished draft.
+- **Repo doc** — `docs/readability.md`, the operator-facing mirror of the standard. See Shared reference artifacts for
+  the documentation convention it follows.
+
+**Acceptance criteria.**
+
+- [ ] The shared writing standard states that a term the reader cannot resolve from the material being described gets a
+      half-sentence explanation at first use, and names the three kinds it covers: outside technologies and language
+      runtimes, named statistical or numerical methods, and compound nouns a document coins for itself.
+- [ ] The standard's own check catches a first use with no explanation, so a draft that fails the requirement is
+      corrected before it is presented.
+- [ ] The rewriting editor's rubric enforces the same requirement, so a finished draft handed to it gains the missing
+      explanations.
+- [ ] The requirement applies to prose only. Diagram bodies, code fences, and citation identifiers stay untouched by it.
+- [ ] The operator-facing page that mirrors the standard describes the wider requirement and matches what the standard
+      says.
+
+**Depends on.** `None.`
+
+## W-2 — Write the review report to a configured location under a name derived from the branch
+
+**Summary.** A code review has nowhere it reliably writes its report. Someone who set an output location in their Han
+configuration does not get it honored here. Consecutive runs also collide, because the name never varies with what was
+reviewed. This work makes the review write its report to a resolved location under a name derived from the branch or
+ticket.
+
+**Work to be done.**
+
+- Resolve the report's destination before the report is written, honoring a configured output location.
+  - Touch point: `han-coding/skills/code-review/SKILL.md`. The skill already reads configuration in its Project Context
+    block and already picks a directory for its specialists' reports. The report's own destination is the gap.
+  - Precedence, relative-path resolution, and what to do with an unusable value are governed by the config rule. Honor
+    that file rather than restating its rules in the skill.
+- Derive the report file name from the branch or ticket under review, with a fallback for a run that has no
+  distinguishing branch.
+  - The review already detects its mode and captures a branch name for later steps, so the inputs for the name exist by
+    the time the report is written.
+- State what happens when the derived name is already taken, and when the destination cannot be written, so the run
+  carries both facts into its closing message.
+- Describe the destination and naming behavior on the skill's long-form doc.
+  - Touch point: `han-coding/docs/skills/code-review.md`.
+
+**Justification.** Improvement 2 of the issue's quoted "Suggested improvements", recorded in the boundary record:
+resolve the destination through the config precedence chain, and name the file from the branch or ticket so consecutive
+runs stop colliding.
+
+**References.**
+
+- **Plan decisions**
+  - **D5** — both skills resolve where their output goes through Han's configuration chain, falling back to today's
+    location when nothing is configured.
+  - **D6** — the review report is named from the branch or ticket under review, with a named-from-scope fallback and a
+    replace-and-say-so rule when the name is already taken.
+- **Spec sections** — [A code review run](feature-specification.md#a-code-review-run) steps 1 and 8, and
+  [Edge Cases and Failure Modes](feature-specification.md#edge-cases-and-failure-modes) for the rows covering an
+  unconfigured default, a configured location inside the repository, an unwritable destination, a run with no
+  distinguishing branch, and a name already taken.
+- **Rule file** — `han-core/references/config-rule.md`. See Shared reference artifacts.
+- **Skill doc** — `han-coding/docs/skills/code-review.md`, the canonical operator-facing description of this skill.
+
+**Acceptance criteria.**
+
+- [ ] The review writes its report to a file, and the location comes from the person's configured output location when
+      one is set.
+- [ ] With nothing configured, the report lands where the review already puts the reports its specialists produce.
+- [ ] The file name is derived from the branch or ticket under review.
+- [ ] When the branch does not distinguish the run, the name comes from what was reviewed: the single file, directory,
+      or symbol when there is one, and the common parent of the reviewed files when there is not.
+- [ ] A report already sitting at the derived name is replaced, and the run records that it replaced one.
+- [ ] A destination that cannot be written falls back to the unconfigured default, the run records which destination it
+      could not use, and the run finishes rather than stopping.
+
+**Depends on.** `None.`
+
+## W-3 — Close a review with the recommendation and counts instead of the whole report
+
+**Summary.** A code review ends by pasting its whole report into the conversation. The reader scrolls a long document to
+reach the one thing they wanted, which is whether the code can be merged. The companion overview skill already gets this
+right and says only what the reader needs. This work gives the review a short closing message that leads with the
+recommendation and the counts, then points at the file.
+
+**Work to be done.**
+
+- Add a closing step to the review that presents a short message and stops pasting the report into the conversation.
+  - Touch point: `han-coding/skills/code-review/SKILL.md`, after the verification step.
+  - Source `han-communication:explanation-guidance` before writing the message. Neither of the two skills invokes it
+    today.
+- Order the message so the recommendation and the counts come before anything about how the run went.
+- Cover the clean review, the advisory-only review, the replaced report, and the unwritable destination in the message
+  rules.
+- Reconcile the verification rule that forbids anything following the review document.
+  - Touch point: `han-coding/skills/code-review/references/output-verification.md`, the item requiring the review output
+    to be the complete and final response. That rule assumes the report is the conversation response. The report is now
+    a file, and the message is what follows it.
+- Describe the closing message on the skill's long-form doc.
+
+**Justification.** Improvements 2 and 8 of the issue's quoted "Suggested improvements", recorded in the boundary record:
+close with the path, the recommendation, and the count by severity, stop pasting the full review into the conversation,
+and lead the closing message with the answer.
+
+**References.**
+
+- **Plan decisions**
+  - **D7** — the review's closing message gives the recommendation, the counts by severity, and the path, and separates
+    the count a person must act on from the advisory count.
+  - **D8** — both skills' closing messages lead with the answer rather than with facts about the run.
+- **Spec sections** — [A code review run](feature-specification.md#a-code-review-run) step 10,
+  [Edge Cases and Failure Modes](feature-specification.md#edge-cases-and-failure-modes) for the clean-review and
+  advisory-only rows, and [User Interactions](feature-specification.md#user-interactions) for what the message affords.
+- **Rule file** — `han-communication/references/explanation-rule.md`. See Shared reference artifacts.
+- **Skill doc** — `han-coding/docs/skills/code-review.md`.
+
+**Acceptance criteria.**
+
+- [ ] The run ends with a short message, and the full report is not repeated into the conversation.
+- [ ] The message leads with the recommendation and the finding counts by severity, then gives the path to the report.
+- [ ] Facts about the run itself, such as the size band or how the specialists reconciled, come after the answer or stay
+      in the file.
+- [ ] A review that found nothing says the code can be approved and gives the path.
+- [ ] A review whose only findings are advisory still recommends approval, states that the count a person must act on is
+      zero, and names the advisory count separately.
+- [ ] The message names a replaced report and a destination that could not be written, when either happened.
+- [ ] The skill sources Han's standard for explaining work to a non-implementer before it writes the message.
+
+**Depends on.** `W-2`.
+
+## W-4 — Give every actionable finding a plain-language explanation
+
+**Summary.** A review finding tells an engineer what to change and where. It does not tell anyone whether the problem
+can really happen. People read a finding and then ask whether it matters, which costs a follow-up turn every time. This
+work adds a plain-language explanation to each finding a reader is expected to act on, written for someone who will not
+open the file.
+
+**Work to be done.**
+
+- Add the explanation to the finding block in the review's output template, for the corrective severities and for the
+  security block.
+  - Touch point: `han-coding/skills/code-review/references/template.md`. Leave the advisory section's format alone.
+  - The template's existing rule that a finding's prose lives in exactly one place still holds. The explanation is part
+    of that one place.
+- State in the skill body that the explanation is drafted for a reader who will not open the file, and source the
+  explanation standard before any finding is drafted.
+  - Touch point: `han-coding/skills/code-review/SKILL.md`, at the step that generates the review output.
+- Carry the reachability reasoning the review already produces into the explanation instead of discarding it.
+  - Touch point: the gate in `han-coding/skills/code-review/SKILL.md` that demotes a finding whose rationale signals the
+    failure mode is unreachable. That reasoning exists at that moment and is thrown away.
+  - Say plainly that this is writing work and never feeds back into severity, because finding discovery and severity are
+    outside this work.
+- Describe what a finding now carries on the skill's long-form doc.
+
+**Note on what stays untouched.** How findings are discovered, challenged, and dropped does not change here. The
+specialists, the pass that challenges every finding against the code, the counter-evidence bar for dropping one, and the
+severity bands all stay as they are.
+
+**Justification.** Improvement 1 of the issue's quoted "Suggested improvements", recorded in the boundary record: give
+each finding a second prose slot carrying the observable consequence, the preconditions, and an honest likelihood, and
+publish the reachability reasoning there instead of discarding it.
+
+**References.**
+
+- **Plan decisions**
+  - **D1** — each finding the reader is expected to act on leads with a plain-language explanation answering what goes
+    wrong, what has to be true for it to happen, and how likely that is.
+  - **D2** — corrective findings carry that explanation and advisory findings do not, because an advisory finding's
+    stated reopen trigger already answers it.
+  - **D3** — where the review already worked out that a failure mode cannot be reached, it publishes that reasoning
+    instead of discarding it, and deriving the answers never changes a finding's severity.
+  - **D4** — the review sources Han's standard for explaining work to a non-implementer before it drafts findings.
+  - **D15** — security findings carry the explanation and keep the single remediation note their section already ends
+    with, rather than gaining a second one.
+- **Spec sections** — [A code review run](feature-specification.md#a-code-review-run) steps 3, 4, and 5,
+  [A finding may never fire](feature-specification.md#a-finding-may-never-fire),
+  [Edge Cases and Failure Modes](feature-specification.md#edge-cases-and-failure-modes) for the row on a finding whose
+  likelihood is not in doubt, and [Out of Scope](feature-specification.md#out-of-scope) for what stays untouched.
+- **Rule file** — `han-communication/references/explanation-rule.md`. See Shared reference artifacts.
+- **Skill doc** — `han-coding/docs/skills/code-review.md`.
+
+**Acceptance criteria.**
+
+- [ ] Every critical, warning, suggestion, and security finding leads with a plain-language explanation answering three
+      things: what someone could observe going wrong, what has to be true for it to happen, and how likely that is.
+- [ ] The explanation answers all three. Where an answer is not in doubt, it is a clause rather than a sentence.
+- [ ] The existing guidance for the engineer who will open the file follows the explanation and keeps its detail.
+- [ ] Advisory findings carry no explanation, because their stated reopen trigger already says what it would say.
+- [ ] A security finding carries the explanation and keeps the one remediation note its section already ends with. It
+      gains no second one.
+- [ ] Where the review already worked out that a failure mode cannot be reached, the explanation states that reasoning
+      and says the finding is a no-op if the conditions do not hold.
+- [ ] Working out a finding's preconditions and likelihood never changes its severity, its identifier, or its position
+      in the report.
+- [ ] The skill sources Han's standard for explaining work to a non-implementer before it drafts any finding.
+
+**Depends on.** `None.`
+
+## W-5 — Name how each finding gets fixed
+
+**Summary.** After reading a finding, people ask which tool to reach for. The report already knows the answer, because
+the shape of the fix follows from the finding. Asking costs a turn every time. This work has each actionable finding
+name its own route to a fix.
+
+**Work to be done.**
+
+- Add the fix route to the finding block in the review's output template, beside the explanation.
+  - Touch point: `han-coding/skills/code-review/references/template.md`.
+- State the three routes in the skill body, along with the rule that naming a route is not starting it.
+  - Touch point: `han-coding/skills/code-review/SKILL.md`.
+  - The routes are Han's test-first path for a missing behavior, its restructuring path for a design change, and a hand
+    edit for a small change. Name each as the reader would reach for it.
+- Describe the route on the skill's long-form doc.
+
+**Justification.** Improvement 5 of the issue's quoted "Suggested improvements", recorded in the boundary record: each
+finding should name the route to fix it, because the user asks anyway.
+
+**References.**
+
+- **Plan decisions**
+  - **D12** — each finding the reader is expected to act on names its fix route: written test-first as a missing
+    behavior, restructured as a design change, or edited by hand.
+  - **D15** — security findings carry the explanation but no separate fix route, because their section already ends with
+    a remediation note.
+- **Spec sections** — [A code review run](feature-specification.md#a-code-review-run) step 7, and
+  [Coordinations](feature-specification.md#coordinations) for the row stating the route is named, never invoked.
+- **Skill doc** — `han-coding/docs/skills/code-review.md`.
+
+**Acceptance criteria.**
+
+- [ ] Every critical, warning, and suggestion finding names how it gets fixed: written test-first as a missing behavior,
+      restructured as a design change, or edited by hand.
+- [ ] The route is named, never started. The review invokes nothing on the reader's behalf.
+- [ ] Security findings carry no separate route, because their section already ends with a remediation note.
+- [ ] Advisory findings carry no route, matching their existing treatment.
+
+**Depends on.** `W-4`.
+
+## W-6 — Put the fix route and the may-never-fire cue where a person triages
+
+**Summary.** A person holding thirty findings scans the summary table first and reads the bodies afterwards. Knowing
+that a finding may never fire, or that it is a one-line hand edit, sits inside the body where a scanner never reaches
+it. So the reader works through findings that never needed their attention. This work brings both cues up to the table
+and to each finding's opening line.
+
+**Work to be done.**
+
+- Carry the fix route and the may-never-fire cue into the report's summary table.
+  - Touch point: `han-coding/skills/code-review/references/template.md`, the Review Summary table and the note declaring
+    a table row an index entry rather than prose. Keep that note true.
+- Put the may-never-fire cue on the finding's opening line as well, so a reader who opens the finding meets it first.
+- Extend the structural verification that already checks the table lists every finding, so it also checks the new cells.
+  - Touch point: `han-coding/skills/code-review/references/output-verification.md`, the item covering table
+    completeness.
+- Describe what the summary table now carries on the skill's long-form doc.
+
+**Justification.** A necessity of improvements 1 and 5, as the specification adjusts them: the explanation and the route
+only remove follow-up turns if a person triaging a long finding list sees them before opening any finding.
+
+**References.**
+
+- **Plan decisions**
+  - **D16** — the likelihood cue and the fix route reach the report's summary table and the finding's opening line, not
+    only the finding body, so triage happens before the reading.
+- **Spec sections** — [A code review run](feature-specification.md#a-code-review-run) steps 6 and 7,
+  [A finding may never fire](feature-specification.md#a-finding-may-never-fire),
+  [User Interactions](feature-specification.md#user-interactions), and
+  [Out of Scope](feature-specification.md#out-of-scope) for the finding identifiers and ordering that do not change.
+- **Skill doc** — `han-coding/docs/skills/code-review.md`.
+
+**Acceptance criteria.**
+
+- [ ] Each row in the report's summary table carries the finding's fix route.
+- [ ] A finding the review has established may never fire says so in its summary row and on its opening line.
+- [ ] The summary table stays an index. It gains cues, not a second copy of each finding's prose.
+- [ ] Finding identifiers, severities, and the order findings appear in are unchanged.
+- [ ] The report's structural verification confirms the table carries the route and the cue for every finding that
+      should have them.
+
+**Depends on.** `W-4`, `W-5`.
+
+## W-7 — Check the review's new required content before presenting it
+
+**Summary.** The review already checks its own output before presenting it. Those checks cover the parts of the report
+that existed before this work. The new explanation, the fix route, and the summary cues have nothing confirming they
+arrived. This work adds them to the check the review already runs.
+
+**Work to be done.**
+
+- Add the new content checks to the review's existing verification list.
+  - Touch point: `han-coding/skills/code-review/references/output-verification.md`. The structural list is where the
+    other presence checks live, and the readability self-check beside it stays as it is.
+- Keep the fix-before-presenting rule explicit, matching how the file already treats its other failures.
+- Describe the check on the skill's long-form doc.
+
+**Justification.** A necessity of improvements 1 and 5. A required piece of finding content with nothing checking for it
+is a preference, and the review already runs a verification pass where the check belongs.
+
+**References.**
+
+- **Plan decisions**
+  - **D17** — each skill checks that the newly required content is present before it presents, and fixes a failed check
+    rather than shipping it.
+- **Spec section** — [A code review run](feature-specification.md#a-code-review-run) step 9.
+- **Skill doc** — `han-coding/docs/skills/code-review.md`.
+
+**Acceptance criteria.**
+
+- [ ] Before presenting, the review confirms every finding a reader is expected to act on carries the plain-language
+      explanation.
+- [ ] It confirms every such finding names a fix route, and that security findings carry the explanation without a
+      separate route.
+- [ ] It confirms each summary row carries the route and, where it applies, the may-never-fire cue.
+- [ ] A failed check is corrected before the review is presented, rather than reported as a caveat.
+- [ ] The existing checks over identifiers, references, sections, and readability continue to run unchanged.
+
+**Depends on.** `W-4`, `W-5`, `W-6`.
+
+## W-8 — Let the overview write where the person configured it to write
+
+**Summary.** The overview always writes to a temporary location outside the repository. Someone who has told Han where
+its output should go does not get that honored. The rule keeping the overview out of the repository was written as a
+default and behaves as a prohibition. This work makes the configured location win and keeps the old behavior as the
+fallback.
+
+**Work to be done.**
+
+- Resolve the overview's destination against the configured output location before it writes.
+  - Touch point: `han-coding/skills/code-overview/SKILL.md`, the step that writes the scratch file. The skill already
+    reads configuration in its Project Context block.
+  - Precedence, path resolution, and unusable values are governed by the config rule.
+- Reword the operating principle that fixes the file outside the repository, so it describes the skill's own default
+  rather than forbidding the configured case.
+- State the fallback for a resolved destination that cannot be written, so the closing message can name it.
+- Update the long-form doc, which tells readers today that the file is always written outside the repository.
+  - Touch point: `han-coding/docs/skills/code-overview.md`.
+
+**Justification.** Improvement 2 of the issue's quoted "Suggested improvements", recorded in the boundary record:
+resolve the destination through the config precedence chain in both skills, and drop the overview's "outside the
+repository" prescription, which overrides it.
+
+**References.**
+
+- **Plan decisions**
+  - **D5** — both skills resolve their output location through Han's configuration chain, and with nothing configured
+    the overview keeps writing outside the repository.
+- **Spec sections** — [A code overview run](feature-specification.md#a-code-overview-run) step 1, and
+  [Edge Cases and Failure Modes](feature-specification.md#edge-cases-and-failure-modes) for the rows on an unconfigured
+  default, a configured location inside the repository, and an unwritable destination.
+- **Rule file** — `han-core/references/config-rule.md`. See Shared reference artifacts.
+- **Skill doc** — `han-coding/docs/skills/code-overview.md`.
+
+**Acceptance criteria.**
+
+- [ ] The overview writes its document to the person's configured output location when one is set.
+- [ ] With nothing configured, the overview writes outside the repository exactly as it does today.
+- [ ] A configured location inside the repository is honored, and the run says nothing about it.
+- [ ] A destination that cannot be written falls back to the unconfigured default, and the run names the destination it
+      could not use.
+- [ ] The skill's commitment not to be committed into the repository reads as a rule about its own default, not about
+      what a person configures.
+
+**Depends on.** `None.`
+
+## W-9 — Make the overview's diagrams readable
+
+**Summary.** The overview's diagrams are the one thing people complained about more than once. The pass that rewrites
+the document for readability leaves diagram bodies alone, which is right for accuracy and leaves legibility to nobody.
+Boxes end up carrying field names and types nobody can read at a glance. This work gives the template a rule about what
+belongs in a box and moves the detail to the prose beneath.
+
+**Work to be done.**
+
+- Add the diagram rule to the overview template's shared rules, so both modes inherit it.
+  - Touch point: `han-coding/skills/code-overview/references/overview-template.md`. The shared rules already govern
+    chart scope labels, so the diagram rule sits beside them.
+- State in the skill body that the skill owns diagram legibility, since the readability pass is exempt from diagram
+  bodies by design.
+  - Touch point: `han-coding/skills/code-overview/SKILL.md`.
+- Describe the diagram rule on the skill's long-form doc.
+
+**Justification.** Improvement 3 of the issue's quoted "Suggested improvements", recorded in the boundary record: add a
+diagram rule to the overview template so nodes name components and boundaries rather than fields and types, and keep
+diagram bodies exempt from the prose rewrite.
+
+**References.**
+
+- **Plan decisions**
+  - **D9** — diagram legibility belongs to the overview skill and its template: boxes name components and boundaries,
+    technical detail moves to the prose beneath, and the rewrite pass stays out of diagram bodies.
+- **Spec sections** — [A code overview run](feature-specification.md#a-code-overview-run) step 3,
+  [Edge Cases and Failure Modes](feature-specification.md#edge-cases-and-failure-modes) for the row on a diagram that
+  cannot be simplified without losing a step, and [Out of Scope](feature-specification.md#out-of-scope) for the rewrite
+  pass keeping its exemption.
+- **Rule file** — `han-communication/references/readability-rule.md`, whose prose-only rule exempts diagram bodies. See
+  Shared reference artifacts.
+- **Skill doc** — `han-coding/docs/skills/code-overview.md`.
+
+**Acceptance criteria.**
+
+- [ ] The overview's template states that diagram boxes name components and boundaries.
+- [ ] Fields, types, and technical annotations stay out of the boxes and appear in the prose beneath the diagram.
+- [ ] A step the flow needs is never removed to make the diagram simpler. The step stays and its detail moves to the
+      prose.
+- [ ] The pass that rewrites the document for readability still leaves diagram bodies untouched.
+
+**Depends on.** `None.`
+
+## W-10 — Turn "Where to start" into an ordered path with an example call
+
+**Summary.** The overview lists the right files to open first but not the order to open them in. A reader new to the
+code has to guess where to begin. When the target is something other code calls, they also have to work out how to call
+it. This work numbers the starting points and adds one example call where it applies.
+
+**Work to be done.**
+
+- Change the code-mode handoff section of the template so the entry points are numbered in reading order, each carrying
+  what the reader learns there.
+  - Touch point: `han-coding/skills/code-overview/references/overview-template.md`. Only the code mode has a
+    "Where to start" section today. The change-explaining mode's handoff section stays as it is and keeps its
+    navigational-only boundary.
+- Add the rule for one runnable example call on a starting point that is an interface other code calls, judged per entry
+  rather than per target.
+- Bring the skill body's description of the code-mode section into line with the template.
+  - Touch point: `han-coding/skills/code-overview/SKILL.md`, the synthesis step.
+- Describe the ordered handoff on the skill's long-form doc.
+
+**Justification.** Improvement 6 of the issue's quoted "Suggested improvements", recorded in the boundary record: number
+the entry points in reading order with one line on what the reader learns at each, and include one runnable example call
+when the target is an interface.
+
+**References.**
+
+- **Plan decisions**
+  - **D13** — the starting points are numbered in reading order with one line each on what the reader learns, and a
+    starting point that is an interface other code calls carries one runnable example call.
+- **Spec sections** — [A code overview run](feature-specification.md#a-code-overview-run) step 5, and
+  [Edge Cases and Failure Modes](feature-specification.md#edge-cases-and-failure-modes) for the row on a target holding
+  both an interface and the flow behind it.
+- **Skill doc** — `han-coding/docs/skills/code-overview.md`.
+
+**Acceptance criteria.**
+
+- [ ] The starting points are numbered in reading order rather than listed unordered.
+- [ ] Each starting point carries one line on what the reader learns there.
+- [ ] A starting point that is an interface other code calls carries one runnable example call.
+- [ ] Each starting point is judged on its own, so a target holding both an interface and the flow behind it gets the
+      example call on the interface only.
+
+**Depends on.** `None.`
+
+## W-11 — End every overview with a paragraph a person can paste
+
+**Summary.** After reading an overview, people paste a plain summary into a pull request or a message to a reviewer. The
+document holds no such paragraph, so they write one themselves or ask for it. The closing message the run prints leads
+with facts about the run rather than with the answer. This work adds the pasteable paragraph to the document and puts it
+at the front of the closing message.
+
+**Work to be done.**
+
+- Add the closing restatement as the last section of the overview document, in both modes.
+  - Touch point: `han-coding/skills/code-overview/references/overview-template.md`.
+- Reorder the closing message so the restatement leads it and facts about the run follow.
+  - Touch point: `han-coding/skills/code-overview/SKILL.md`, the presenting step. The skill's existing rule against
+    pasting the whole overview into the conversation stays.
+  - Source `han-communication:explanation-guidance` before writing the restatement and the message.
+- Have the closing message carry the document's own restatement rather than writing a second version of it.
+- Describe the closing section and the message ordering on the skill's long-form doc.
+
+**Justification.** Improvements 5 and 8 of the issue's quoted "Suggested improvements", recorded in the boundary record:
+end every overview with three or four sentences a non-author could read aloud, because the reader's next action is
+reliably to paste that somewhere, and lead the closing message with the answer.
+
+**References.**
+
+- **Plan decisions**
+  - **D11** — the overview closes with three or four sentences a non-author could read aloud, carrying no file paths and
+    no type names, and the closing message carries that restatement itself rather than a second version.
+  - **D8** — both skills' closing messages lead with the answer rather than with facts about the run.
+- **Spec sections** — [A code overview run](feature-specification.md#a-code-overview-run) steps 6 and 8,
+  [Edge Cases and Failure Modes](feature-specification.md#edge-cases-and-failure-modes) for the row on a partial
+  coverage note, and [User Interactions](feature-specification.md#user-interactions).
+- **Rule file** — `han-communication/references/explanation-rule.md`. See Shared reference artifacts.
+- **Skill doc** — `han-coding/docs/skills/code-overview.md`.
+
+**Acceptance criteria.**
+
+- [ ] The overview ends with three or four sentences a non-author could read aloud.
+- [ ] Those sentences carry no file paths and no type names.
+- [ ] The closing message leads with that restatement, followed by any divergence from the change's stated purpose, then
+      the path.
+- [ ] The closing message carries the document's own restatement rather than a separately written version of it.
+- [ ] Facts about the run, such as the mode and size, come after the answer, and a partial-coverage note is named after
+      the answer rather than before it.
+- [ ] The skill sources Han's standard for explaining work to a non-implementer before it writes the restatement and the
+      message.
+
+**Depends on.** `W-8`.
+
+## W-12 — Let the overview say when the code does not support a change's stated reason
+
+**Summary.** When an overview explains a set of changes, it states the reason the change was made. Sometimes the code
+shows that reason is already satisfied, or does not support it. The overview knows this and stays silent, which leaves
+the reader holding a claim the evidence contradicts. This work lets the overview say so at the point it states the
+reason.
+
+**Work to be done.**
+
+- Allow the change-explaining mode's why section to report a stated reason the code does not support, stated as a fact
+  about the reason.
+  - Touch points: `han-coding/skills/code-overview/SKILL.md`, the synthesis step's ordering for that mode, and the
+    matching why section in `han-coding/skills/code-overview/references/overview-template.md`.
+- Draw the line between this and the existing inferred-why path, so a reason the code is silent about is not reported as
+  a contradiction.
+  - The skill already requires the why to be grounded in evidence and marked as inferred when it is not. This addition
+    needs the same evidence bar: the overview must have checked and found the contradiction.
+- Keep the no-quality-judgment principle intact, and say why this addition does not cross it.
+- Describe the behavior on the skill's long-form doc.
+
+**Justification.** Improvement 7 of the issue's quoted "Suggested improvements", recorded in the boundary record: when
+the code shows the stated motivation is already satisfied or that the change is not needed for the reason given, say so
+in the why section as a fact about the why.
+
+**References.**
+
+- **Plan decisions**
+  - **D14** — the overview may report that a change's stated reason is not supported by the code, as a fact about the
+    reason rather than as a finding about the code.
+- **Spec sections** —
+  [The code contradicts the stated reason for a change](feature-specification.md#the-code-contradicts-the-stated-reason-for-a-change),
+  and [Out of Scope](feature-specification.md#out-of-scope) for the overview still making no quality judgment.
+- **Boundary record** — `artifacts/scope-boundary.md` carries the recorded constraint on this improvement: keep the
+  quality boundary. See Shared reference artifacts.
+- **Skill doc** — `han-coding/docs/skills/code-overview.md`.
+
+**Acceptance criteria.**
+
+- [ ] When the overview has checked the stated reason against the code and found that the code already satisfies it or
+      does not support it, it says so in the section that states the reason.
+- [ ] The statement is a fact about the stated reason. The overview raises no finding, assigns no severity, and
+      recommends no change.
+- [ ] The rest of the overview proceeds as normal.
+- [ ] A stated reason the code says nothing about either way keeps its existing treatment: the reason is marked as
+      inferred and no discrepancy is claimed.
+- [ ] The overview's rule against judging the code's quality still holds and is not weakened by this addition.
+
+**Depends on.** `None.`
+
+## W-13 — Check the overview's new required content before presenting it
+
+**Summary.** The overview checks its own accuracy and readability before presenting. Nothing confirms the new content
+arrived. The diagrams, the ordered starting points, the explained terms, and the closing paragraph could all go missing
+without anyone noticing until a reader complains. This work extends the check the overview already runs.
+
+**Work to be done.**
+
+- Extend the overview's pre-presentation self-check to cover the newly required content.
+  - Touch point: `han-coding/skills/code-overview/SKILL.md`, alongside the readability self-check that runs after the
+    rewrite pass.
+- Keep the check ordered after the accuracy pass, so it never confirms content that is about to be corrected.
+- Describe the check on the skill's long-form doc.
+
+**Justification.** A necessity of improvements 3, 4, 5, and 6. Each adds required content to the overview, and the
+overview already runs a self-check before presenting, which is where a presence check belongs.
+
+**References.**
+
+- **Plan decisions**
+  - **D17** — each skill checks that the newly required content is present before it presents, and fixes a failed check
+    rather than shipping it.
+- **Spec section** — [A code overview run](feature-specification.md#a-code-overview-run) step 7.
+- **Rule file** — `han-communication/references/readability-rule.md`, whose prose-only rule scopes what the check may
+  read. See Shared reference artifacts.
+- **Skill doc** — `han-coding/docs/skills/code-overview.md`.
+
+**Acceptance criteria.**
+
+- [ ] Before presenting, the overview checks its diagrams against the legibility rule.
+- [ ] It checks that the starting points are in reading order, and that an interface starting point carries its example
+      call.
+- [ ] It checks that terms a reader cannot look up carry their explanations.
+- [ ] It checks that the closing restatement is present and carries no file paths and no type names.
+- [ ] A failed check is fixed before the overview is presented.
+- [ ] The check covers prose regions and diagram box labels only. Code fences and screenshot markup stay outside it,
+      because the shared standard exempts them.
+
+**Depends on.** `W-1`, `W-9`, `W-10`, `W-11`.
+
+## Cut for Scope
+
+This is work the work item excludes, not work deferred for lack of evidence. There is no trigger that reopens an entry
+here; the recorded boundary already settled it.
+
+- **Every other Han skill honoring the configured output location, so a person's configured destination is honored
+  everywhere rather than in these two skills alone.** The recorded boundary in
+  [artifacts/scope-boundary.md](artifacts/scope-boundary.md) names two skills. Only the Atlassian skills consume the
+  configured output location today, so the same gap likely exists elsewhere. The work item is a retrospective on code
+  review and code overview, and its stated scope covers those two. Carried forward from the specification's
+  [Cut for Scope](feature-specification.md#cut-for-scope) section.
+- **The same plain-language explanation in the other skills the issue quotes, so their output would answer the same
+  question this work answers for these two.** The issue quotes people asking other skills for plain-language summaries
+  and offers those quotes as evidence that the gap is shared rather than local. They are corroboration for the finding,
+  not items in the stated scope recorded in [artifacts/scope-boundary.md](artifacts/scope-boundary.md), which names
+  improvements to code review and code overview only. Carried forward from the specification's
+  [Cut for Scope](feature-specification.md#cut-for-scope) section.
+- **A sweep over the Han documents already written, adding the explanations the widened writing standard from W-1 now
+  asks for.** The specification's [Out of Scope](feature-specification.md#out-of-scope) section rules it out by name:
+  every skill sourcing the shared standard gains the rule, and nothing here checks what that does to their output. The
+  standard also applies at generation time, so a document already committed is not re-checked by design. W-1 puts the
+  rule and its enforcer in place; auditing what already exists is separate work.

--- a/docs/readability.md
+++ b/docs/readability.md
@@ -56,8 +56,11 @@ The rule names the output properties, and they shape each skill's template so th
   ("Analysis").
 - **Short, active sentences.** Roughly fifteen to twenty words on average, active by default. The self-check flags any
   sentence past about thirty words as a candidate to split. That is a review trigger, not a hard cap.
-- **Common words.** Prefer the common word over the technical synonym; define a term on first use when it cannot be
-  replaced.
+- **Common words, and a half-sentence explanation for a term the reader cannot look up.** Prefer the common word over
+  the technical synonym. Where a term cannot be replaced, explain it in half a sentence at first use. Three kinds always
+  need it, because the reader has nowhere to resolve them from the material the document describes: outside
+  technologies and language runtimes, named statistical or numerical methods, and compound nouns the document coins for
+  its own convenience. The coined ones matter most, since a reader can search for the other two and find an answer.
 - **No blocklisted words.** The existing writing-voice blocklist is reused for word-level rules.
 - **Numbered lists for steps, bullets for the rest.**
 - **Progressive disclosure.** Reveal the core first and detail in layers.
@@ -82,8 +85,9 @@ at a time:
    [`readability-editor`](../han-communication/docs/agents/readability-editor.md) to audit and rewrite the draft against the
    rule, preserving every fact.
 4. **Self-check.** A discrete pass over the prose regions evaluates six behaviorally-anchored yes/no criteria: main
-   point first, descriptive headings, one idea per paragraph, sentence length, no blocklisted word, and every fact
-   preserved. Anything it fails is corrected before the deliverable is presented.
+   point first, descriptive headings, one idea per paragraph, sentence length, common words with no blocklisted word
+   and an explanation for every term the reader cannot look up, and every fact preserved. Anything it fails is
+   corrected before the deliverable is presented.
 
 The self-check and any rewrite operate on **prose regions only**. Code fences, diagram bodies, rendered markup, and
 inline citation identifiers are neither evaluated nor altered, so they still compile, render, and resolve.

--- a/han-coding/docs/skills/code-overview.md
+++ b/han-coding/docs/skills/code-overview.md
@@ -96,7 +96,8 @@ naming what is being examined (not a metadata block), then leads with the why an
 
 - **Code mode:** _Why it exists_ (the problem solved or goal served, then briefly what it is) → _Context used_ (the
   sources the overview drew on) → _Main flow_ (a Mermaid chart with a scope label, read as how the code delivers on the
-  why) → _Context and uses_ → _Where to start_.
+  why) → _Context and uses_ → _Where to start_ (the entry points numbered in the order to open them, each with what you
+  learn there, and a runnable example call on any entry point that is an interface other code calls).
 - **PR mode:** _Why this change exists_ (the need that motivated it, then the bottom line of what it does) → _Context
   used_ → _Changes by intent_ (grouped by the outcome, the why, each group delivers) → _How the change flows_ (a Mermaid
   chart with a scope label) → _What to watch when reviewing_ (navigational only).

--- a/han-coding/docs/skills/code-overview.md
+++ b/han-coding/docs/skills/code-overview.md
@@ -15,7 +15,8 @@ to use the skill. For what the skill does internally, read the skill definition 
   working on or reviewing it.
 - **When to use it.** You have landed in code you do not know, or a PR you are about to review, and you want a fast
   orientation before you start.
-- **What you get back.** A scratch overview file (written outside the repository) with a purpose statement, a linked
+- **What you get back.** An overview file (written where you configured Han's output to go, or outside the repository
+  when you configured nothing) with a purpose statement, a linked
   list of the context the overview drew on, Mermaid flow charts, the directly-related context, and where to start, all
   at minimal technical depth.
 
@@ -32,8 +33,10 @@ to use the skill. For what the skill does internally, read the skill definition 
 - **Two modes.** _Code mode_ explains a file, directory, or symbol as it is now: why it exists, then what it does. _PR
   mode_ explains a set of changes: why they exist, grouped by the intent each group serves, and how to look at the PR
   before reviewing it. The skill picks the mode from the target.
-- **Understand now, not document for later.** The overview is an ephemeral orientation aid written to a scratch file,
-  never committed into the repository's documentation tree. That is the line against `/project-documentation`.
+- **Understand now, not document for later.** The overview is an ephemeral orientation aid, and the skill never commits
+  it into the repository's documentation tree. That is the line against `/project-documentation`. It is why the file
+  lands outside the repository when you have configured nothing; a destination you configure yourself wins over that
+  default, wherever it points.
 - **No findings.** The overview raises no quality findings, severities, or recommended changes. Even the PR-mode "what
   to watch" section is navigational: it names where the change is hardest to follow, not whether it is any good. That is
   the line against `/code-review`.
@@ -87,9 +90,14 @@ Example prompts:
 
 ## What you get back
 
-A single Markdown overview file written to a scratch location **outside the repository** (for example under your system
-temp directory). The skill shows you the path; open it where the Mermaid charts render. The file is not committed and is
-not maintained; it is a point-in-time orientation aid.
+A single Markdown overview file. It lands under the `output-directory` in your `.han/config.md` when you have set one,
+and outside the repository (for example under your system temp directory) when you have not. A configured directory
+inside the repository is honored without comment, because you chose it. When the resolved destination cannot be written,
+the run falls back to the outside-the-repository default and tells you which destination it could not use, rather than
+throwing away work it has already finished.
+
+The skill shows you the path; open it where the Mermaid charts render. The file is not committed and is not maintained;
+it is a point-in-time orientation aid.
 
 The document follows one structure per mode, under a shared grammar. It opens with a title and a short intro paragraph
 naming what is being examined (not a metadata block), then leads with the why and lets every later section flow from it:

--- a/han-coding/docs/skills/code-overview.md
+++ b/han-coding/docs/skills/code-overview.md
@@ -101,6 +101,11 @@ naming what is being examined (not a metadata block), then leads with the why an
   used_ → _Changes by intent_ (grouped by the outcome, the why, each group delivers) → _How the change flows_ (a Mermaid
   chart with a scope label) → _What to watch when reviewing_ (navigational only).
 
+Every chart is drawn to be read at a glance. Each box names a component or a boundary you can point at, and the fields,
+types, and technical annotations sit in the prose beneath the chart instead. A step the flow needs is never dropped to
+make the picture simpler; the step stays and its detail moves down. The skill owns this itself, because the readability
+pass described below is deliberately barred from editing chart bodies.
+
 The _Context used_ section, placed directly after the lead why section, lists every source the overview drew on. Each
 source with an address is a direct link (a repository file by path, a pull request, issue, or commit by URL), so you
 can walk the same evidence the overview was built from. A source with no address (an uncommitted diff, the branch's

--- a/han-coding/docs/skills/code-overview.md
+++ b/han-coding/docs/skills/code-overview.md
@@ -105,11 +105,18 @@ naming what is being examined (not a metadata block), then leads with the why an
 - **Code mode:** _Why it exists_ (the problem solved or goal served, then briefly what it is) → _Context used_ (the
   sources the overview drew on) → _Main flow_ (a Mermaid chart with a scope label, read as how the code delivers on the
   why) → _Context and uses_ → _Where to start_ (the entry points numbered in the order to open them, each with what you
-  learn there, and a runnable example call on any entry point that is an interface other code calls).
+  learn there, and a runnable example call on any entry point that is an interface other code calls) → _What this code
+  does, in plain language_.
 - **PR mode:** _Why this change exists_ (the need that motivated it, then the bottom line of what it does, plus a
   sentence when the code turns out not to support that reason) → _Context
   used_ → _Changes by intent_ (grouped by the outcome, the why, each group delivers) → _How the change flows_ (a Mermaid
-  chart with a scope label) → _What to watch when reviewing_ (navigational only).
+  chart with a scope label) → _What to watch when reviewing_ (navigational only) → _What this change does, in plain
+  language_.
+
+Both modes end with three or four sentences you could read aloud, carrying no file paths and no type names. They are
+there to be lifted out and pasted into a pull request description or a message to a reviewer. The run's closing message
+repeats those exact sentences rather than writing its own version, so you can paste from the terminal without opening
+the file and never wonder which of two summaries is the real one.
 
 Every chart is drawn to be read at a glance. Each box names a component or a boundary you can point at, and the fields,
 types, and technical annotations sit in the prose beneath the chart instead. A step the flow needs is never dropped to

--- a/han-coding/docs/skills/code-overview.md
+++ b/han-coding/docs/skills/code-overview.md
@@ -98,7 +98,8 @@ naming what is being examined (not a metadata block), then leads with the why an
   sources the overview drew on) → _Main flow_ (a Mermaid chart with a scope label, read as how the code delivers on the
   why) → _Context and uses_ → _Where to start_ (the entry points numbered in the order to open them, each with what you
   learn there, and a runnable example call on any entry point that is an interface other code calls).
-- **PR mode:** _Why this change exists_ (the need that motivated it, then the bottom line of what it does) → _Context
+- **PR mode:** _Why this change exists_ (the need that motivated it, then the bottom line of what it does, plus a
+  sentence when the code turns out not to support that reason) → _Context
   used_ → _Changes by intent_ (grouped by the outcome, the why, each group delivers) → _How the change flows_ (a Mermaid
   chart with a scope label) → _What to watch when reviewing_ (navigational only).
 
@@ -130,6 +131,11 @@ Accuracy settles first, so the editor never polishes a claim that is about to ch
 
 The validator checks the description against the code only to keep it truthful. It never judges the code's quality; the
 overview still raises no findings about the work itself.
+
+One thing a change overview will now tell you that it used to keep to itself: when the code shows that the stated reason
+for a change is already satisfied, or does not hold, the overview says so where it states that reason. It says it as a
+fact about the reason, with no finding, no severity, and no recommendation. It only says it when it checked and found
+that, so a reason the code is silent about is still marked as inferred rather than reported as contradicted.
 
 When the target is too large to cover fully at the chosen size, the overview adds a coverage note immediately after the
 header, naming what it did not cover and the next size up, so you know the picture is partial before you study the

--- a/han-coding/docs/skills/code-overview.md
+++ b/han-coding/docs/skills/code-overview.md
@@ -144,6 +144,11 @@ The readability pass runs next. `readability-editor` rewrites the corrected draf
 standard, preserving every fact, so the overview leads with its point and reads for someone who did not do the work.
 Accuracy settles first, so the editor never polishes a claim that is about to change.
 
+The skill then checks its own output before showing it to you: that every chart's boxes name components rather than
+carrying field and type detail, that the starting points are numbered in reading order with an example call where one is
+called for, that terms you could not look up carry their explanations, and that the closing restatement is there and free
+of file paths and type names. Anything that fails is fixed before you see it, not reported to you as a caveat.
+
 The validator checks the description against the code only to keep it truthful. It never judges the code's quality; the
 overview still raises no findings about the work itself.
 

--- a/han-coding/docs/skills/code-review.md
+++ b/han-coding/docs/skills/code-review.md
@@ -165,9 +165,13 @@ other section appears only when it has at least one item, and when several are p
   corrective finding's tier is carried by its task-ID prefix; a security finding shows its tier inline in the row (for
   example, `SEC-001 (Critical)`) so the table stands alone as the complete severity index.
 - **Critical findings** (🔴). Each with task ID (`CRIT-001`, `CRIT-002`, …), `file_path:line_number`, the issue, and the
-  recommended fix. The `[Category]` label is kept on a block only when it names content a standalone reader needs (an
-  ADR violation naming the record, a standards violation naming the standard, or a security finding) and dropped for
-  generic categories the table already carries.
+  recommended fix. Each also opens with a plain-language explanation written for someone who will not open the file:
+  what they could observe going wrong, what has to be true for it to happen, and how likely that is, said outright when
+  the answer is that the finding may never fire. All three are answered, and an answer that is not in doubt takes a
+  clause rather than a sentence. The guidance for the person who will open the file follows it, unchanged. The
+  `[Category]` label is kept on a block only when it names content a standalone reader needs (an ADR violation naming
+  the record, a standards violation naming the standard, or a security finding) and dropped for generic categories the
+  table already carries.
 - **Warnings** (🟡). Same structure with task ID `WARN-NNN`.
 - **Suggestions** (🔵). Same structure with task ID `SUGG-NNN`.
 - **Agent findings.** Coverage gaps (`T#`), edge cases (`EC#`), security findings (`SEC-NNN`), structural findings
@@ -180,7 +184,8 @@ other section appears only when it has at least one item, and when several are p
   verbatim statement _"These findings will not be corrected unless explicitly requested. They are documented so the team
   can decide consciously whether to keep, simplify, or defer the items."_ Each finding is one line naming the failing
   evidence type, the matched anti-pattern, and a single reopen-trigger clause. YAGNI findings are advisory; they are not
-  counted under CRIT / WARN / SUGG, do not appear in the summary table, and do not block a clean review.
+  counted under CRIT / WARN / SUGG, do not appear in the summary table, and do not block a clean review. They carry no
+  plain-language explanation either, because that reopen trigger already answers what the explanation would say.
 - **Security vulnerabilities** (🔐). One full `SEC-NNN` block per proven vulnerability (OWASP category, location,
   evidence, `EXPLOIT:` path, and severity), followed by a single short **Remediation** note that references the
   `SEC-NNN` IDs and states the actionable fix in one or two sentences. Security findings are not cross-referenced into

--- a/han-coding/docs/skills/code-review.md
+++ b/han-coding/docs/skills/code-review.md
@@ -334,6 +334,9 @@ readability pass inserted between Steps 8 and 9):
    8.5. **Rewrite the finding prose for readability.** Dispatch `readability-editor` over the assembled review so its prose
    meets the shared readability standard, with every task ID, severity, `file_path:line_number` reference, and code excerpt
    preserved.
+   8.6. **Write the report file.** Resolve the directory (a configured `output-directory`, else the specialists' report
+   directory) and the file name (the branch, the ticket, or what was reviewed), then write it. A report already at that
+   name is replaced and recorded; an unwritable destination falls back and is recorded.
 9. **Verify.** Step 9.0 runs the self-consistency check (extract
    `{task-id, file-path, line-range, recommended-action-summary}` tuples, then compare overlapping pairs and demote
    contradictory recommendations with a `Tension with {other-task-id}:` note). Step 9.1 then verifies task IDs are
@@ -344,6 +347,21 @@ readability pass inserted between Steps 8 and 9):
    confirms the newer content arrived: every finding you are expected to act on carries its plain-language explanation,
    every corrective one names a fix route, and a finding that may never fire says so both in its own explanation and in
    its summary row. Anything missing is fixed before the review reaches you, not reported to you as a caveat.
+10. **Present.** A short message that leads with the recommendation and the counts by severity, then the path, then the
+    run's own facts. The review is never pasted into the conversation.
+
+## What the run says when it finishes
+
+A short message, in a fixed order, so the answer is the first thing you read:
+
+1. The recommendation, in the report's own words.
+2. The counts by severity, with any advisory count named separately rather than folded into the total.
+3. The path to the report, plus any report it replaced and any destination it could not write to.
+4. The run's own facts last: the size band and why, and the validator reconciliation.
+
+A clean review says the code can be approved and gives you the path. A review whose only findings are advisory still
+recommends approval, says the count needing action is zero, and names the advisory count beside it, so you are never
+told "no findings" about a report whose body lists items.
 
 ## YAGNI
 

--- a/han-coding/docs/skills/code-review.md
+++ b/han-coding/docs/skills/code-review.md
@@ -168,7 +168,9 @@ other section appears only when it has at least one item, and when several are p
   recommended fix. Each also opens with a plain-language explanation written for someone who will not open the file:
   what they could observe going wrong, what has to be true for it to happen, and how likely that is, said outright when
   the answer is that the finding may never fire. All three are answered, and an answer that is not in doubt takes a
-  clause rather than a sentence. The guidance for the person who will open the file follows it, unchanged. The
+  clause rather than a sentence. The guidance for the person who will open the file follows it, unchanged. Each finding
+  then names how it gets fixed: test-first (`/tdd`) when a behavior is missing, restructure (`/refactor`) when the
+  behavior is right and the shape is wrong, or by hand when the edit is small. The route is named, never started. The
   `[Category]` label is kept on a block only when it names content a standalone reader needs (an ADR violation naming
   the record, a standards violation naming the standard, or a security finding) and dropped for generic categories the
   table already carries.

--- a/han-coding/docs/skills/code-review.md
+++ b/han-coding/docs/skills/code-review.md
@@ -154,7 +154,13 @@ Example prompts:
 
 ## What you get back
 
-A structured review in-channel. Each finding's prose appears exactly once (its finding block, or its full security
+A structured review written to a file, named `code-review-{slug}.md` for the branch, ticket, or scope it covers. It
+lands under the `output-directory` in your `.han/config.md` when you have set one, and beside the specialists' own
+reports when you have not. A report already sitting at that name is replaced, and the run tells you which one it
+replaced. When the resolved destination cannot be written, the run falls back and names the destination it could not
+use, rather than throwing away a finished review.
+
+Each finding's prose appears exactly once (its finding block, or its full security
 block; the summary-table row is an index, not a copy), and sections render only when they have content: a review of a
 small change produces a small document. The Review Summary table and the Review Recommendation are always present; every
 other section appears only when it has at least one item, and when several are present they keep a fixed order

--- a/han-coding/docs/skills/code-review.md
+++ b/han-coding/docs/skills/code-review.md
@@ -163,7 +163,10 @@ other section appears only when it has at least one item, and when several are p
 - **A Review Summary table** indexing every corrective finding and every security finding across categories (automated
   checks, correctness, testing, security, ADR/standard/docs compliance, documentation freshness), ordered by severity. A
   corrective finding's tier is carried by its task-ID prefix; a security finding shows its tier inline in the row (for
-  example, `SEC-001 (Critical)`) so the table stands alone as the complete severity index.
+  example, `SEC-001 (Critical)`) so the table stands alone as the complete severity index. Each row also carries the
+  finding's fix route, and a finding the review established may never fire says so in its row. Both cues are there so
+  you can triage a long list before opening any single finding. Row order, severities, and finding identifiers are
+  unchanged; the cues sit inside existing rows.
 - **Critical findings** (🔴). Each with task ID (`CRIT-001`, `CRIT-002`, …), `file_path:line_number`, the issue, and the
   recommended fix. Each also opens with a plain-language explanation written for someone who will not open the file:
   what they could observe going wrong, what has to be true for it to happen, and how likely that is, said outright when

--- a/han-coding/docs/skills/code-review.md
+++ b/han-coding/docs/skills/code-review.md
@@ -334,7 +334,10 @@ readability pass inserted between Steps 8 and 9):
    sequential, `file_path:line_number` references are valid, exploit fields are populated for security findings, the
    summary table indexes every corrective and security finding (with security tiers shown inline) and matches the
    sections present, no section is rendered empty, security findings carry no Critical cross-reference while the
-   recommendation still reflects their severity, and the YAGNI section's verbatim opening is preserved.
+   recommendation still reflects their severity, and the YAGNI section's verbatim opening is preserved. The same step
+   confirms the newer content arrived: every finding you are expected to act on carries its plain-language explanation,
+   every corrective one names a fix route, and a finding that may never fire says so both in its own explanation and in
+   its summary row. Anything missing is fixed before the review reaches you, not reported to you as a caveat.
 
 ## YAGNI
 

--- a/han-coding/skills/code-overview/SKILL.md
+++ b/han-coding/skills/code-overview/SKILL.md
@@ -382,6 +382,21 @@ optional: the standard governs how the content is said, never whether a required
 
 For this skill, the main point the opening line must state is what is being examined and why it exists.
 
+**Required-content check.** Run this after the readability self-check, and after the accuracy pass, BECAUSE a check that
+runs before the accuracy pass can confirm content that is about to be corrected or cut. Each item is a yes/no question
+about the finished document. Fix every failure before presenting; never present a failure as a caveat.
+
+1. **Diagrams.** Every chart's boxes name components and boundaries, with fields, types, signatures, and annotations in
+   the prose beneath rather than inside a box. This is the one check that reads **inside** the chart bodies, which the
+   readability self-check leaves alone by design.
+2. **Starting points.** The entry points are numbered in reading order, each carries one line on what the reader learns
+   there, and every entry point that is an interface other code calls carries one runnable example call.
+3. **Terms the reader cannot look up.** Criterion 5 of the readability self-check above carries this one: every outside
+   technology, language runtime, named method, and coined compound noun has its half-sentence explanation at first use.
+   Confirm it passed rather than re-running it.
+4. **The closing restatement.** The final section is present, runs three or four sentences, and carries no file paths,
+   no type names, and no symbol names.
+
 ## Step 8: Present
 
 Present a short message in this fixed order. The answer leads and the run's own bookkeeping comes last, BECAUSE this

--- a/han-coding/skills/code-overview/SKILL.md
+++ b/han-coding/skills/code-overview/SKILL.md
@@ -238,7 +238,8 @@ it exists** (the problem the code solves or goal it serves, then briefly what it
 all flowing from the why); **Context used** (the context ledger, rendered per the rules below); **Main flow** (a Mermaid
 chart with a one-line scope label, read as how the code delivers on the why); **Context and uses** (context and uses
 kept distinguishable, framed as what it depends on to meet the need and where that need is served from); **Where to
-start** (the concrete entry points the reader opens first).
+start** (the entry points numbered in the order a reader opens them, each with one line on what the reader learns there,
+and one runnable example call on any entry point that is an interface other code calls).
 
 **PR mode** renders, in order: the same title and intro paragraph; the same conditional coverage note; **Why this change
 exists** (the problem the change solves or goal it advances, then briefly the bottom line of what it does); **Context

--- a/han-coding/skills/code-overview/SKILL.md
+++ b/han-coding/skills/code-overview/SKILL.md
@@ -74,7 +74,9 @@ Read these before doing anything. They constrain every step below.
 - **No quality judgment, ever.** The overview raises no findings, severities, or recommended changes — including in the
   PR-mode "what to watch" section, which is navigational only. BECAUSE reviewing a PR's quality is `code-review`'s job;
   this skill only helps the reader understand the PR before they review it. Crossing this line collapses the boundary
-  between the two skills.
+  between the two skills. Saying the code does not support a change's stated reason is not a crossing: the claim under
+  test there is the document's own leading claim about the reason, which this skill already owns and already validates,
+  not a judgment about the code's quality.
 - **No PR statistics, ever.** The overview never states lines changed, files changed, additions/deletions, commit
   counts, or any other diff-stat figure — not in the intro, not in a section, not anywhere. BECAUSE these numbers go
   stale the instant the PR is updated and add no understanding; describe what changed and why, never how big the diff
@@ -233,6 +235,21 @@ is not recoverable from the code and its intent (commit messages, PR/issue text,
 the code demonstrably does toward a goal and mark the inferred why as inferred — never invent a business rationale the
 evidence does not support.
 
+**Say when the code does not support the stated reason (PR mode).** You already read the code to ground the why. When
+that reading shows the code already satisfies the stated motivation, or shows the change is not needed for the reason
+given, say so in the why section itself, in one or two sentences, as a fact about the stated reason. Raise no finding,
+assign no severity, recommend no change; the rest of the overview proceeds as normal. Three states, and only the first
+gets the sentence:
+
+1. You checked and the code contradicts the stated reason. Say so.
+2. You checked and the code supports it. Say nothing extra.
+3. The code says nothing either way. That is the inferred-why case above: mark the reason as inferred and claim no
+   discrepancy.
+
+NEVER report a contradiction you did not check and find, BECAUSE that is a stronger claim than the evidence carries and
+the honest weaker claim already has a home in state 3. This is the highest-value sentence a change overview can carry,
+and it is also the easiest one to get wrong by reaching.
+
 **Code mode** renders, in order: the title and intro paragraph; a coverage note **only if** coverage was partial; **Why
 it exists** (the problem the code solves or goal it serves, then briefly what it is and why it works the way it does —
 all flowing from the why); **Context used** (the context ledger, rendered per the rules below); **Main flow** (a Mermaid
@@ -242,8 +259,9 @@ start** (the entry points numbered in the order a reader opens them, each with o
 and one runnable example call on any entry point that is an interface other code calls).
 
 **PR mode** renders, in order: the same title and intro paragraph; the same conditional coverage note; **Why this change
-exists** (the problem the change solves or goal it advances, then briefly the bottom line of what it does); **Context
-used** (the context ledger, rendered per the rules below); **Changes by intent** (grouped by the reader-visible outcome
+exists** (the problem the change solves or goal it advances, then briefly the bottom line of what it does, plus the
+unsupported-reason sentence when it applies — see below); **Context used** (the context ledger, rendered per the rules
+below); **Changes by intent** (grouped by the reader-visible outcome
 each group delivers — the why each group serves — not by file, layer, or author motivation; a single logical change is
 one narrative with no grouping header); **How the change flows** (a Mermaid chart with a scope label, placed after the
 grouped changes BECAUSE the reviewer must know what changed before that chart is meaningful); **What to watch when
@@ -288,7 +306,9 @@ and the resolved target (and, in PR mode, the changed-file set) so it knows what
   starting with the one the document leads on: is the stated **why** — the problem the code solves or the goal it serves
   — grounded in real evidence (commit messages, PR/issue intent, code comments, what the code visibly does toward that
   goal), or is it an invented business rationale, and where the why is inferred rather than stated, is it marked as
-  inferred; does the code actually do what _Why it exists_ / _Why this change exists_ says; does the **Main flow** /
+  inferred; does the code actually do what _Why it exists_ / _Why this change exists_ says; where the overview claims
+  the code already satisfies the stated reason or does not support it, does the code show that, or is the code merely
+  silent on the point — silence is not a contradiction, and a discrepancy claimed on silence is an inaccuracy to cut; does the **Main flow** /
   **How the change flows** chart match the real control flow, in the right order, with no invented or missing steps; do
   the named **Where to start** entry points exist and are they the right ones; does each **Changes by intent** grouping
   describe what that change actually does and the why it claims to serve; does every entry in **Context used** point at

--- a/han-coding/skills/code-overview/SKILL.md
+++ b/han-coding/skills/code-overview/SKILL.md
@@ -218,7 +218,10 @@ the explorers cover the highest-signal areas; carry that into the coverage note 
 ## Step 5: Synthesize the Overview
 
 Invoke `han-communication:readability-guidance` to surface the shared readability standard into your context before you
-write, then draft the overview against it. Read [references/overview-template.md](./references/overview-template.md) and
+write. Then invoke `han-communication:explanation-guidance`, which surfaces Han's standard for explaining technical work
+to a reader who will not implement it: that standard governs the closing restatement this step writes and the closing
+message Step 8 prints, BECAUSE both go to someone who will not open the code. Both run inline and hand control straight
+back; continue with this step as soon as they return. Then draft the overview against both. Read [references/overview-template.md](./references/overview-template.md) and
 render the structure for the resolved mode, drawing on the explorers' findings and the input from Step 3. The skill
 writes the overview; the explorers' raw findings are not pasted in.
 
@@ -258,7 +261,8 @@ all flowing from the why); **Context used** (the context ledger, rendered per th
 chart with a one-line scope label, read as how the code delivers on the why); **Context and uses** (context and uses
 kept distinguishable, framed as what it depends on to meet the need and where that need is served from); **Where to
 start** (the entry points numbered in the order a reader opens them, each with one line on what the reader learns there,
-and one runnable example call on any entry point that is an interface other code calls).
+and one runnable example call on any entry point that is an interface other code calls); **What this code does, in plain
+language** (the closing restatement).
 
 **PR mode** renders, in order: the same title and intro paragraph; the same conditional coverage note; **Why this change
 exists** (the problem the change solves or goal it advances, then briefly the bottom line of what it does, plus the
@@ -267,7 +271,8 @@ below); **Changes by intent** (grouped by the reader-visible outcome
 each group delivers — the why each group serves — not by file, layer, or author motivation; a single logical change is
 one narrative with no grouping header); **How the change flows** (a Mermaid chart with a scope label, placed after the
 grouped changes BECAUSE the reviewer must know what changed before that chart is meaningful); **What to watch when
-reviewing** (navigational only — where the change is hardest to follow and why; never a quality or risk judgment).
+reviewing** (navigational only — where the change is hardest to follow and why; never a quality or risk judgment);
+**What this change does, in plain language** (the closing restatement).
 
 **Render the `Context used` section from the context ledger** built in Steps 3 and 4, directly after the lead why
 section in both modes. One line per source, each with a short note on what it contributed. Link every source that has a
@@ -282,6 +287,13 @@ deduplicate the list and keep it a reference list, not prose.
 under the Changes-by-intent item or the flow step they depict, BECAUSE a visual next to its description spares the
 reader a trip back to the PR. Keep the image URL exactly as captured. Omit screenshots entirely when the PR had none;
 never invent or placeholder an image.
+
+**Close with a restatement a person can paste.** Both modes end with three or four plain sentences a reader who did not
+do this work could read aloud, carrying no file paths, no type names, and no symbol names. Write them under the
+explanation standard sourced above. These sentences are the canonical text: Step 8's message repeats them rather than
+composing its own version, BECAUSE the reader's next move after an overview is reliably to paste a plain summary into a
+pull request description or a message to a reviewer, and two texts saying the same thing in different words teach them
+to distrust the shorter one.
 
 Apply the per-section detail rule from the template: minimal technical detail in the why, flow, and context sections —
 the why told as a problem solved or goal met, not technical mechanics; concrete named entry points in the handoff
@@ -372,6 +384,14 @@ For this skill, the main point the opening line must state is what is being exam
 
 ## Step 8: Present
 
-Present to the user in a short message: the scratch-file path, the mode and size used (and why), and any coverage gap
-the overview noted. Do not paste the whole overview into the conversation; point the user at the file, where the Mermaid
-charts render.
+Present a short message in this fixed order. The answer leads and the run's own bookkeeping comes last, BECAUSE this
+message is the first thing the user reads and facts about how the run went are the last thing they need from it:
+
+1. **The closing restatement**, copied from the overview's own final section. Repeat those sentences; never compose a
+   second version of them.
+2. **Any divergence from the change's stated purpose**, when the overview reported one (PR mode only).
+3. **The path** to the overview file. When Step 6 fell back because the resolved destination could not be written, name
+   the destination it could not use.
+4. **The run's own facts, last:** the mode and size used and why, plus any coverage gap the overview noted.
+
+Do not paste the whole overview into the conversation; point the user at the file, where the Mermaid charts render.

--- a/han-coding/skills/code-overview/SKILL.md
+++ b/han-coding/skills/code-overview/SKILL.md
@@ -57,6 +57,11 @@ Read these before doing anything. They constrain every step below.
   required fact about the code appears. Its dedicated `han-communication:readability-editor` pass (Step 7) replaces the
   older information-architect / junior-developer readability review; the accuracy validator is a separate pass and
   stays.
+- **Diagram legibility is this skill's job, not the editor's.** The readability rewrite pass is barred from touching
+  diagram bodies, so nothing but this skill checks whether a chart can be read. Apply the template's diagram rule as
+  you draw each chart: boxes name components and boundaries, and fields, types, and technical annotations go into the
+  prose beneath. BECAUSE the exemption is right for accuracy — an editor free to reword a box could silently change
+  what the chart claims about the code — and the reading load it leaves behind has to land on someone.
 - **Read-only, always.** The skill explains; it never edits the target. It writes only its own scratch overview file.
   BECAUSE the job is understanding, not modification — this keeps the skill safe to point at unfamiliar code.
 - **Accurate to the code, always.** Every claim the overview makes — the why it states (grounded in commit and PR/issue
@@ -259,7 +264,8 @@ never invent or placeholder an image.
 
 Apply the per-section detail rule from the template: minimal technical detail in the why, flow, and context sections —
 the why told as a problem solved or goal met, not technical mechanics; concrete named entry points in the handoff
-section. Give every chart a scope label. When coverage is partial, place the coverage note immediately after the intro
+section. Give every chart a scope label, and apply the template's diagram rule to every chart you draw: each box names
+a component or a boundary, and the fields, types, and annotations go into the prose beneath the chart. When coverage is partial, place the coverage note immediately after the intro
 paragraph so the reader calibrates before investing in the charts.
 
 ## Step 6: Write the Scratch File

--- a/han-coding/skills/code-overview/SKILL.md
+++ b/han-coding/skills/code-overview/SKILL.md
@@ -86,9 +86,11 @@ Read these before doing anything. They constrain every step below.
   issue / commit URL), stated in one plain sentence when it does not (an uncommitted diff, the branch's commit messages,
   context supplied in conversation). BECAUSE the reader should be able to walk the same evidence the overview was built
   from, and a fabricated or broken link poisons that trust — never invent a URL or link a path that does not exist.
-- **Ephemeral, not documentation.** The overview is written to a scratch file outside the repository and is never
-  committed into the repository's documentation tree. BECAUSE durable feature and system docs are
-  `project-documentation`'s job; this skill is an understand-now orientation aid.
+- **Ephemeral, not documentation.** The overview is an understand-now orientation aid, not durable documentation,
+  BECAUSE durable feature and system docs are `project-documentation`'s job. That is why the skill's own default
+  destination sits outside the repository, and why the skill never commits the file. This principle governs the
+  skill's default only, not what a person configures: a configured output directory wins wherever it points, and the
+  run says nothing about it (Step 6).
 - **Default to small.** Start size classification at small and escalate only when a higher-band signal is clearly
   present. BECAUSE under-dispatching is recoverable by re-running larger; over-dispatching burns tokens and dilutes the
   overview.
@@ -269,8 +271,8 @@ reviewing** (navigational only — where the change is hardest to follow and why
 
 **Render the `Context used` section from the context ledger** built in Steps 3 and 4, directly after the lead why
 section in both modes. One line per source, each with a short note on what it contributed. Link every source that has a
-direct address: a repository file or directory as a Markdown link whose target is its absolute path (the scratch file
-lives outside the repository, so a relative path would not resolve); a pull request, issue, or commit as its URL (in PR
+direct address: a repository file or directory as a Markdown link whose target is its absolute path (the overview file may
+sit outside the repository, so a relative path would not resolve); a pull request, issue, or commit as its URL (in PR
 mode with a remote, prefer the remote's file URLs at the PR's head so the links work for a reader outside this machine).
 A source with no address — the uncommitted diff, the branch's commit messages, context the user supplied in conversation
 — gets one plain sentence stating what the context was. Never fabricate a URL or link a path that does not exist;
@@ -287,19 +289,35 @@ section. Give every chart a scope label, and apply the template's diagram rule t
 a component or a boundary, and the fields, types, and annotations go into the prose beneath the chart. When coverage is partial, place the coverage note immediately after the intro
 paragraph so the reader calibrates before investing in the charts.
 
-## Step 6: Write the Scratch File
+## Step 6: Resolve the Destination and Write the File
 
-Write the rendered overview to a scratch file **outside the repository** — for example
-`${TMPDIR:-/tmp}/code-overview-{short-target-slug}.md`. Never write it into the repository's documentation tree; this
-overview is ephemeral. The next step reviews and rewrites this file in place.
+The file is named `code-overview-{short-target-slug}.md` wherever it lands. Only the directory is resolved here.
+
+**Resolve the directory in this order:**
+
+1. **A configured `output-directory`.** When the config read at the top of this skill supplied one, write the overview
+   beneath it. Honor it even when it points inside the repository, and say nothing about that, BECAUSE the person who
+   configured a destination chose it, and this skill's own default is not a veto over their choice. Relative-path
+   resolution, `~` expansion, and precedence between the personal and project files are governed by
+   [config-rule.md](../../references/config-rule.md); do not re-derive them here.
+2. **No configured value.** Write outside the repository — for example
+   `${TMPDIR:-/tmp}/code-overview-{short-target-slug}.md` — BECAUSE an unconfigured overview is an orientation aid
+   rather than documentation, and a default inside the repository would land it in a commit sooner or later.
+
+**When the resolved directory cannot be written**, write to the unconfigured default in 2 instead and record which
+destination you could not use, so Step 8's message can name it. NEVER abandon the run over this, BECAUSE everything the
+run produced is finished by the time it writes, and losing all of it to a directory that does not exist is the worse
+outcome by far.
+
+The next step reviews and rewrites this file in place.
 
 ## Step 7: Validate Accuracy, then Rewrite for Readability
 
 This step runs two distinct passes, in order: the accuracy validator first, then the readability rewrite. Accuracy is
 settled before readability so the editor never polishes a claim that is about to be cut.
 
-**Pass 1 — accuracy.** Dispatch `han-core:adversarial-validator` over the draft overview. Pass it the scratch-file path
-and the resolved target (and, in PR mode, the changed-file set) so it knows what to re-read.
+**Pass 1 — accuracy.** Dispatch `han-core:adversarial-validator` over the draft overview. Pass it the overview file's
+path from Step 6 and the resolved target (and, in PR mode, the changed-file set) so it knows what to re-read.
 
 - **`han-core:adversarial-validator`** — assume every claim the overview makes about the code is WRONG until the code
   and its intent prove it right. Re-read the target (and the diff, in PR mode) and challenge each material claim,
@@ -319,7 +337,7 @@ and the resolved target (and, in PR mode, the changed-file set) so it knows what
   the code's quality and do not raise findings about the code itself.** Return a list of inaccurate or unsupported
   claims, each with the corrected fact or a note that the claim should be cut.
 
-Apply the validator's corrections to the scratch file first: fix or cut every claim it disproved. A sentence that reads
+Apply the validator's corrections to the overview file first: fix or cut every claim it disproved. A sentence that reads
 beautifully but describes a flow the code does not follow must still be corrected or removed. If validation removed so
 much that coverage is now meaningfully partial, add or update the coverage note.
 
@@ -329,10 +347,10 @@ readability rewrite, not two overlapping reviews.
 
 - **`han-communication:readability-editor`** — rewrite the overview against the shared readability standard for the
   default reader (a capable reader who did not do this work and lacks the author's context), preserving every fact. Pass
-  it the scratch-file path; the editor reads han-communication's own canonical rule, so pass no rule path. It operates
+  it the overview file's path; the editor reads han-communication's own canonical rule, so pass no rule path. It operates
   on **prose regions only**: it does not touch the Mermaid chart bodies, code fences, or the embedded screenshot markup,
   and it leaves every named file, symbol, entry point, and `Context used` link target exact. It applies the rewrite to
-  the scratch file in place and returns a rubric verdict and a fact-preservation ledger. Tell it: **rewrite the
+  the overview file in place and returns a rubric verdict and a fact-preservation ledger. Tell it: **rewrite the
   overview document for readability only — do not review the underlying code, and do not raise findings about it.**
   This skill makes no quality judgment about the code; the validator guards truth, the editor guards clarity, and
   neither crosses into evaluating the work itself.

--- a/han-coding/skills/code-overview/references/overview-template.md
+++ b/han-coding/skills/code-overview/references/overview-template.md
@@ -1,6 +1,6 @@
 # Overview Document Template
 
-The skill renders one of the two structures below into the scratch file. Both modes share the same grammar — a header,
+The skill renders one of the two structures below into the overview file. Both modes share the same grammar — a header,
 an optional coverage note, a content-bearing lead section, a grouped/flow body, and an actionable handoff — so a reader
 who learns one mode can scan the other. Fill the placeholders, remove the guidance comments, and keep the section order
 exactly as written.

--- a/han-coding/skills/code-overview/references/overview-template.md
+++ b/han-coding/skills/code-overview/references/overview-template.md
@@ -164,6 +164,25 @@ need, not technical mechanics. Then, briefly, the bottom line of what it does. I
 the why can only be inferred from intent (commit messages, PR/issue text), say so
 rather than inventing one.}
 
+<!-- When you checked the stated reason against the code and found the code
+already satisfies it, or found the code does not support it, say so here, in one
+or two sentences, as a fact about the stated reason. Three states, and only the
+first one gets this sentence:
+
+1. Checked, and the code contradicts the stated reason → say so here.
+2. Checked, and the code supports the stated reason → say nothing extra.
+3. The code says nothing either way → this is the inferred-why case above. Mark
+   the reason as inferred and claim no discrepancy.
+
+This is a fact about the reason, never a finding about the code: raise no
+finding, assign no severity, recommend no change. NEVER report a contradiction
+you did not check and find, BECAUSE saying the code contradicts a reason is a
+stronger claim than saying the code is silent, and the weaker, honest claim
+already has a home in state 3. -->
+
+{One or two sentences on the stated reason the code does not support — only when
+state 1 above holds. Delete this block otherwise.}
+
 ## Context used
 
 <!-- One line per source the overview drew on. Link directly when the source has

--- a/han-coding/skills/code-overview/references/overview-template.md
+++ b/han-coding/skills/code-overview/references/overview-template.md
@@ -136,6 +136,15 @@ in the language or query syntax a caller would use. -->
 {one runnable example call against that interface}
 ```
 
+## What this code does, in plain language
+
+<!-- Three or four sentences a person who did not do this work could read aloud. No file paths, no type names, no
+symbol names. Written to be lifted out of this document whole and pasted somewhere else — a pull request description,
+a message to a reviewer — BECAUSE that is reliably the reader's next move. These sentences are the canonical text: the
+run's closing message repeats them rather than writing a second version, so the two never drift apart. -->
+
+{Three or four plain sentences restating why this code exists and what it does.}
+
 ````
 
 ---
@@ -226,5 +235,14 @@ quality or risk judgment; that is code-review's job, not this skill's. -->
 
 {The concrete entry points — the specific files or components — where the change is densest or most interconnected, with
 one line each on why a reviewer should slow down there.}
+
+## What this change does, in plain language
+
+<!-- Three or four sentences a person who did not do this work could read aloud. No file paths, no type names, no
+symbol names. Written to be lifted out of this document whole and pasted somewhere else — a pull request description,
+a message to a reviewer — BECAUSE that is reliably the reader's next move. These sentences are the canonical text: the
+run's closing message repeats them rather than writing a second version, so the two never drift apart. -->
+
+{Three or four plain sentences restating why this change exists and what it does.}
 
 ````

--- a/han-coding/skills/code-overview/references/overview-template.md
+++ b/han-coding/skills/code-overview/references/overview-template.md
@@ -119,8 +119,22 @@ above.}
 
 ## Where to start
 
-{The concrete entry points — the specific files or components — the reader would open first to begin working, with one
-line each on what each is for.}
+<!-- Number the entry points in the order a reader should open them, first to last. Each carries one line on what the
+reader learns there — what they will understand after reading it, not what the file is. A set of the right files is not
+a path through them, and the reader asked for the path. Judge each entry point on its own: one that is an interface
+other code calls carries a single runnable example call, and one that is a step in a flow does not, BECAUSE an invented
+example call for a mid-flow file is noise. A target holding both an interface and the flow behind it gets the example
+on the interface entry only. -->
+
+1. **{file or component}** — {what the reader learns here}.
+2. **{file or component}** — {what the reader learns here}.
+
+<!-- Include this block only under an entry point that is an interface other code calls. One call, runnable as written,
+in the language or query syntax a caller would use. -->
+
+```{language}
+{one runnable example call against that interface}
+```
 
 ````
 

--- a/han-coding/skills/code-overview/references/overview-template.md
+++ b/han-coding/skills/code-overview/references/overview-template.md
@@ -40,6 +40,25 @@ exactly as written.
   concrete entry points (the specific files or components) the reader would open first, or it is not actionable.
 - **Chart scope labels.** Every flow chart carries a one-line label stating what it covers, and — when coverage is
   partial — what it leaves out. A chart must make sense to a reader who reads only the chart and its label.
+- **Diagram boxes name components and boundaries.** Each box names something the reader can point at: a component, a
+  system, a service, a boundary between two of them. Mobile, web, the GraphQL layer, the shared engine. Fields, types,
+  signatures, parameter lists, and technical annotations stay out of the boxes and go into the prose beneath the chart,
+  BECAUSE a chart is read at a glance and a box crowded with detail cannot be. Where a step the flow genuinely needs
+  cannot be named at that level, keep the step and move the detail about it to the prose. Legibility never removes a
+  step from the flow.
+
+  ```mermaid
+  %% not this — the boxes carry the detail
+  flowchart TD
+    A["RecalcJob.perform(account_id:, as_of: Date)"] --> B["PositionSnapshot#rebuild! (idempotent, upserts by account_id+date)"]
+  ```
+
+  ```mermaid
+  %% do this — the boxes name components, and the prose beneath carries the detail
+  flowchart TD
+    A[Recalculation job] --> B[Position snapshot store]
+  ```
+
 - **No quality judgment.** The document never raises findings, severities, or recommended changes. It explains; it does
   not review.
 - **Flow charts render as Mermaid** fenced code blocks (` ```mermaid `).

--- a/han-coding/skills/code-review/SKILL.md
+++ b/han-coding/skills/code-review/SKILL.md
@@ -354,35 +354,9 @@ Extract the items from the Findings sections of each file that was read.
 
 ### Step 7.2: Apply the reachability phrase-match demotion gate
 
-For each finding read at Step 7.1, scan the rationale text (the agent's own explanation of why the finding matters) for
-any of these reachability phrases:
-
-- `theoretical`
-- `hypothetical`
-- `defense-in-depth`
-- `effectively impossible`
-- `in case the upstream`
-- `could happen`
-- `should never happen`
-- `edge case that does not occur`
-
-When a finding's rationale contains any of these phrases, the agent itself signaled that the failure mode is not
-reachable in production. Demote the finding by one severity: CRIT becomes WARN, WARN becomes SUGG, SUGG is omitted
-entirely. Apply the demotion exactly once per finding regardless of how many phrases match.
-
-**Keep the reasoning that drove each demotion.** Carry it to Step 8, where it becomes the preconditions and the
-likelihood in that finding's plain-language explanation. Discarding it here is what makes a reader ask whether a finding
-can happen at all, on a question this gate already answered.
-
-This gate is the merged form of the reachability and "directly introduced" filters; the size-aware rubric in Step 7.3 is
-the single later pass and does not re-demote on these phrases. The phrase list is the only signal the gate uses; do not
-infer reachability from other text. The gate is a cheap, deterministic first pass and is brittle to paraphrase by
-design: a finding that hedges its own reachability without using one of the literal phrases (for example, "unlikely in
-practice", "would need an unusual sequence") slips through here. That paraphrased hedging is caught semantically by the
-independent validation in Step 7.4, not by expanding this list.
-
-Security findings (SEC-series) are exempt from this gate because the security agent's evidence standard already requires
-a demonstrated exploit path or CVE reference before any finding is raised.
+Specified in [finding-filters.md](./references/finding-filters.md). It scans each finding's rationale for a fixed list of
+reachability phrases and demotes one severity on a match, exempting security findings. Keep the reasoning behind each
+demotion: Step 8 publishes it as that finding's preconditions and likelihood.
 
 ### Step 7.3: Classify with the size-aware rubric
 
@@ -401,60 +375,10 @@ counted toward the cap):
 
 ### Step 7.4: Validate the finding list (independent adversarial pass)
 
-The specialist agents and the manual passes each filter findings on the findings' own wording. This sub-step is
-different: it dispatches one critic that re-attacks the **consolidated finding list against the code itself**, in fresh
-context, the way `investigate` validates a root cause and fix. It is the only pass that judges a finding by re-reading
-the change rather than by trusting the producing agent's rationale.
-
-**Run condition.** Run this sub-step whenever at least one corrective finding (CRIT / WARN / SUGG, manual or agent, plus
-any SEC-### finding) has survived to this point. **Skip it when there are zero corrective findings** — a clean review
-needs no validation. YAGNI findings are out of scope here: they are advisory and are never validated, demoted, or
-dropped by this pass.
-
-**Dispatch one `han-core:adversarial-validator`** via the `Agent` tool. Give it, in this order:
-
-1. **The change under review as primary material** — the diff from Step 1 (Mode A), or the changed file list with a note
-   that the files were read in full (Mode B / Mode C). The validator must judge against the code, not against the
-   finding text, so it does not anchor on what the producing agents concluded.
-2. **The complete corrective finding list**, with each finding's task ID, current severity, `file_path:line_number`, the
-   finding's claim, and the producing agent's rationale **verbatim**.
-3. **The `{size}` from Step 3.1 and the calibration directive from Step 3.3**, so it judges severity on the same scale
-   the rest of the review used.
-
-Pass this brief verbatim:
-
-> Treat every finding as wrong until the code proves it right. For each finding, return exactly one verdict —
-> **Confirmed**, **Partially Refuted**, or **Refuted** — and for anything other than Confirmed, cite concrete
-> counter-evidence at `file_path:line_number`. Challenge specifically: (a) findings that misread the change's intent or
-> the surrounding code; (b) findings that target pre-existing code this change did not introduce or worsen, unless the
-> issue is critical irrespective of who introduced it; (c) findings whose rationale hedges its own reachability in
-> paraphrase ("unlikely in practice", "would need an unusual sequence", "only under a race we don't see") that the
-> literal-phrase gate did not catch; (d) severity that overstates impact, where the true worst case is "an operator sees
-> an error and retries". Do not invent new findings — you are validating the list, not extending it.
-
-**Reconcile the verdicts (orchestrator).** Apply each verdict to the finding:
-
-- **Confirmed** → keep the finding at its current severity.
-- **Partially Refuted** (real but mis-severitied or partly wrong) → demote one severity (CRIT → WARN → SUGG; a SUGG
-  stays SUGG). Append the validator's one-line counter-point to the finding body.
-- **Refuted** → drop the finding, **but only when the validator supplied concrete counter-evidence** (a
-  `file_path:line_number` showing the code does not do what the finding claims, or that the finding targets unchanged
-  pre-existing code). A refutation that asserts without counter-evidence does **not** drop the finding; demote it one
-  severity instead.
-- **Security findings (SEC-###)** → the validator may challenge the exploit path, but a SEC finding is dropped only when
-  the validator refutes the demonstrated exploit with concrete counter-evidence. Otherwise it stands at its original
-  severity; the security evidence bar is already higher.
-
-**Overcorrection guard.** This pass exists to remove findings the code disproves, not to quiet the review. Never drop a
-finding on assertion alone — counter-evidence at `file_path:line_number` is required for every drop. When the validator
-is uncertain, the finding stays. Suppressing a real finding is more costly here than carrying one the human will reject.
-
-**Record the reconciliation.** Keep a single orchestrator-log line: how many findings were Confirmed, demoted, and
-dropped, plus the dropped task IDs and the counter-evidence reference for each. This makes the pass auditable; it does
-not add a section to the review output.
-
-This pass is a finding **filter, not a finding source** — the validator never contributes findings of its own, so Step
-9's verification (which forbids findings from agents not dispatched in Step 3) is unaffected.
+Specified in [finding-filters.md](./references/finding-filters.md). It dispatches one `han-core:adversarial-validator`
+over the consolidated corrective finding list and the change itself, then reconciles the verdicts. It runs whenever at
+least one corrective finding survives and is skipped entirely when none does. It is a finding filter, never a finding
+source, so Step 9's rule against findings from undispatched agents is unaffected.
 
 ## Step 8: Generate Review Output
 

--- a/han-coding/skills/code-review/SKILL.md
+++ b/han-coding/skills/code-review/SKILL.md
@@ -8,7 +8,7 @@ description:
   code-overview for that. Does not capture feedback on Han''s own skills — use han-feedback for that.'
 arguments: size
 argument-hint: "[size: small | medium | large | dynamic] [optional context about changes or areas to focus on]"
-allowed-tools: Bash(git *), Bash(gh *), Bash(make *), Bash(npm *), Read, Grep, Glob, Agent
+allowed-tools: Bash(git *), Bash(gh *), Bash(make *), Bash(npm *), Read, Write, Grep, Glob, Agent
 ---
 
 When running a code review, follow the process outlined here.
@@ -425,6 +425,35 @@ intact. The descriptive-heading criterion does not apply to the report's prescri
 
 Apply the editor's rewrite to the review draft. If it reports it could not preserve a fact while satisfying a criterion,
 keep the fact.
+
+## Step 8.6: Write the Report File
+
+The review is a file, not a conversation message. Resolve where it goes, name it for what it covers, and write it.
+
+**Resolve the directory in this order:**
+
+1. **A configured `output-directory`.** When the config read at the top of this skill supplied one, write the report
+   beneath it. Relative-path resolution, `~` expansion, and precedence between the personal and project files are
+   governed by [config-rule.md](../../references/config-rule.md); do not re-derive them here.
+2. **No configured value.** Write it to the `{output_directory}` Step 3 already resolved for the specialists' reports,
+   BECAUSE splitting the report from the analysis it was built on makes a run's output harder to find, not easier.
+
+**Name the file `code-review-{slug}.md`**, where `{slug}` identifies what this run covered:
+
+- **The ticket**, when Step 1.5's branch context surfaced a ticket identifier the branch name does not already carry.
+- **The branch**, otherwise, in Mode A and Mode B.
+- **What was reviewed**, when the branch does not distinguish this run — a review against the default branch, or a Mode
+  C run with no branch at all. Use the single file, directory, or symbol when there is one, and the common parent of the
+  reviewed files when there is not. NEVER use a branch name that does not distinguish the run, BECAUSE a name that does
+  not say what a report covers is the collision this naming exists to remove.
+
+**When a report already exists at that name, replace it** and record that you did, plus the name you replaced, for Step
+10's message. Keeping both would leave two reports for one branch with nothing in their names to say which is current.
+Saying so is what protects someone still working the earlier report as a queue.
+
+**When the resolved directory cannot be written**, write to the fallback in 2 instead and record which destination you
+could not use, for the same message. NEVER abandon the run over this: the review is finished by the time it is written,
+and losing all of it to a missing directory is the worse outcome.
 
 ## Step 9: Verify Review Output
 

--- a/han-coding/skills/code-review/SKILL.md
+++ b/han-coding/skills/code-review/SKILL.md
@@ -390,7 +390,9 @@ return. Draft the finding prose and narrative against both.
 **Every CRIT, WARN, SUGG, and SEC finding opens with a plain-language explanation** written for the reader who will not
 open the file: what they could observe going wrong, what has to be true for it to happen, and how likely that is. Apply
 [finding-content.md](./references/finding-content.md) for which findings carry it, what it answers, where the answers
-come from, and why working them out NEVER changes a finding's severity, task ID, or position. Use the template at
+come from, and why working them out NEVER changes a finding's severity, task ID, or position. **Every CRIT, WARN, and
+SUGG finding also names how it gets fixed** — test-first, restructure, or by hand — chosen by the rule in that same
+file. Name the route; never start it. Use the template at
 [template.md](./references/template.md) for the output structure. **Render a section only when it has content** — never
 emit a heading followed by empty-state placeholder text. The Review Summary table and the Review Recommendation are
 always present; every other section (Critical, Warnings, Suggestions, YAGNI, Security Vulnerabilities, Remediation,
@@ -415,8 +417,9 @@ own canonical rule, so pass no rule path.
 Constrain the rewrite tightly. The editor rewrites **prose only** — the sentences inside finding bodies, the Remediation
 note, the narrative in the What's Good and Review Recommendation sections. It must leave every structural token
 byte-for-byte: task IDs (`CRIT-001`, `SEC-001`, and the rest), severity labels, `file_path:line_number` references,
-`EXPLOIT:` fields, category labels, the fixed section headings and their order, the Review Summary table structure and
-its cells, any `Tension with …` pointer, and every code snippet or fenced block. It preserves every fact: each finding's
+`EXPLOIT:` fields, category labels, the `**Fix:**` label and the route name that follows it, the fixed section headings
+and their order, the Review Summary table structure and its cells, any `Tension with …` pointer, and every code snippet
+or fenced block. It preserves every fact: each finding's
 recommended action, its severity, its location, its quantities, and its named entities survive with their precision
 intact. The descriptive-heading criterion does not apply to the report's prescribed section headings, which are fixed.
 

--- a/han-coding/skills/code-review/SKILL.md
+++ b/han-coding/skills/code-review/SKILL.md
@@ -370,6 +370,10 @@ When a finding's rationale contains any of these phrases, the agent itself signa
 reachable in production. Demote the finding by one severity: CRIT becomes WARN, WARN becomes SUGG, SUGG is omitted
 entirely. Apply the demotion exactly once per finding regardless of how many phrases match.
 
+**Keep the reasoning that drove each demotion.** Carry it to Step 8, where it becomes the preconditions and the
+likelihood in that finding's plain-language explanation. Discarding it here is what makes a reader ask whether a finding
+can happen at all, on a question this gate already answered.
+
 This gate is the merged form of the reachability and "directly introduced" filters; the size-aware rubric in Step 7.3 is
 the single later pass and does not re-demote on these phrases. The phrase list is the only signal the gate uses; do not
 infer reachability from other text. The gate is a cheap, deterministic first pass and is brittle to paraphrase by
@@ -454,8 +458,15 @@ This pass is a finding **filter, not a finding source** — the validator never 
 
 ## Step 8: Generate Review Output
 
-Before writing the output, invoke `han-communication:readability-guidance` to surface the shared readability standard
-into your context, then draft the finding prose and narrative against it. Use the template at
+Before writing the output, invoke `han-communication:readability-guidance` to surface the shared readability standard,
+then invoke `han-communication:explanation-guidance` to surface Han's standard for explaining technical work to a reader
+who will not implement it. Both run inline and hand control straight back; continue with this step as soon as they
+return. Draft the finding prose and narrative against both.
+
+**Every CRIT, WARN, SUGG, and SEC finding opens with a plain-language explanation** written for the reader who will not
+open the file: what they could observe going wrong, what has to be true for it to happen, and how likely that is. Apply
+[finding-content.md](./references/finding-content.md) for which findings carry it, what it answers, where the answers
+come from, and why working them out NEVER changes a finding's severity, task ID, or position. Use the template at
 [template.md](./references/template.md) for the output structure. **Render a section only when it has content** — never
 emit a heading followed by empty-state placeholder text. The Review Summary table and the Review Recommendation are
 always present; every other section (Critical, Warnings, Suggestions, YAGNI, Security Vulnerabilities, Remediation,

--- a/han-coding/skills/code-review/SKILL.md
+++ b/han-coding/skills/code-review/SKILL.md
@@ -459,4 +459,32 @@ and losing all of it to a missing directory is the worse outcome.
 
 Run the checks in [output-verification.md](./references/output-verification.md) before presenting the review: the
 self-consistency pass that demotes and annotates contradictory recommendations on overlapping code, then the
-structural verification items over the finished document.
+structural verification items over the finished document. Fix every failure in the report file; a failed check is never
+reported alongside the review as a caveat.
+
+## Step 10: Present
+
+Close with a short message in this fixed order. The answer leads and the run's own bookkeeping comes last, BECAUSE this
+message is the first thing the person reads and how the run was conducted is the last thing they need from it. Write it
+in the register `han-communication:explanation-guidance` surfaced at Step 8; it goes to someone who has not opened the
+report yet.
+
+1. **The recommendation**, in the words the report's own Review Recommendation uses.
+2. **The counts by severity** — critical, warning, suggestion. Name any YAGNI count separately, never folded into the
+   total.
+3. **The path** to the report file. Name the report you replaced when Step 8.6 replaced one, and the destination you
+   could not use when it fell back.
+4. **The run's own facts, last:** the size band and why, and the validator reconciliation line. Or nothing at all.
+
+**NEVER paste the review into the conversation.** The report is the deliverable and it is a file. Pasting it is what
+made the one fact a person needed after a review, the path, unfindable inside a message long enough to hold everything
+else.
+
+Two states this message has to get right:
+
+- **Nothing found.** Say the code can be approved and give the path. No explanations were written, because there are no
+  findings to explain.
+- **Only advisory findings.** Still recommend approval, BECAUSE the YAGNI class is non-correcting by construction and
+  never blocks a merge. Say the count needing action is zero and name the advisory count beside it, so nobody is told
+  "no findings" about a report whose body lists items. The advisory pass runs on every change regardless of size, so
+  this is an ordinary state, not an exotic one.

--- a/han-coding/skills/code-review/references/finding-content.md
+++ b/han-coding/skills/code-review/references/finding-content.md
@@ -56,6 +56,26 @@ reading "this may be a no-op if the upstream never returns nil" keeps the severi
 re-deciding severity here would silently reopen the discovery and validation passes this content is written on top of,
 and those passes see evidence this step does not.
 
+## The fix route
+
+Every CRIT, WARN, and SUGG finding also names how it gets fixed. The reader asks anyway, and the finding already carries
+what decides the answer, so naming it costs a clause.
+
+Pick exactly one of three:
+
+| Route           | Pick it when                                                                                      | Rendered as                   |
+| --------------- | ------------------------------------------------------------------------------------------------- | ----------------------------- |
+| **test-first**  | A behavior is missing or wrong. The fix is new or corrected behavior, and a test should drive it. | `test-first (\`/tdd\`)`       |
+| **restructure** | The behavior is right and the shape is wrong. The fix changes design without changing behavior.   | `restructure (\`/refactor\`)` |
+| **by hand**     | The fix is a small local edit. No skill is worth spinning up for it.                              | `by hand`                     |
+
+**The route is named, never started.** The review points at the route and stops. It does not invoke `/tdd`, `/refactor`,
+or anything else on the reader's behalf, BECAUSE the reader decides what to act on and in what order, and a review that
+starts fixing things stops being a review.
+
+**Security findings carry no route** — see below. **YAGNI findings carry no route**, on the same grounds as the
+explanation: they are not corrected unless somebody asks for them.
+
 ## Security findings
 
 A SEC finding carries the explanation on the same terms as every other finding a reader must act on. Its exemption from

--- a/han-coding/skills/code-review/references/finding-content.md
+++ b/han-coding/skills/code-review/references/finding-content.md
@@ -1,0 +1,67 @@
+# Finding Content: the plain-language explanation
+
+Every finding a reader is expected to act on opens with a plain-language explanation written for someone who will not
+open the file. This file says which findings carry it, what it answers, and where the answers come from. The block
+format it renders into is in [template.md](./template.md).
+
+The register comes from Han's standard for explaining technical work to a non-implementer, sourced by invoking
+`han-communication:explanation-guidance` before any finding is drafted. Give a concrete outcome the reader could
+observe, not the mechanism that produces it.
+
+## Which findings carry it
+
+**Carry it:** every CRIT, WARN, and SUGG finding, and every SEC finding. These are the findings the report asks someone
+to act on.
+
+**Do not carry it:** YAGNI findings. Each one already ends with the concrete circumstance that would justify keeping the
+code as written, which is the same content the explanation exists to supply. Requiring both would print the same thing
+twice and lengthen a section whose brevity is the point.
+
+Both skills say this in the report's own vocabulary. "Corrective" and "advisory" are not words a reader of a report
+sees.
+
+## What the explanation answers
+
+Three questions, always all three:
+
+1. **What goes wrong that someone could observe.** The message, the wrong number, the state they would encounter. Not
+   the function that produces it.
+2. **What has to be true for it to happen.** The preconditions, all of them, stated plainly.
+3. **How likely that is.** An honest answer, including "this may never fire if X" when that is the honest answer.
+
+**Answer all three; do not print three fixed slots.** Where an answer is not in doubt, it is a clause rather than a
+sentence. On a finding whose failure is certain and unconditional, the preconditions and the likelihood both collapse to
+"always", and spending a sentence on each is padding. Requiring the questions to be answered keeps the whole of the
+evidence; requiring three sentences does not.
+
+**The explanation leads the finding**, ahead of the existing guidance written for the person who will open the file.
+That guidance keeps its detail: the location, the mechanism, the suggested fix. The two registers serve different
+readers, and the reader this one is written for should not have to read past prose addressed to someone else to reach
+their own.
+
+## Where the answers come from
+
+**When Step 7.2 already produced the reasoning, publish it.** That gate reads a finding's rationale for signals that the
+failure mode is not reachable, and demotes the finding when it finds one. Today it computes that reasoning and throws it
+away. It is exactly what questions 2 and 3 ask for, so it goes into the explanation instead.
+
+**Otherwise, derive the answers from the evidence the finding already carries.** The gate matches a fixed list of
+phrases, so it produces reasoning on the findings it matched and nothing on the rest. That is not the same population as
+the findings a reader cannot judge unaided, so the rest are worked out at drafting time from what the finding already
+shows.
+
+**Deriving them NEVER changes the finding's severity.** Not the finding's severity, not its task ID, not its position in
+the report. This is writing work, and it runs after every pass that sets severity. A finding whose explanation comes out
+reading "this may be a no-op if the upstream never returns nil" keeps the severity those passes gave it. BECAUSE
+re-deciding severity here would silently reopen the discovery and validation passes this content is written on top of,
+and those passes see evidence this step does not.
+
+## Security findings
+
+A SEC finding carries the explanation on the same terms as every other finding a reader must act on. Its exemption from
+the Step 7.2 demotion gate is about the evidence bar the security agent already meets, not about what the reader needs.
+A security finding is the one a non-implementer can least evaluate unaided, so it is the last one that should quietly
+skip the explanation.
+
+It does not gain a separately-labelled fix route. Its section already ends with a single Remediation note naming what to
+do, and a second answer to the same question in one block is worse than either alone.

--- a/han-coding/skills/code-review/references/finding-content.md
+++ b/han-coding/skills/code-review/references/finding-content.md
@@ -76,6 +76,24 @@ starts fixing things stops being a review.
 **Security findings carry no route** — see below. **YAGNI findings carry no route**, on the same grounds as the
 explanation: they are not corrected unless somebody asks for them.
 
+## Both cues reach the summary table
+
+The report's only index is one summary row per finding, and every finding a reader must act on just got longer. Two
+things travel up into that row, BECAUSE the complaint this content answers is comparative: a finding that will probably
+never fire reads as a behavior change when it sits at the same visual weight as the two findings beside it, and a longer
+finding body leaves that weight exactly where it was while adding reading load on top.
+
+1. **The fix route**, in its own `Fix` column. Security rows show `—`.
+2. **The may-never-fire cue**, opening the row's Description cell, on any finding the review established may not be
+   reachable.
+
+The same cue opens the finding's own body. When the honest answer to question 3 is that the finding may never fire, that
+answer leads the explanation rather than trailing it, so a reader who opens the finding meets it first.
+
+This changes what sits inside existing rows and nothing else. **No severity band changes, no row order changes, and no
+finding identifier changes.** People work those identifiers as a queue across sessions, and the row order is
+severity-ordered by design.
+
 ## Security findings
 
 A SEC finding carries the explanation on the same terms as every other finding a reader must act on. Its exemption from

--- a/han-coding/skills/code-review/references/finding-filters.md
+++ b/han-coding/skills/code-review/references/finding-filters.md
@@ -1,0 +1,94 @@
+# Finding Filters: the reachability gate and the independent validation pass
+
+Two of Step 7's sub-steps filter the collected finding list. Both are specified here, and every reference to Step 7.2 or
+Step 7.4 elsewhere in the skill points to this file. They run in the order below, with Step 7.3's size-aware rubric
+between them.
+
+Neither pass is a finding source. Both only demote or drop, so Step 9's verification rule against findings from
+undispatched agents is unaffected by either.
+
+## Step 7.2: Apply the reachability phrase-match demotion gate
+
+For each finding read at Step 7.1, scan the rationale text (the agent's own explanation of why the finding matters) for
+any of these reachability phrases:
+
+- `theoretical`
+- `hypothetical`
+- `defense-in-depth`
+- `effectively impossible`
+- `in case the upstream`
+- `could happen`
+- `should never happen`
+- `edge case that does not occur`
+
+When a finding's rationale contains any of these phrases, the agent itself signaled that the failure mode is not
+reachable in production. Demote the finding by one severity: CRIT becomes WARN, WARN becomes SUGG, SUGG is omitted
+entirely. Apply the demotion exactly once per finding regardless of how many phrases match.
+
+**Keep the reasoning that drove each demotion.** Carry it to Step 8, where it becomes the preconditions and the
+likelihood in that finding's plain-language explanation ([finding-content.md](./finding-content.md)). Discarding it here
+is what makes a reader ask whether a finding can happen at all, on a question this gate already answered.
+
+This gate is the merged form of the reachability and "directly introduced" filters; the size-aware rubric in Step 7.3 is
+the single later pass and does not re-demote on these phrases. The phrase list is the only signal the gate uses; do not
+infer reachability from other text. The gate is a cheap, deterministic first pass and is brittle to paraphrase by
+design: a finding that hedges its own reachability without using one of the literal phrases (for example, "unlikely in
+practice", "would need an unusual sequence") slips through here. That paraphrased hedging is caught semantically by the
+independent validation in Step 7.4, not by expanding this list.
+
+Security findings (SEC-series) are exempt from this gate because the security agent's evidence standard already requires
+a demonstrated exploit path or CVE reference before any finding is raised.
+
+## Step 7.4: Validate the finding list (independent adversarial pass)
+
+The specialist agents and the manual passes each filter findings on the findings' own wording. This sub-step is
+different: it dispatches one critic that re-attacks the **consolidated finding list against the code itself**, in fresh
+context, the way `investigate` validates a root cause and fix. It is the only pass that judges a finding by re-reading
+the change rather than by trusting the producing agent's rationale.
+
+**Run condition.** Run this sub-step whenever at least one corrective finding (CRIT / WARN / SUGG, manual or agent, plus
+any SEC-### finding) has survived to this point. **Skip it when there are zero corrective findings** — a clean review
+needs no validation. YAGNI findings are out of scope here: they are advisory and are never validated, demoted, or
+dropped by this pass.
+
+**Dispatch one `han-core:adversarial-validator`** via the `Agent` tool. Give it, in this order:
+
+1. **The change under review as primary material** — the diff from Step 1 (Mode A), or the changed file list with a note
+   that the files were read in full (Mode B / Mode C). The validator must judge against the code, not against the
+   finding text, so it does not anchor on what the producing agents concluded.
+2. **The complete corrective finding list**, with each finding's task ID, current severity, `file_path:line_number`, the
+   finding's claim, and the producing agent's rationale **verbatim**.
+3. **The `{size}` from Step 3.1 and the calibration directive from Step 3.3**, so it judges severity on the same scale
+   the rest of the review used.
+
+Pass this brief verbatim:
+
+> Treat every finding as wrong until the code proves it right. For each finding, return exactly one verdict —
+> **Confirmed**, **Partially Refuted**, or **Refuted** — and for anything other than Confirmed, cite concrete
+> counter-evidence at `file_path:line_number`. Challenge specifically: (a) findings that misread the change's intent or
+> the surrounding code; (b) findings that target pre-existing code this change did not introduce or worsen, unless the
+> issue is critical irrespective of who introduced it; (c) findings whose rationale hedges its own reachability in
+> paraphrase ("unlikely in practice", "would need an unusual sequence", "only under a race we don't see") that the
+> literal-phrase gate did not catch; (d) severity that overstates impact, where the true worst case is "an operator sees
+> an error and retries". Do not invent new findings — you are validating the list, not extending it.
+
+**Reconcile the verdicts (orchestrator).** Apply each verdict to the finding:
+
+- **Confirmed** → keep the finding at its current severity.
+- **Partially Refuted** (real but mis-severitied or partly wrong) → demote one severity (CRIT → WARN → SUGG; a SUGG
+  stays SUGG). Append the validator's one-line counter-point to the finding body.
+- **Refuted** → drop the finding, **but only when the validator supplied concrete counter-evidence** (a
+  `file_path:line_number` showing the code does not do what the finding claims, or that the finding targets unchanged
+  pre-existing code). A refutation that asserts without counter-evidence does **not** drop the finding; demote it one
+  severity instead.
+- **Security findings (SEC-###)** → the validator may challenge the exploit path, but a SEC finding is dropped only when
+  the validator refutes the demonstrated exploit with concrete counter-evidence. Otherwise it stands at its original
+  severity; the security evidence bar is already higher.
+
+**Overcorrection guard.** This pass exists to remove findings the code disproves, not to quiet the review. Never drop a
+finding on assertion alone — counter-evidence at `file_path:line_number` is required for every drop. When the validator
+is uncertain, the finding stays. Suppressing a real finding is more costly here than carrying one the human will reject.
+
+**Record the reconciliation.** Keep a single orchestrator-log line: how many findings were Confirmed, demoted, and
+dropped, plus the dropped task IDs and the counter-evidence reference for each. This makes the pass auditable; it does
+not add a section to the review output.

--- a/han-coding/skills/code-review/references/output-verification.md
+++ b/han-coding/skills/code-review/references/output-verification.md
@@ -66,6 +66,15 @@ Then verify:
     Security Vulnerabilities section nor the Remediation note is rendered.
 18. The `### ✅ What's Good` section is rendered only when a specific, substantive positive exists; it is omitted
     entirely rather than filled with generic praise.
+19. Every CRIT / WARN / SUGG block opens with its plain-language explanation, and every SEC block carries its
+    `What this means` line. YAGNI findings carry neither, because their reopen trigger already answers it.
+20. Every CRIT / WARN / SUGG block names a fix route. SEC blocks name none, since the single Remediation note carries
+    it.
+21. A finding the review established may never fire carries that cue in two places and they agree: leading its own
+    explanation, and opening its summary row's Description cell.
+
+Every item in this list is fixed before the review is presented, never reported alongside it as a caveat. A required
+piece of content that is missing is missing; saying so in the message does not put it in the report.
 
 ### Step 9.2: Readability self-check
 

--- a/han-coding/skills/code-review/references/output-verification.md
+++ b/han-coding/skills/code-review/references/output-verification.md
@@ -38,7 +38,9 @@ Then verify:
 4. Deferred tests note is present if the han-core:test-engineer produced skipped items
 5. The Review Summary table includes every corrective finding (CRIT/WARN/SUGG) and every security finding, and matches
    the sections that are present. YAGNI findings are excluded from the table (see rule 12). For findings whose block
-   omits the category, the table is the only place that category appears.
+   omits the category, the table is the only place that category appears. Every CRIT/WARN/SUGG row carries its fix route
+   in the `Fix` column and every security row carries `—` there; any finding the review established may never fire opens
+   its Description cell with that cue.
 6. All `file_path:line_number` references point to real files from the file list determined in Step 1
 7. SEC-### IDs are sequential starting at SEC-001
 8. Every SEC-### finding has an `EXPLOIT:` field populated

--- a/han-coding/skills/code-review/references/output-verification.md
+++ b/han-coding/skills/code-review/references/output-verification.md
@@ -49,8 +49,9 @@ Then verify:
    Critical-severity security finding yields a do-not-merge recommendation)
 10. Junior-developer findings that overlap with a specialist agent's finding reference the specialist finding instead of
     duplicating it
-11. The review output is the COMPLETE and FINAL response. Do not append a trailing summary, commentary, sign-off, or
-    follow-up message after the review. The structured review document IS the deliverable — nothing follows it.
+11. The report file is the COMPLETE deliverable. It carries no trailing commentary or sign-off, and no part of it is
+    pasted into the conversation. What the run says in the conversation is the short closing message Step 10 specifies,
+    and nothing else.
 12. The `### 🟡 YAGNI` section, when present, opens with the verbatim statement defined in Review Constraints, and YAGNI
     findings appear ONLY in this section — not duplicated under CRIT/WARN/SUGG and not in the Review Summary table.
 13. Any `Tension with {other-task-id}:` notes added by Step 9.0 appear on both members of each contradictory pair.

--- a/han-coding/skills/code-review/references/template.md
+++ b/han-coding/skills/code-review/references/template.md
@@ -20,7 +20,8 @@ subject to the descriptive-heading rule.
 
 PROSE ONCE: each finding's prose lives in exactly one place — its finding block, or its
 full security block. The Review Summary table row is an index entry, not prose; a
-`Tension with …` pointer note is a pointer, not prose.
+`Tension with …` pointer note is a pointer, not prose. The plain-language explanation is
+part of that one place, not a second copy of it.
 -->
 
 ## 📋 Review Summary
@@ -57,9 +58,13 @@ full security block. The Review Summary table row is an index entry, not prose; 
 
 <!-- Finding block format. Keep `file:line` (the actionable anchor). Omit the [Category] label when the category is generic and already conveyed by the table and task-ID prefix (logic, performance, clarity, and similar). Keep a category cue only when it names content a standalone reader needs and the task ID does not supply — an ADR violation that names the record, a standards violation that names the standard, or a security finding. -->
 
+<!-- Every CRIT / WARN / SUGG block opens with the plain-language explanation, then the existing guidance for the person who will open the file. The rules for writing it — what it answers, where the answers come from, and why deriving them never changes severity — are in references/finding-content.md. YAGNI findings carry no explanation. -->
+
 <!-- Generic category (omit the label): -->
 
-**{TASK-ID}** `{file_path:line_number}` {Description of issue.}
+**{TASK-ID}** `{file_path:line_number}` {Plain-language explanation: what someone could observe going wrong, what has to
+be true for it to happen, and how likely that is. All three answered; an answer not in doubt is a clause, not a
+sentence.} {Description of issue, for the person who will open the file.}
 
 ```suggestion
 {Suggested fix}
@@ -67,7 +72,8 @@ full security block. The Review Summary table row is an index entry, not prose; 
 
 <!-- Content-bearing category (keep the label): -->
 
-**{TASK-ID}** **[{ADR: record / Standard: name / Security}]** `{file_path:line_number}` {Description of issue.}
+**{TASK-ID}** **[{ADR: record / Standard: name / Security}]** `{file_path:line_number}` {Plain-language explanation.}
+{Description of issue.}
 
 ```suggestion
 {Suggested fix}
@@ -75,11 +81,11 @@ full security block. The Review Summary table row is an index entry, not prose; 
 
 ### 🟡 Warnings
 
-**{TASK-ID}** `{file_path:line_number}` {Description of concern.}
+**{TASK-ID}** `{file_path:line_number}` {Plain-language explanation.} {Description of concern.}
 
 ### 🔵 Suggestions
 
-**{TASK-ID}** `{file_path:line_number}` {Optional improvement idea.}
+**{TASK-ID}** `{file_path:line_number}` {Plain-language explanation.} {Optional improvement idea.}
 
 ### 🟡 YAGNI
 
@@ -98,6 +104,8 @@ version available}. Reopen / keep when: {the concrete trigger that would justify
 
 **SEC-001: [Brief descriptive title]**
 
+- **What this means:** {Plain-language explanation, same three questions and same terms as every other finding a reader
+  must act on. A security finding is the one a non-implementer can least judge unaided.}
 - **OWASP:** A0X — Category Name
 - **Location:** `file_path:line_number`
 - **Evidence:** {exact code snippet demonstrating the vulnerability}

--- a/han-coding/skills/code-review/references/template.md
+++ b/han-coding/skills/code-review/references/template.md
@@ -58,13 +58,14 @@ part of that one place, not a second copy of it.
 
 <!-- Finding block format. Keep `file:line` (the actionable anchor). Omit the [Category] label when the category is generic and already conveyed by the table and task-ID prefix (logic, performance, clarity, and similar). Keep a category cue only when it names content a standalone reader needs and the task ID does not supply — an ADR violation that names the record, a standards violation that names the standard, or a security finding. -->
 
-<!-- Every CRIT / WARN / SUGG block opens with the plain-language explanation, then the existing guidance for the person who will open the file. The rules for writing it — what it answers, where the answers come from, and why deriving them never changes severity — are in references/finding-content.md. YAGNI findings carry no explanation. -->
+<!-- Every CRIT / WARN / SUGG block opens with the plain-language explanation, then the existing guidance for the person who will open the file, then the fix route. The rules for both — what the explanation answers, where its answers come from, why deriving them never changes severity, and how to pick one of the three routes — are in references/finding-content.md. YAGNI findings carry neither. Security findings carry the explanation but no route: their section already ends with a Remediation note. -->
 
 <!-- Generic category (omit the label): -->
 
 **{TASK-ID}** `{file_path:line_number}` {Plain-language explanation: what someone could observe going wrong, what has to
 be true for it to happen, and how likely that is. All three answered; an answer not in doubt is a clause, not a
-sentence.} {Description of issue, for the person who will open the file.}
+sentence.} {Description of issue, for the person who will open the file.} **Fix:** {test-first (`/tdd`) | restructure
+(`/refactor`) | by hand}.
 
 ```suggestion
 {Suggested fix}
@@ -73,7 +74,7 @@ sentence.} {Description of issue, for the person who will open the file.}
 <!-- Content-bearing category (keep the label): -->
 
 **{TASK-ID}** **[{ADR: record / Standard: name / Security}]** `{file_path:line_number}` {Plain-language explanation.}
-{Description of issue.}
+{Description of issue.} **Fix:** {route}.
 
 ```suggestion
 {Suggested fix}
@@ -81,11 +82,11 @@ sentence.} {Description of issue, for the person who will open the file.}
 
 ### 🟡 Warnings
 
-**{TASK-ID}** `{file_path:line_number}` {Plain-language explanation.} {Description of concern.}
+**{TASK-ID}** `{file_path:line_number}` {Plain-language explanation.} {Description of concern.} **Fix:** {route}.
 
 ### 🔵 Suggestions
 
-**{TASK-ID}** `{file_path:line_number}` {Plain-language explanation.} {Optional improvement idea.}
+**{TASK-ID}** `{file_path:line_number}` {Plain-language explanation.} {Optional improvement idea.} **Fix:** {route}.
 
 ### 🟡 YAGNI
 

--- a/han-coding/skills/code-review/references/template.md
+++ b/han-coding/skills/code-review/references/template.md
@@ -30,15 +30,21 @@ part of that one place, not a second copy of it.
 
 <!-- A corrective finding's severity is already carried by its task-ID prefix (CRIT-/WARN-/SUGG-). A security finding's task ID does not encode a tier, so show the tier inline in the Task ID cell — e.g. `SEC-001 (Critical)` — so the table stands alone as the complete severity-ordered index. -->
 
+<!-- The Description cell carries the fix route, and opens with `May never fire —` on any finding the review established
+may not be reachable. Both cues sit here so a person triaging thirty findings gets them before opening any one of them;
+a longer finding body would leave the triage exactly where it was. The cell stays an index entry, not a second copy of
+the finding's prose. Security findings show `—` for the route: their Remediation note carries it. -->
+
 <!-- If no issues were found, use the no-issues row instead. -->
 
-| Task ID                            | Category     | File        | Description                                   |
-| ---------------------------------- | ------------ | ----------- | --------------------------------------------- |
-| {TASK-ID}                          | {Category}   | {file:line} | {Brief description of finding}                |
-| SEC-### ({Critical\|High\|Medium}) | {OWASP: A0X} | {file:line} | {Brief description of security vulnerability} |
+| Task ID                            | Category     | File        | Fix                                    | Description                                   |
+| ---------------------------------- | ------------ | ----------- | -------------------------------------- | --------------------------------------------- |
+| {TASK-ID}                          | {Category}   | {file:line} | {test-first \| restructure \| by hand} | {Brief description of finding}                |
+| {TASK-ID}                          | {Category}   | {file:line} | {route}                                | May never fire — {brief description}          |
+| SEC-### ({Critical\|High\|Medium}) | {OWASP: A0X} | {file:line} | —                                      | {Brief description of security vulnerability} |
 
 <!-- No-issues row if applicable: -->
-<!-- | — | — | — | No issues found | -->
+<!-- | — | — | — | — | No issues found | -->
 
 ### Review Recommendation
 

--- a/han-communication/agents/readability-editor.md
+++ b/han-communication/agents/readability-editor.md
@@ -69,7 +69,7 @@ bottom line up front, main point first, one idea per paragraph, topic sentence, 
 progressive disclosure, layered detail, active voice, passive construction, nominalization, sentence length flag,
 common word over technical synonym, vocabulary blocklist, prose region, code fence, diagram body, rendered markup,
 citation identifier, fact preservation, fidelity loss, precision-bearing qualifier, quantity, named entity, stated
-condition, audience frame, insider shorthand
+condition, audience frame, insider shorthand, coined term, first-use explanation, language runtime, term of art
 
 ## Anti-Patterns
 
@@ -79,6 +79,9 @@ condition, audience frame, insider shorthand
   "Overview", "Details", or "Notes" that do not predict what follows.
 - **Multi-Idea Paragraph**: One paragraph carries several ideas, so scanning first sentences loses the argument.
   Detection: a paragraph whose first sentence does not cover what the rest of it says.
+- **Unexplained Coined Term**: The draft invents a compound noun and then uses it as though the reader already knows it.
+  Detection: a capitalized or hyphenated phrase that names a concept, appears more than once, and is defined nowhere in
+  the draft.
 - **Fidelity Loss Disguised as Simplification**: A rewrite drops or blurs a quantity, condition, or qualifier.
   Detection: "exceeded 340ms in three of ten windows" becomes "was sometimes slow", or "only when X and Y both hold"
   becomes "generally".
@@ -100,11 +103,15 @@ Audit and rewrite against these six criteria. They are the whole rubric.
 4. **Short, active sentences** — sentences average roughly fifteen to twenty words and are active by default. Treat any
    sentence past about thirty words as a candidate to split, but leave a long sentence that reads clearly and would be
    hurt by splitting.
-5. **Common words, no blocklisted words** — prefer the common word over the technical synonym; define an unavoidable
-   term on first use. Remove every word on the vocabulary blocklist (the writing-voice profile's "Avoided words and
-   phrases" and "AI slop to avoid" lists). Replace stale figures of speech and foreign, Latinate, or archaic diction
-   ("in lieu of," "aforementioned") with plain equivalents, but keep a fresh analogy that is load-bearing for the
-   explanation. Keep domain terms the reader genuinely needs.
+5. **Common words, no blocklisted words** — prefer the common word over the technical synonym. Remove every word on the
+   vocabulary blocklist (the writing-voice profile's "Avoided words and phrases" and "AI slop to avoid" lists). Replace
+   stale figures of speech and foreign, Latinate, or archaic diction ("in lieu of," "aforementioned") with plain
+   equivalents, but keep a fresh analogy that is load-bearing for the explanation. Keep domain terms the reader
+   genuinely needs, and give each one a half-sentence explanation at first use when the reader cannot look it up: an
+   outside technology or language runtime, a named statistical or numerical method, or a compound noun the draft coined
+   for its own convenience. A coined term is the one you will meet most and the one the reader can do least about,
+   BECAUSE it exists nowhere but this draft. Write the explanation from what the draft already says; adding one is
+   making the draft's own term readable, not adding a fact.
 6. **Progressive disclosure** — the core idea comes before its qualifications, edge cases, and supporting evidence.
    Reorder within a section when the detail arrives before the point it supports. Pull implementation and technical
    references (symbol names, file paths, flags) out of the prose where the reader does not need them to follow the
@@ -131,7 +138,10 @@ Return a short report:
 ## Rules
 
 - Fidelity outranks readability on every conflict. When in doubt, keep the fact and the precision.
-- Never add a fact, claim, or recommendation the draft did not already carry. Your job is rewriting, not creation.
+- Never add a fact, claim, or recommendation the draft did not already carry. Your job is rewriting, not creation. The
+  half-sentence explanation criterion 5 asks for is the one thing you write that was not there, and it is bounded: say
+  what the draft already shows the term means, and never reach outside the draft to define it. When the draft does not
+  say enough to explain its own term, leave the term alone and name it in your report.
 - Never raise findings about the underlying work — the bug, the code, the plan, the architecture. You edit the writing,
   nothing else.
 - Never judge subjective clarity ("this is confusing"). Apply the six concrete criteria.

--- a/han-communication/docs/agents/readability-editor.md
+++ b/han-communication/docs/agents/readability-editor.md
@@ -70,8 +70,8 @@ Example prompts:
 The draft, rewritten in place (or returned inline when the deliverable is conversational), plus a short report:
 
 - **Rubric verdict.** One line per criterion: pass, or what was changed to make it pass. The six criteria are main point
-  first, descriptive headings, one idea per paragraph, sentence length, common words with no blocklisted words, and
-  progressive disclosure.
+  first, descriptive headings, one idea per paragraph, sentence length, common words with no blocklisted words and a
+  half-sentence explanation for every term the reader cannot look up, and progressive disclosure.
 - **Fact-preservation ledger.** Confirmation that every claim, quantity, named entity, and stated condition survived.
   Any fact that could not be preserved while satisfying a criterion is named, with a note that the fact was kept.
 - **Untouched regions.** The non-prose regions left unchanged.

--- a/han-communication/docs/skills/edit-for-readability.md
+++ b/han-communication/docs/skills/edit-for-readability.md
@@ -80,7 +80,8 @@ The rewritten target plus the editor's report:
 - **For pasted text or a conversation draft**, the rewrite comes back inline, with the scratch file path where the
   working copy was written. The original is never touched, so no confirmation is needed.
 - **Rubric verdict.** One line per criterion (main point first, descriptive headings, one idea per paragraph, sentence
-  length, no blocklisted words, every fact preserved): pass, or what changed to make it pass.
+  length, common words with no blocklisted words and an explanation for every term you cannot look up, every fact
+  preserved): pass, or what changed to make it pass.
 - **Fact-preservation ledger.** Confirmation that every claim, quantity, named entity, and stated condition survived.
   Any fact that could not be preserved while satisfying a criterion is named, with a note that the fact was kept.
 - **Untouched regions.** The non-prose regions left unchanged (code fences, diagrams, citation identifiers).

--- a/han-communication/references/readability-rule.md
+++ b/han-communication/references/readability-rule.md
@@ -48,8 +48,15 @@ bolted on afterward.
   "Analysis"), so a reader scanning headings can navigate.
 - **Short, active sentences.** Sentences are short (roughly fifteen to twenty words on average) and active by default.
   Few run past twenty-five to thirty words.
-- **Common words.** Prefer the common word over the technical synonym. Define a term on first use when it cannot be
-  replaced.
+- **Common words, and a half-sentence explanation for a term the reader cannot look up.** Prefer the common word over
+  the technical synonym. Where a term cannot be replaced, explain it in half a sentence at first use. Three kinds always
+  need it, BECAUSE the reader has nowhere to resolve them from the material the document describes:
+  - **Outside technologies and language runtimes** — a product, library, service, or runtime the document names but
+    never says what it is.
+  - **Named statistical or numerical methods** — a method carrying a person's name or a field's term of art.
+  - **Compound nouns the document coins for its own convenience** — a phrase this document invented to save itself
+    words. These matter most of the three: a reader can search for the other two and find an answer, and a coined term
+    exists nowhere but here.
 - **No blocklisted words.** Apply the vocabulary blocklist (below) for word-level rules.
 - **Numbered lists for steps, bullets for the rest.** Number anything sequential; bullet anything that is not.
 - **Progressive disclosure.** Reveal the core first and detail in layers. The reader meets the essential idea before the
@@ -115,7 +122,8 @@ presented.
 2. **Descriptive headings** — each heading names its content and is not a generic label.
 3. **One idea per paragraph** — each paragraph carries one idea and leads with it.
 4. **Sentence length** — no sentence runs past the soft length flag (about thirty words) without reason.
-5. **No blocklisted word** — no word from the vocabulary blocklist is present.
+5. **Common words, no blocklisted word** — no word from the vocabulary blocklist is present, and every term the reader
+   cannot look up carries its half-sentence explanation at first use.
 6. **Every fact preserved** — every claim, quantity, named entity, and stated condition or qualifier in the draft
    survives with its precision intact.
 

--- a/han-github/docs/skills/post-code-review-to-pr.md
+++ b/han-github/docs/skills/post-code-review-to-pr.md
@@ -12,7 +12,7 @@ and _how_ to use the skill. For what the skill does internally, read the skill d
 - **What it does.** Runs [`/code-review`](../../../han-coding/docs/skills/code-review.md) against the current branch's GitHub PR and
   optionally posts the review to GitHub as a formal review or PR comment.
 - **When to use it.** You want the full code review _and_ you want it visible to the team on the PR.
-- **What you get back.** The full code-review output in-channel, posted to the PR when you confirm, plus an optional fix
+- **What you get back.** The full code-review report, posted to the PR when you confirm, plus an optional fix
   plan for Critical and Warning findings.
 
 ## Key concepts
@@ -71,10 +71,11 @@ Example prompts:
 
 A full review plus GitHub integration:
 
-- **The full `/code-review` output in-channel.** Review Summary table, Review Recommendation, and all findings organized
-  by severity, plus any optional sections (What's Good, Security Vulnerabilities, Remediation) that are present. The
-  code-review skill renders a section only when it has content, so the body builder treats every section other than the
-  table and the recommendation as optional. See the `/code-review` documentation for the detailed shape.
+- **The full `/code-review` report**, written to a file by that skill and read back from the path its closing message
+  names. Review Summary table, Review Recommendation, and all findings organized by severity, plus any optional sections
+  (What's Good, Security Vulnerabilities, Remediation) that are present. The code-review skill renders a section only
+  when it has content, so the body builder treats every section other than the table and the recommendation as optional.
+  See the `/code-review` documentation for the detailed shape.
 - **An offer to post to GitHub.** `AskUserQuestion` with "Yes, post to GitHub" / "No, just the local review."
 - **When accepted.** The skill gathers PR metadata (`owner/repo`, `pr_number`, `head_sha`, author login, current user
   login) and runs a `junior-developer` clarity pass on the draft review body. That pass flags unclear wording,

--- a/han-github/skills/post-code-review-to-pr/SKILL.md
+++ b/han-github/skills/post-code-review-to-pr/SKILL.md
@@ -40,7 +40,11 @@ exists for the current branch and stop.
 ## Step 2: Run Code Review
 
 Invoke the `/code-review` skill to perform the full code review. Pass along any user-provided focus areas or context
-from the original arguments. After /code-review completes, proceed immediately to Step 3 — do not stop here.
+from the original arguments.
+
+`/code-review` writes its report to a file and names the path in its closing message; it does not print the review into
+the conversation. **Capture that path** — Step 3 reads the report from it. After /code-review completes, proceed
+immediately to Step 3 — do not stop here.
 
 ## Step 3: Offer to Post Review to GitHub
 
@@ -51,8 +55,8 @@ If the user accepts:
 
 1. Gather PR metadata by running `${CLAUDE_SKILL_DIR}/scripts/pr-metadata.sh`, which outputs JSON with `owner_repo`,
    `pr_number`, `head_sha`, `pr_author_login`, and `current_user_login`.
-2. Build the review body from: Review Summary table, Review Recommendation, and all findings organized by severity, plus
-   any optional sections that are present. Treat every section other than the Review Summary table and the Review
+2. Read the report file at the path captured in Step 2, then build the review body from it: Review Summary table, Review
+   Recommendation, and all findings organized by severity, plus any optional sections that are present. Treat every section other than the Review Summary table and the Review
    Recommendation as optional — the code-review skill renders a section only when it has content, so a section (the
    What's Good section, an absent severity section on a clean review, the Security Vulnerabilities section, the
    Remediation note) may simply not be there. Include each section when present and omit it without error or an empty


### PR DESCRIPTION
## Summary

**This PR rewrites what `/code-review` and `/code-overview` hand back at the end of a run, so that a reader gets an answer they can act on instead of a report they have to interview.**

## Behavior changes

`/code-review` now writes its report to a file and closes with a short message rather than pasting the whole review into the conversation. That message leads with the recommendation and the counts by severity, then the path, then the run's own bookkeeping last. Inside the report, every finding a reader is asked to act on opens with a plain-language explanation for someone who will not open the file: what they could observe going wrong, what has to be true for it, and how likely that is. Every corrective finding also names how it gets fixed: test-first, restructure, or by hand. The route is named, never started. Both cues travel up into the summary table so a long list can be triaged before opening any single finding, with no change to severities, row order, or task IDs. `/post-code-review-to-pr` now reads the review back from that report file instead of from the conversation.

`/code-overview` now ends both modes with three or four plain sentences a person could read aloud. Those sentences carry no file paths or type names and are written to be lifted out and pasted into a PR description. The closing message repeats those exact sentences rather than composing a second version. The overview also honors a configured `output-directory` wherever it points, falling back outside the repository when nothing is configured or the destination cannot be written. Where-to-start is now an ordered path through the entry points with a runnable example call on any interface other code calls, rather than a set of files. The most consequential new sentence appears in PR mode. When the code shows that the change's stated reason is already satisfied or does not hold, the overview says so, right where it states that reason. It states this as a fact about the reason, never as a finding, and only when it checked and found that to be true. Silence in the code stays an inferred why, not a contradiction.

The shared writing standard in `han-communication` picks up one new requirement behind both: a term the reader cannot look up gets a half-sentence explanation at first use. Three kinds qualify, and the compound nouns a document coins for its own convenience matter most, since a reader can search for the other two. The `readability-editor` agent enforces this as part of its common-words criterion, bounded to what the draft already shows the term means. Because that editor is barred from touching diagram bodies, `/code-overview` now owns chart legibility itself: boxes name components and boundaries. Fields, types, and annotations move to the prose beneath, with no step ever dropped to simplify the picture.
