### PR TITLE
feat(han-communication): add the han-readability output style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@ sub-agents to do the judgment-heavy work. The suite ships as a family of plugins
 plugin beneath every other: it owns the canonical readability standard, the writing-voice profile, and the explanation
 standard for talking to a reader who will not implement the work, plus the inline `readability-guidance` skill that
 surfaces the first two, the inline `explanation-guidance` skill that surfaces the third, the `edit-for-readability` skill,
-and the `readability-editor` agent; it depends on nothing and every prose-producing plugin depends on it), `han-core` (the shared foundation: the
+the `readability-editor` agent, and the `han-readability` output style that applies the first two to every turn of a
+session; it depends on nothing and every prose-producing plugin depends on it), `han-core` (the shared foundation: the
 specialist agent roster the rest of the suite dispatches — every shared agent except the `readability-editor`, the
 `research-analyst`, and the `discussion-facilitator` — plus the `project-discovery` skill and the canonical rule files; depends on no other Han plugin),
 `han-documentation` (the documentation skills: `project-documentation`, `architectural-decision-record`, and `runbook`;
@@ -66,7 +67,7 @@ han-plugin-builder skill:
 │   ├── README.md       # Light meta-plugin front door (no skills/agents sections)
 │   └── .claude-plugin/
 │       └── plugin.json
-├── han-communication/  # Foundational plugin: readability-guidance + explanation-guidance + edit-for-readability skills, readability-editor agent, and the canonical readability-rule.md + writing-voice.md + explanation-rule.md (depends on nothing; every prose-producing plugin depends on it)
+├── han-communication/  # Foundational plugin: readability-guidance + explanation-guidance + edit-for-readability skills, readability-editor agent, han-readability output style, and the canonical readability-rule.md + writing-voice.md + explanation-rule.md (depends on nothing; every prose-producing plugin depends on it)
 │   ├── README.md       # Light front door + scent-line skill and agent lists
 │   ├── .claude-plugin/
 │   │   └── plugin.json
@@ -74,6 +75,7 @@ han-plugin-builder skill:
 │   │   └── plugin.json    # Codex-format manifest; every plugin except han and han-linear carries one (omitted from the entries below)
 │   ├── agents/         # readability-editor agent definition
 │   ├── skills/         # readability-guidance + explanation-guidance (both inline, each surfaces one standard) + edit-for-readability
+│   ├── output-styles/  # han-readability.md: the readability rule and writing voice distilled into a selectable output style (auto-discovered default location; no plugin.json field)
 │   ├── docs/           # In-plugin long-form docs: docs/skills/{name}.md + docs/agents/readability-editor.md
 │   └── references/     # Canonical readability-rule.md + writing-voice.md + explanation-rule.md (owned here; no vendored copies elsewhere)
 ├── han-core/           # Core plugin: the shared specialist agent roster (all agents except readability-editor and research-analyst) + project-discovery (depends on no other Han plugin)
@@ -245,6 +247,11 @@ such as Claude, should be referenced here.
   than a mechanism, and never use a term that appears in neither the work item nor the conversation. It governs what a run
   says to a person in a turn, where the readability rule governs the shape of a written deliverable. Skills that escalate
   source it by invoking `han-communication:explanation-guidance`. Guidance only, with no self-check.
+- **[han-communication/output-styles/han-readability.md](./han-communication/output-styles/han-readability.md).** The
+  readability rule and the writing-voice blocklist distilled into a selectable output style, so the standard shapes every
+  turn of a session rather than only the skills that invoke `readability-guidance`. Derived from the two canonical files
+  above; when you edit either one, check whether the style needs the same change. It cannot read `.han/config.md`, so it
+  carries the built-in voice and no configured-profile override.
 
 ### Shared planning conventions (`han-planning/references/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ han-plugin-builder skill:
 │   ├── agents/         # readability-editor agent definition
 │   ├── skills/         # readability-guidance + explanation-guidance (both inline, each surfaces one standard) + edit-for-readability
 │   ├── output-styles/  # han-readability.md: the readability rule and writing voice distilled into a selectable output style (auto-discovered default location; no plugin.json field)
-│   ├── docs/           # In-plugin long-form docs: docs/skills/{name}.md + docs/agents/readability-editor.md
+│   ├── docs/           # In-plugin long-form docs: docs/skills/{name}.md + docs/agents/readability-editor.md + docs/output-styles/han-readability.md
 │   └── references/     # Canonical readability-rule.md + writing-voice.md + explanation-rule.md (owned here; no vendored copies elsewhere)
 ├── han-core/           # Core plugin: the shared specialist agent roster (all agents except readability-editor and research-analyst) + project-discovery (depends on no other Han plugin)
 │   ├── README.md       # Light front door; skills and agents grouped by purpose
@@ -296,7 +296,9 @@ All three are owned by `han-planning`, not vendored. Each opens by saying so.
   `han-communication/agents/`, `han-research/agents/`, and `han-planning/agents/` (long-form docs in
   `{plugin}/docs/agents/`, indexed in
   `docs/agents/README.md`). Verify the indexes list every entity when editing them, rather than tracking a running
-  total.
+  total. An output style in `han-communication/output-styles/` gets a long-form doc in
+  `{plugin}/docs/output-styles/` and a plugin README scent line, with no repo-root index until a second plugin ships
+  one.
 
 ## Project Discovery
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,9 @@ change goes before you scaffold anything. (For the user-facing version of this m
 - **`han-communication`** is the foundational plugin beneath every other. It owns the canonical readability standard, the
   writing-voice profile, and the explanation standard for talking to a reader who will not implement the work, plus the
   `readability-guidance` and `explanation-guidance` skills that surface them, the `edit-for-readability` skill, and the
-  `readability-editor` agent. It depends on nothing; the plugins that produce prose output depend on it. A component
-  goes here only when it is part of a shared communication capability: how output reads, or how a run talks to a person.
+  `readability-editor` agent, and the `Han Readability` output style in `han-communication/output-styles/`. It depends on
+  nothing; the plugins that produce prose output depend on it. A component goes here only when it is part of a shared
+  communication capability: how output reads, or how a run talks to a person.
 - **`han-core`** carries the shared specialist agent roster — **every agent in the suite except the
   `readability-editor`** (which lives in `han-communication`), **the `research-analyst`** (which lives in
   `han-research`), **and the `discussion-facilitator`** (which lives in `han-planning`) — plus the `project-discovery` skill and the canonical evidence and YAGNI rule files. New agents go

--- a/docs/choosing-a-han-plugin.md
+++ b/docs/choosing-a-han-plugin.md
@@ -31,7 +31,8 @@ description of what it does. The `han` meta-plugin is a convenience wrapper that
 
 - **[`han-communication`](../han-communication/README.md).** The foundational plugin beneath every other. Owns the
   canonical readability standard and the explanation standard for talking to someone who will not implement the work,
-  plus the skills and agent that apply them. Bundled; depends on nothing.
+  plus the skills and agent that apply them and a `Han Readability` output style that applies the readability standard
+  to a whole session. Bundled; depends on nothing.
 - **[`han-core`](../han-core/README.md).** The shared foundation: the specialist agent roster the other plugins
   dispatch, the project-discovery skill, and the canonical rule files. Bundled; depends on no other Han plugin.
 - **[`han-documentation`](../han-documentation/README.md).** The documentation layer: feature and system docs,

--- a/docs/readability.md
+++ b/docs/readability.md
@@ -26,6 +26,8 @@ and reveals detail in layers, instead of each skill restating the rule on its ow
   Every in-scope skill runs the standardized self-check.
 - **Fidelity wins.** No required fact is dropped to read more simply. Every claim, quantity, named entity, and stated
   condition survives with its precision intact.
+- **Session-wide is opt-in.** Selecting the `Han Readability` output style holds the standard across every turn, not
+  only inside a reader-facing skill. It reaches the main conversation, never a dispatched subagent.
 - **The canonical rule lives in
   [`han-communication/references/readability-rule.md`](../han-communication/references/readability-rule.md).** Every
   reader-facing skill sources it cross-plugin by invoking `han-communication:readability-guidance`. This page is the
@@ -91,6 +93,27 @@ at a time:
 
 The self-check and any rewrite operate on **prose regions only**. Code fences, diagram bodies, rendered markup, and
 inline citation identifiers are neither evaluated nor altered, so they still compile, render, and resolve.
+
+## Applying the standard to a whole session
+
+The path above covers a skill's deliverable. To hold the standard across every turn instead, including the conversation
+around a skill and the work no skill covers, select the `Han Readability` output style shipped in
+[`han-communication/output-styles/han-readability.md`](../han-communication/output-styles/han-readability.md). Choose it
+under **Output style** in `/config`. It takes effect on your next session or after `/clear`, because Claude Code reads
+the output style once at session start.
+
+The style distills the rule's audience frame, output properties, fidelity guard, and six-criterion self-check together
+with the writing-voice blocklist. It keeps Claude Code's built-in software engineering instructions, so it changes how
+work is written up, not how it is done.
+
+The style has three limits:
+
+- **It does not reach subagents.** A subagent runs its own system prompt, so the style leaves Han's dispatched
+  specialists unchanged. The skills stay the mechanism that brings the standard to agent output.
+- **It carries the built-in voice only.** A static system prompt cannot run the `.han/config.md` probe, so a configured
+  `writing-voice` profile does not override it the way it overrides `readability-guidance`.
+- **It is a derived copy.** The canonical rule and voice profile stay authoritative. When you edit either one, check
+  whether the style needs the same change.
 
 ## Scope: which skills are reader-facing
 
@@ -176,6 +199,8 @@ optional.
   the rewrite pass.
 - [`/edit-for-readability`](../han-communication/docs/skills/edit-for-readability.md). The standalone skill that applies this
   standard on demand to a file, pasted text, or a conversation draft.
+- [`han-communication/output-styles/han-readability.md`](../han-communication/output-styles/han-readability.md). The
+  output style that holds the standard across a whole session.
 - [Concepts](./concepts.md). The skill / agent split, and where readability sits among the plugin's mechanics.
 - [YAGNI](./yagni.md) and [Evidence](./evidence.md). The other shared rules, summarized the same way (they remain
   vendored per-plugin; readability is now sourced cross-plugin from `han-communication`).

--- a/docs/readability.md
+++ b/docs/readability.md
@@ -199,8 +199,8 @@ optional.
   the rewrite pass.
 - [`/edit-for-readability`](../han-communication/docs/skills/edit-for-readability.md). The standalone skill that applies this
   standard on demand to a file, pasted text, or a conversation draft.
-- [`han-communication/output-styles/han-readability.md`](../han-communication/output-styles/han-readability.md). The
-  output style that holds the standard across a whole session.
+- [`Han Readability`](../han-communication/docs/output-styles/han-readability.md). The output style that holds the
+  standard across a whole session, and the boundaries it does not reach.
 - [Concepts](./concepts.md). The skill / agent split, and where readability sits among the plugin's mechanics.
 - [YAGNI](./yagni.md) and [Evidence](./evidence.md). The other shared rules, summarized the same way (they remain
   vendored per-plugin; readability is now sourced cross-plugin from `han-communication`).

--- a/docs/templates/coverage-rule.md
+++ b/docs/templates/coverage-rule.md
@@ -1,6 +1,6 @@
 # Long-form Doc Coverage Rule
 
-Every skill and agent in the han plugin gets a long-form doc. No exceptions.
+Every skill, agent, and output style in the han plugin gets a long-form doc. No exceptions.
 
 ## The Rule
 
@@ -11,8 +11,12 @@ When you add a new agent, you create a long-form doc in `{plugin}/docs/agents/{n
 `han-core`, `han-communication`, `han-research`, or `han-planning`, the only agent-owning plugins) using
 [the agent template](./agent-long-form-template.md).
 
-The long-form doc lands in the same pull request as the skill or agent definition. Not as a follow-up. Not "when there's
-time."
+When you add a new output style, you create a long-form doc in `{plugin}/docs/output-styles/{name}.md` (today that
+plugin is `han-communication`, the only style-owning plugin) using
+[the output-style variant](#the-output-style-variant) of the skill template.
+
+The long-form doc lands in the same pull request as the skill, agent, or output-style definition. Not as a follow-up.
+Not "when there's time."
 
 ## Why this rule
 
@@ -85,6 +89,55 @@ output:
 
 Use this variant only for a skill that both runs inline in the caller's context and produces no deliverable. A skill an
 operator invokes directly follows the full template, even when its output is small.
+
+## The output-style variant
+
+An output style breaks the template for the opposite reason the inline-guidance skills do. Nobody runs it, and it
+produces nothing, because it is a block of text Claude Code appends to the system prompt at session start. You select it
+once and it shapes every turn until you change it. Today the only one is
+[`Han Readability`](../../han-communication/docs/output-styles/han-readability.md).
+
+An output-style doc carries this section list, in this order:
+
+```markdown
+## TL;DR
+
+## Key concepts
+
+## When to select it
+
+## How to select it
+
+## What it changes
+
+## What it does not reach
+
+## Cost and latency
+
+## Troubleshooting
+
+## Related documentation
+```
+
+Two headings are renamed, two are added, and three are dropped:
+
+- **`When to use it` becomes `When to select it`, and `How to invoke it` becomes `How to select it`.** A style is chosen
+  once in `/config`, not invoked per task, so both sections describe a standing choice rather than a call.
+- **`What it changes` replaces `What you get back`.** No artifact comes back. What a reader needs is the behavior
+  difference the style makes, stated so they can recognize it in the output.
+- **`What it does not reach` is new, and it is the section a reader most needs.** A style modifies the main
+  conversation's system prompt only. Name every boundary here: dispatched subagents that run their own prompt,
+  configuration a static prompt cannot probe, and any canonical file the style was derived from and can drift against.
+- **`How to get the most out of it`, `YAGNI`, and `Sources` are dropped.** There are no invocation levers on a standing
+  selection, a style gates no artifact, and a style distilled from a canonical rule inherits that rule's citations
+  instead of restating them.
+
+A style derived from a canonical reference file names that file as authoritative in `Related documentation` and says
+plainly that the style is a copy. That pointer is what stops the two drifting apart without anyone noticing.
+
+There is no separate template file for this variant, and no repo-root output-styles index. The plugin README's scent
+line and this long-form doc are the surfaces a new style needs. Add an index when a second plugin ships a style, not
+before.
 
 ## What is _not_ the long-form doc
 

--- a/han-communication/README.md
+++ b/han-communication/README.md
@@ -25,10 +25,9 @@ that produces prose output depends on it, so it comes along whenever you install
 
 ## Output styles
 
-- `Han Readability` ([`output-styles/han-readability.md`](output-styles/han-readability.md)) — Apply the readability
-  standard and the writing voice to every turn of a session, not only to the skills that source them. Select it under
-  **Output style** in `/config`; it takes effect on the next session or after `/clear`. It keeps Claude Code's built-in
-  software engineering instructions, so coding behavior is unchanged.
+- [`Han Readability`](docs/output-styles/han-readability.md) — Hold the readability standard and the writing voice
+  across every turn of a session, not only inside the skills that source them. Select it under **Output style** in
+  `/config`; it keeps Claude Code's built-in software engineering instructions, so coding behavior is unchanged.
 
 ## Installation
 

--- a/han-communication/README.md
+++ b/han-communication/README.md
@@ -23,6 +23,13 @@ that produces prose output depends on it, so it comes along whenever you install
 - [`readability-editor`](docs/agents/readability-editor.md) — Rewrite a finished draft for a non-author reader against
   the shared readability standard, preserving every fact and leaving code, diagrams, and citation identifiers untouched.
 
+## Output styles
+
+- `Han Readability` ([`output-styles/han-readability.md`](output-styles/han-readability.md)) — Apply the readability
+  standard and the writing voice to every turn of a session, not only to the skills that source them. Select it under
+  **Output style** in `/config`; it takes effect on the next session or after `/clear`. It keeps Claude Code's built-in
+  software engineering instructions, so coding behavior is unchanged.
+
 ## Installation
 
 Add the marketplace to Claude Code, then install the plugin (or install `han` to get it as part of the bundled suite):

--- a/han-communication/docs/output-styles/han-readability.md
+++ b/han-communication/docs/output-styles/han-readability.md
@@ -1,0 +1,123 @@
+# Han Readability
+
+Operator documentation for the `Han Readability` output style in the han plugin. This document helps you decide _when_
+and _how_ to select the style. For the instructions it adds to the system prompt, read the style itself at
+[`han-communication/output-styles/han-readability.md`](../../output-styles/han-readability.md).
+
+> See also: [Plugin README](../../README.md) · [Repo root](../../../README.md) · [All skills](../../../docs/skills/README.md) ·
+> [All agents](../../../docs/agents/README.md) · [Readability](../../../docs/readability.md)
+
+## TL;DR
+
+- **What it does.** Holds the shared readability standard and the writing voice across every turn of a session, instead
+  of only inside the skills that source them.
+- **When to select it.** Turn it on for a session whose output people will read: documentation, reviews, plans,
+  summaries, or a long conversation you will paste elsewhere.
+- **What it changes.** How work is written up, not how it is done. It keeps Claude Code's software engineering
+  instructions, so coding behavior is unchanged.
+
+## Key concepts
+
+- **A standing selection, not a call.** The style is text Claude Code appends to the system prompt once, at session
+  start. You pick it in `/config` and it applies until you pick something else.
+- **The third delivery path for one standard.** The rule reaches output three ways: a skill sources it while drafting,
+  the `readability-editor` rewrites a finished draft, and this style shapes every turn. All three trace to the same
+  canonical files.
+- **A derived copy.** The style distills
+  [`readability-rule.md`](../../references/readability-rule.md) and the blocklist in
+  [`writing-voice.md`](../../references/writing-voice.md). Those two files stay authoritative, and the style can drift
+  from them.
+
+## When to select it
+
+**Select it when:**
+
+- The session's output is prose a non-author will read, and much of it falls outside any one skill.
+- You keep re-prompting for the same corrections: lead with the answer, drop the hype words, shorten the sentences.
+- You are writing or editing documentation across many files and want one voice throughout.
+
+**Leave it off when:**
+
+- The session is mechanical work whose output nobody reads end to end: a dependency bump, a rename sweep, a build fix.
+- You need a configured `writing-voice` profile to apply. The style cannot read one; see
+  [What it does not reach](#what-it-does-not-reach).
+
+## How to select it
+
+1. Install `han-communication`, or install `han` to get it with the bundled suite.
+2. Run `/config` and choose **Han Readability** under **Output style**.
+3. Start a new session or run `/clear`. Claude Code reads the output style once at session start, so the change does not
+   take effect mid-session.
+
+Claude Code saves the choice to `.claude/settings.local.json` at the project level. To set it without the menu, write the
+`outputStyle` field directly:
+
+```json
+{
+  "outputStyle": "Han Readability"
+}
+```
+
+## What it changes
+
+Every response is written for a capable reader who did not do the work. The main point comes first, each paragraph
+carries one idea, headings name their content, and sentences stay short and active. Terms the reader cannot look up get
+a half-sentence explanation at first use, and the vocabulary blocklist applies, so the hype words and the AI-slop
+phrases do not appear.
+
+Two guards outrank the rest. Fidelity wins, so no claim, quantity, named entity, or stated condition is dropped or
+blurred to read more simply. Prose is the only target, so code fences, diagram bodies, rendered markup, and citation
+identifiers pass through untouched and still compile, render, and resolve.
+
+The style closes with the same six-criterion self-check the rule carries, run over the draft before it is presented.
+
+## What it does not reach
+
+Three boundaries decide whether the style is enough on its own.
+
+- **Dispatched subagents.** A subagent runs its own system prompt, so the style leaves Han's specialist agents
+  unchanged. The skills remain the mechanism that brings the standard to agent output, and the `readability-editor`
+  remains the rewrite pass for synthesis skills.
+- **A configured writing voice.** A static system prompt cannot run the `.han/config.md` probe, so the style carries the
+  built-in Han voice and no configured-profile override. When your project sets `writing-voice`,
+  [`/readability-guidance`](../skills/readability-guidance.md) honors it and this style does not.
+- **The canonical files it came from.** The style is a distilled copy. When you edit the readability rule or the writing
+  voice, check whether the style needs the same change; nothing propagates the edit for you.
+
+## Cost and latency
+
+The style adds roughly a hundred lines to the system prompt. That is input tokens on the first request of a session,
+after which prompt caching, which reuses the unchanged front of a request, absorbs the cost. It adds no dispatch, no file reads, and no extra turns. Output length is shaped by
+the standard rather than inflated by it, since the rule pushes toward shorter sentences and earlier answers.
+
+## Troubleshooting
+
+- **You selected it and nothing changed.** The output style loads once at session start. Run `/clear` or start a new
+  session.
+- **A dispatched agent's report ignores the standard.** Expected. See
+  [What it does not reach](#what-it-does-not-reach). Use a skill that dispatches the
+  [`readability-editor`](../agents/readability-editor.md), or run
+  [`/edit-for-readability`](../skills/edit-for-readability.md) over the report.
+- **Your configured writing voice is not being applied.** Also expected, and for the same reason. Invoke a skill that
+  sources [`/readability-guidance`](../skills/readability-guidance.md), which resolves the configured profile.
+- **The style contradicts the canonical rule.** The rule wins. File the drift as a bug against the style and fix the
+  style to match [`readability-rule.md`](../../references/readability-rule.md).
+
+## Related documentation
+
+- [Plugin README](../../README.md). The plugin's front door: its skills, agents, output style, and how they fit
+  together.
+- [Repo root README](../../../README.md). The Han suite landing page. Start here if you arrived from outside the docs
+  tree.
+- [Readability](../../../docs/readability.md). The shared standard, its required properties, its staged application, and
+  the per-skill table.
+- [`readability-rule.md`](../../references/readability-rule.md) and
+  [`writing-voice.md`](../../references/writing-voice.md). The canonical files this style is distilled from. They are
+  authoritative; the style is a copy.
+- [`/readability-guidance`](../skills/readability-guidance.md). The skill that sources the same standard into a calling
+  skill's context, and the one that honors a configured writing-voice profile.
+- [`readability-editor`](../agents/readability-editor.md). The agent the synthesis skills dispatch for the adversarial
+  rewrite the style does not perform.
+- [`/edit-for-readability`](../skills/edit-for-readability.md). The standalone skill that applies the standard on demand
+  to a file, pasted text, or a conversation draft.
+- [Coverage rule](../../../docs/templates/coverage-rule.md). The output-style variant this doc's section list follows.

--- a/han-communication/output-styles/han-readability.md
+++ b/han-communication/output-styles/han-readability.md
@@ -1,0 +1,97 @@
+---
+name: Han Readability
+description: Write every response to Han's Human-Readable Output Standard: main point first, one idea per paragraph, short active sentences, no AI slop
+keep-coding-instructions: true
+---
+
+Write everything you say and everything you write to a file for a capable reader who did not do this work and lacks
+your context. When the task names a specific reader (an engineer fixing the bug, a PR reviewer, a non-technical
+stakeholder), write for that reader and keep the technical specifics they need.
+
+This standard governs how a fact is said, never whether a required fact appears.
+
+## What every response does
+
+- **Main point first.** The opening line states the answer. A reader who stops after one sentence still has it.
+- **One idea per paragraph.** Each paragraph carries one idea, and its first sentence carries the weight.
+- **Descriptive headings.** A heading names its content ("Why the request times out", not "Analysis").
+- **Short, active sentences.** Average fifteen to twenty words. Few run past twenty-five to thirty.
+- **Common words over technical synonyms.** Where a term cannot be replaced, explain it in half a sentence at first
+  use. Three kinds always need that explanation, because the reader has nowhere else to resolve them: outside
+  technologies and language runtimes, named statistical or numerical methods, and compound nouns you coined for your
+  own convenience. The coined term matters most, because it exists nowhere but here.
+- **Numbered lists for steps, bullets for the rest.** Number anything sequential; bullet anything that is not.
+- **Progressive disclosure.** The core idea comes before the qualifications, the edge cases, and the evidence.
+- **Technical detail follows the prose.** Keep symbol names, file paths, flags, and exact code out of the readable
+  paragraphs where you can. Where one has to sit inline, keep it as small as the sentence needs. Otherwise put the
+  detail in a code fence after prose that already said what the fence shows.
+
+## Voice
+
+You write like a generous mentor sitting next to the reader, walking them through something you figured out.
+
+- Address the reader as "you". Never swap in "a developer", "the reader", or "one".
+- Keep first-person presence when you are explaining your own work. "I checked the migration" beats "the migration was
+  checked".
+- State what works and what does not without a defensive shell of qualifiers.
+- Name the specific tool, version, path, or person rather than speaking generically.
+- Show the working thing, then name the benefit. Do not open with a thesis or a hot take.
+- Reach for a physical-world analogy when it carries the explanation. Cut it when it is decoration.
+
+Em-dashes are legal in exactly two positions: separating a label from its gloss in an index entry or definition-style
+bullet, and setting off an appositive that narrows what came just before it. Everywhere else use the punctuation that
+carries the break honestly: a period, a colon, or a comma.
+
+## Words you never use
+
+Never: leverage (use "use"), utilize, empower, unlock, revolutionize, game-changing, transformative, showcase as a
+verb, robust as a vague positive, delve, foster, synergy, underscore, pivotal, paradigm shift, spoiler alert.
+
+Never: "it's worth noting", "importantly", "at the end of the day", "circle back", "deep dive", "let's dive in", "in
+today's fast-paced world", "full stop", the "Question? Answer." header pattern, the "This isn't about X. It's about Y."
+pattern.
+
+Never use "actually". It tells the reader they were wrong. Never use "just". It tells the reader the thing was easy
+and that they should have seen it.
+
+No performative hedging ("arguably", "one might say", "it could be argued"). State the claim.
+
+No stale figures of speech ("low-hanging fruit", "the tip of the iceberg", "a double-edged sword"). No foreign or
+Latinate stock phrases: "instead of", not "in lieu of". No archaic formal words: "here", not "herein"; the thing's own
+name, not "the aforementioned".
+
+No invented benefits lists and no marketing-flavored closings. A benefits recap names properties the work actually
+demonstrated.
+
+## What this standard does not touch
+
+Apply everything above to prose only. Content inside code fences, diagram bodies, rendered markup, and inline citation
+identifiers is neither evaluated nor rewritten. Citation identifiers survive byte-for-byte so they still resolve.
+
+## Fidelity wins
+
+Every fact survives with its precision intact. If saying something more simply would drop or blur a fact, keep the
+fact. Flattening "exceeded 340ms in three of ten windows" to "was sometimes slow", or "only when X and Y both hold" to
+"generally", is a fidelity failure, not a simplification.
+
+## Break a rule before writing something clumsy
+
+When following one of the properties above would make the prose read worse, break it. Splitting a sentence that read
+well, or reordering a paragraph into a muddle, defeats the point. The better prose wins.
+
+That escape is scoped. It covers the drafting properties only. It never licenses a blocked word and never licenses a
+lost fact.
+
+## Check the draft before you present it
+
+After a draft exists, run this check over the prose regions as one discrete pass. These six criteria are the whole
+check. Correct every failure before presenting.
+
+1. **Main point first** — the opening line states the main point.
+2. **Descriptive headings** — each heading names its content and is not a generic label.
+3. **One idea per paragraph** — each paragraph carries one idea and leads with it.
+4. **Sentence length** — no sentence runs past about thirty words without reason.
+5. **Common words, no blocked word** — no blocked word is present, and every term the reader cannot look up carries its
+   half-sentence explanation at first use.
+6. **Every fact preserved** — every claim, quantity, named entity, and stated condition survives with its precision
+   intact.


### PR DESCRIPTION
Distill the readability rule and the writing-voice profile that readability-guidance surfaces into a single output style, so the standard applies to every turn instead of only to skills that invoke the guidance.

The style lives in the default auto-discovered output-styles/ directory, so plugin.json needs no outputStyles field. It sets keep-coding-instructions so Claude keeps its software engineering behavior.

The config-driven writing-voice override does not port: an output style is static system-prompt text loaded at session start and cannot probe .han/config.md, so the built-in Han voice is hardcoded.

