### PR TITLE
fix(han-planning): correct two defects in the visual-material reference material

### DIFF
--- a/han-planning/references/planning-boundary-rule.md
+++ b/han-planning/references/planning-boundary-rule.md
@@ -79,7 +79,8 @@ answer. Those three are different states. A recorded answer of any kind is never
 ## Visual Material Received
 
 One row per piece of visual material, written as the item arrives rather than at the end of the run. `None received`
-when the run received none.
+when the run received none. In that case `None received` stands alone and the table below is omitted, because the
+completeness gate reads every row as an item claimed on disk and refuses a placeholder row.
 
 | Item | What state it depicts | Kept at |
 | ---- | --------------------- | ------- |

--- a/han-planning/skills/plan-a-feature/references/artifact-invariants.md
+++ b/han-planning/skills/plan-a-feature/references/artifact-invariants.md
@@ -36,3 +36,4 @@ Step 8's synthesis preserves these; it does not restate them.
   - The `## Cut for Scope` section carries every scope-gate cut with what it would have done and the boundary citation,
     and no entry appears in both that section and `## Deferred (YAGNI)`.
   - The `Visual Reference` table lists every item the boundary record records as received, under that exact heading, with
+    an inline embed beside the prose describing each state.


### PR DESCRIPTION
Fixes the two defects reported in #187, both in `han-planning` reference material and both about how a planning run handles visual material.

## The truncated invariant

`plan-a-feature/references/artifact-invariants.md` ended mid-clause on the `Visual Reference` invariant, stopping after the word "with". Step 8 tells the synthesizer to read that file and preserve the invariants it carries, so a run that received visual material was asked to preserve a rule whose definition was unfinished.

The missing clause was lost when the file was extracted from `SKILL.md` in d01abe6. I recovered it from that commit's parent, where the same invariant reads in full at line 655. It is restored verbatim: the table lists every item the boundary record records as received, under that exact heading, with an inline embed beside the prose describing each state.

## The empty visual-material table

`planning-boundary-rule.md` said the Visual Material Received section takes `None received` when nothing arrived, then showed the section as a table with two illustrative rows. Nothing said the table itself goes away. A run that followed the shape it was shown wrote a placeholder row, and the Step 9 completeness gate refused it, because the gate reads every row as an item claimed on disk.

The rule now says `None received` stands alone and the table is omitted, and names the gate as the reason.

## Verification

`npm run lint` passes. Both changes are prose in reference files with no script or schema behavior attached.

Closes #187.