### PR TITLE
fix: close the four defects feedback issue #194 reported in code-review and research

### DIFF
--- a/docs/plans/code-review-research-feedback-issue-194/artifacts/change-decision-log.md
+++ b/docs/plans/code-review-research-feedback-issue-194/artifacts/change-decision-log.md
@@ -1,0 +1,705 @@
+# Change Decision Log: Code Review and Research Response to Feedback Issue #194
+
+<!--
+This file records every decision committed while planning this change. The plan itself lives in
+[../change-plan.md](../change-plan.md) — this file captures the question, rationale, evidence, and rejected
+alternatives behind each decision. Evidence about the code as it stands today lives in
+[current-state-findings.md](current-state-findings.md) as numbered C-N findings.
+-->
+
+## Trivial decisions
+
+- D-13: Both long-form skill docs are updated in the same change — the doc in each plugin's `docs/skills/` is
+  canonical for its skill by the repository's own convention, and each currently states a fact this change makes
+  wrong. — Referenced in plan: Surface Delta, Change Units.
+- D-14: No plugin version is bumped and no CHANGELOG entry is written — `CLAUDE.md` assigns the changelog to the
+  `han-release` skill, and no version bump was asked for. — Referenced in plan: Change Units.
+- D-20: Three reference files get contents-list maintenance in the units that touch them — two gain an entry for a new
+  section, and the verification file gains a contents list outright, because it sits at exactly the length past which
+  the authoring guidance requires one and this change pushes it over. Raised by `han-core:junior-developer`. —
+  Referenced in plan: Surface Delta, Change Units.
+- D-15: `han-research/agents/research-analyst.md` is not changed — the analyst keeps numbering its own sources from
+  `A1`, because D-8 puts the whole fix on the orchestrator's side of the merge. — Referenced in plan: Target State.
+
+## Full decisions
+
+### D-1: The degraded mode is named, and it is not a fourth letter in the existing series
+
+- **Question:** What is the manual-only execution mode called, and does it extend the skill's existing Mode A / Mode B
+  / Mode C series?
+- **Decision:** The mode is called **`manual-only mode`**. The A/B/C letter series is not extended. The existing
+  letters enumerate one axis, how much git context the run has; whether agent dispatch is available is a second,
+  independent axis. A Mode A run with a full branch diff can be manual-only, and so can a Mode C run.
+- **Rationale:** A fourth letter would assert that the four states are mutually exclusive, which they are not. Naming
+  the mode at all is what the change is for: C-1 records that the only handling today is a step-skip sentence that
+  names no mode, and C-13 records the repository's own authoring rule that a degraded path gets a name so other
+  sites can refer to it.
+- **Evidence:** C-1, C-13. The authoring rule verbatim: "Define modes explicitly by name so the skill body and review
+  output can reference them clearly."
+- **Behavior impact:** Preserving on its own. Naming a mode changes no output; the entries that depend on this
+  decision carry the behavior changes.
+- **Rejected alternatives:**
+  - **`Mode D`** — rejected because it puts a second axis into a one-axis enumeration, and every existing site that
+    says "Mode B and Mode C" would become ambiguous about whether it also means Mode D.
+  - **Leaving the state unnamed and describing it inline at each site** — rejected because C-2 and C-3 establish
+    three separate consumers (the report block, the closing message, the verification item), and C-16 records the
+    repository's convention that a rule with several consumers gets one named home the others cite.
+- **Revisit criterion:** If agent availability and git context ever become mutually exclusive, the axes have merged
+  and one enumeration is correct.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-1, S-2, S-3
+- **Dependent decisions:** D-2, D-3
+- **Referenced in plan:** Target State, Surface Delta
+
+### D-2: The coverage disclosure renders only when coverage was absent, and it reaches the closing message too
+
+- **Question:** Where does the disclosure live, and does the report carry it on every run or only on degraded runs?
+- **Decision:** Two places. In the report, a `## Review Coverage` section at heading level two — a peer of Recommended
+  Changes, not a child of Review Summary — rendering immediately after the Review Summary block closes and **only when
+  some planned coverage was absent**, so its absence means every planned coverage ran. It is named in the template's
+  fixed section order, since a section absent from that list has no defined position. It opens with a line naming its
+  own cause, because the report's reader and the operator are different people and a reviewer on a pull request never
+  sees the closing message. Then one row per absent item:
+
+  ```markdown
+  - **Absent:** {coverage name} — {reason}; {swept by hand under {categories} | not swept — {what to do instead}}.
+  ```
+
+  Worked example:
+
+  ```markdown
+  ## Review Coverage
+
+  Agent dispatch was unavailable on this run, so no specialist read this change (manual-only mode).
+
+  - **Absent:** security review — swept by hand under Data Isolation, Error Handling, API Design. Nothing substitutes for an exploit path demonstrated against the code.
+  - **Absent:** concurrency review — not swept; no checklist category covers races or lock ordering. Check shared state and async ordering by hand before merging.
+  - **Absent:** independent validation of the findings — not swept; the findings below were not re-checked against the code by a second pass. Weigh each on its own evidence.
+  ```
+
+  Three things the grammar does deliberately, all of them corrections from the review round. The plain-English coverage
+  name leads and the agent identifier is dropped, because a reviewer on a pull request has no roster and no plugin
+  installed. Internal step numbers are gone for the same reason. And the `not swept` branch carries a clause saying
+  what to do instead, because a line with no verb aimed at the reader gets read as bookkeeping about the run rather
+  than as something addressed to them.
+
+  The population is settled once: every agent selection produced, plus the independent validation pass, which is
+  planned coverage a manual-only run cannot reach because it dispatches an agent. Selection is a fact by the time
+  detection fires, not a counterfactual.
+
+  And in the closing message, one clause appended to the run's-own-facts part, naming the cause and the consequence
+  rather than a mode name and a count:
+
+  ```
+  Medium: 6 files touched, adds one index. Agent dispatch was unavailable, so no specialist read this change; 8 of 11
+  coverage areas were swept by hand and 3 were not. See Review Coverage in the report.
+  ```
+
+- **Rationale:** The report is where the issue asks for it, in as many words, and a fixed home is what it asks for.
+  The closing message carries it too because the message is what a person reads first and the report is a file they
+  may not open; a disclosure only in the file would leave the reported failure half-fixed. Conditional rendering
+  rather than an always-present section follows the template's own lazy-section rule, which C-2 quotes, so the
+  disclosure costs nothing on a healthy run.
+- **Evidence:** C-2 (no surface exists today, and the lazy-section rule that governs any new one), C-3 (the closing
+  message's four parts, with part 4 already the home for the run's own conduct), C-14 (the sibling skill that already
+  discloses a coverage gap in both its artifact and its summary, with the stated purpose "so the coverage gap is
+  visible rather than silent"). The work item asks for it directly: "the report must record which specialist coverage
+  was absent. Add a matching line to the report template so the disclosure has a fixed home."
+- **Behavior impact:** **Changing.** A degraded run's report gains a section it did not carry, and every run's
+  closing message can gain a clause. The observer is the person reading the report and the operator in the turn. The
+  work item asks for both in its suggested fix, so the recorded boundary is the decision on it; no separate operator
+  answer was sought. Named in the run's closing summary as a behavior change.
+- **Rejected alternatives:**
+  - **An always-present Review Coverage section stating full coverage on healthy runs** — rejected because it
+    contradicts the template's lazy-section rule that C-2 quotes, and it puts a line on every report to carry
+    information the absent case already conveys. Recorded as a YAGNI candidate with its reopen trigger.
+  - **The report only, with no closing-message clause** — rejected because the report is a file the run explicitly
+    never pastes into the conversation, so a reader who stops at the message would learn nothing about the gap. That
+    is the reported failure at one remove.
+  - **A row in the Review Summary table instead of its own section** — rejected because that table is defined as an
+    index of findings, one row per finding, and absent coverage is not a finding.
+- **Revisit criterion:** A reader who needs positive confirmation that coverage was complete — an auditor, or someone
+  weighing an old approval months later — appearing as a real reader of these reports. The review round sharpened this
+  trigger: the risk is not that a reader draws a wrong inference from silence, because the default reading of silence
+  matches the truth. The risk is that a reader wanting assurance has nothing to read.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-4, S-5, S-6, S-7
+- **Dependent decisions:** —
+- **Referenced in plan:** Target State, Surface Delta, Behavior Changes
+
+### D-3: The mode is detected by the dispatch mechanism failing, never by an empty result
+
+- **Question:** How does a run learn that agent dispatch is unavailable, and how does it avoid mistaking an agent with
+  nothing to say for an agent that never ran?
+- **Decision:** Two triggers, both about the mechanism: the dispatch tool is unavailable, or the dispatch call is
+  denied. **An empty or silent agent result is not a trigger.** No new probe and no change to the existing detection
+  script. The line the run emits:
+
+  ```
+  Manual-only mode: agent dispatch unavailable ({verbatim tool error, or "Agent tool not in allowed-tools"}).
+  Manual review is the primary path. Coverage absent: junior-developer, security, and every conditional agent
+  Step 3.2 selected. See the sweep mapping for what substitutes.
+  ```
+
+- **Rationale:** Nothing earlier in the run can know the answer. C-4 records that selection reasons only about signals
+  in the changed-file list and that the frontmatter lists the dispatch tool beside every other tool with no guard, so
+  the first moment the state is observable is the dispatch itself.
+
+  The exclusion of empty results is the correction the review round forced, and it matters more than the rest of this
+  decision. An earlier draft counted "every dispatched agent fails to return" as a third trigger. C-4 quotes the roster
+  entry for the always-dispatched security agent: "the agent stays silent when the standard is not met." A run reading
+  that silence as failure would enter the mode, sweep by hand, and print a disclosure claiming security coverage was
+  absent on a run where it ran and passed. **A false disclosure is worse than the silent one this change exists to
+  fix**, because the whole point of the block is that a reader can trust what it says.
+- **Evidence:** C-4, C-13. C-13 records the one difference from the existing git modes that matters: those are probed
+  by a script before the work starts, and a shell script cannot observe whether a model's tool call will be permitted.
+  The silent-agent case was raised by `han-core:junior-developer` in the review round and confirmed against the roster
+  text.
+- **Behavior impact:** Preserving on its own. Detection produces a recorded line; the observable changes belong to the
+  disclosure and the sweep.
+- **Rejected alternatives:**
+  - **Counting an empty agent result as a trigger** — rejected on the evidence above.
+  - **A new probe in the shared repo-root `scripts/`** — rejected as cross-plugin infrastructure carrying its own Bats
+    tests, for a state the dispatch attempt already reveals. Deferred with a reopen trigger.
+  - **Extending the existing detection script** — rejected on the same grounds plus a concrete one: a shell script
+    cannot observe whether a model's tool call will be permitted.
+- **Revisit criterion:** If a host exposes tool availability to a shell script, the probe becomes the cheaper
+  detection. If an agent is ever specified to fail silently in a way indistinguishable from passing silently, the
+  exclusion needs revisiting.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-1, S-3
+- **Dependent decisions:** —
+- **Referenced in plan:** Target State, Surface Delta
+
+### D-4: The by-hand sweep is a stated mapping from each absent agent to checklist categories
+
+- **Question:** What does "sweep the specialist categories by hand" mean concretely, so a run does the same thing
+  twice?
+- **Decision:** A mapping stated in `agent-dispatch.md`'s new manual-only section, one line per agent, pinned by a
+  grammar line and worked entries:
+
+  ```
+  - `{agent}` → sweep by hand under {review-checklist category}, {category} — at the {size} band from Step 3.1.
+  - `han-core:test-engineer` → sweep by hand under Testing, Correctness — at the {size} band from Step 3.1.
+  - `han-core:adversarial-security-analyst` → sweep by hand under Data Isolation, Error Handling, API Design — at the {size} band from Step 3.1.
+  ```
+
+  The mapping is written out in the plan for every agent on the roster, plus a fallback row form for an agent a project
+  config's `## Extra Agents` list contributes, which cannot be pre-mapped because the file has never heard of it.
+
+  **Writing it out changed what this decision is worth, and the plan says so.** Four of the roster's agents have no
+  checklist counterpart or only a partial one: concurrency and infrastructure coverage is recovered not at all, and
+  security and resilience coverage only in part. An earlier draft showed two rows and implied the sweep recovered most
+  of what was lost. It does not, and the honest result is that the disclosure matters more than the sweep does.
+
+- **Rationale:** C-5 establishes that the manual checklist runs at its normal depth whether the agents ran or not, and
+  that nothing conditions its scope on the dispatch outcome. A sweep instruction with no mapping would leave the
+  substitution to each run's judgment, which is the state C-5 already describes. Naming the band is what the work
+  item asks for.
+- **Evidence:** C-5, C-7 (the checklist's category names the mapping's right-hand side draws on). The work item:
+  "the specialist categories the roster would have covered should be swept by hand at the same size band".
+- **Behavior impact:** **Changing.** A manual-only run raises findings it did not raise before, in the mapped
+  categories. The observer is the author of the change under review. The work item asks for the sweep in its
+  suggested fix, so the recorded boundary is the decision on it. Named in the run's closing summary.
+- **Rejected alternatives:**
+  - **"Review more carefully when no agents ran"** — rejected because it is not a mapping and two runs would do
+    different things.
+  - **Dispatching nothing and disclosing only** — rejected because it discards the coverage the work item asks to
+    recover, and the disclosure alone would report a gap the run made no attempt to close.
+- **Revisit criterion:** If an agent's coverage is found to have no checklist counterpart at all, that agent's row
+  says "nothing substitutes" rather than naming a category that does not cover it.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-1
+- **Dependent decisions:** —
+- **Referenced in plan:** Target State, Surface Delta, Behavior Changes
+
+### D-5: The Packaging category names the gap rather than inspecting the artifact
+
+- **Question:** Does a `code-review` run open a built artifact when the diff changes what gets packaged, or does it
+  report that it did not?
+- **Decision:** It reports. A new `Packaging (when applicable)` category in `review-checklist.md` triggers on a diff
+  that changes what gets packaged and raises an ordinary review finding. The run acquires no new command permission
+  and opens no archive. The category matches the shape C-7 records: an entry in the file's contents list and a
+  heading, both carrying the `(when applicable)` suffix, over a bullet list of concrete triggers.
+
+  The triggers, which are the diff signals the category watches for: shading or relocation rules, vendoring, include
+  and exclude patterns, dependency scope changes, and bundling configuration.
+
+  What the finding must state, pinned as a worked example so two runs write the same thing:
+
+  ```markdown
+  **WARN-002** `build.gradle:41` Someone installs the published jar and calls `WidgetFactory.create`, and it fails at
+  startup with a missing-class error, because the exclude rule added here drops a class that surviving classes still
+  reference. This review did not open the built artifact and cannot tell you whether that happened: the exclude
+  patterns say what was removed, not what still points at it. A green build is not evidence either, because a
+  development run has a wider classpath than the shipped artifact. Check the produced artifact before merging: that
+  every internal reference resolves inside it, that no third-party package is exported unrelocated, and that the
+  licence notices the packaging requires are present. **Fix:** by hand.
+  ```
+
+  **Severity:** WARN by default, since the finding names work the author has to do rather than a defect the review
+  proved. It follows the size-based demotion in Step 3.3 like every other manual finding.
+
+  **The first sentence varies with the diff; the rest is fixed.** The category says so explicitly. Without that, a
+  builder can satisfy this decision by pasting the worked example with the path swapped, and every packaging review
+  then carries five identical sentences that a reader stops reading by the third. The first sentence names the specific
+  rule the diff added and the specific symptom it could produce.
+
+  **The summary-table row opens with `Not checked —`**, matching the `May never fire —` cue the template already uses to
+  mark a finding class a triaging reader should weigh differently, and placed for the same stated reason: so a person
+  triaging thirty findings gets the cue before opening any one of them. Without it, a row saying the review did not look
+  sits at the same visual weight as a proven defect.
+
+  **Mode scope**, stated inside the category rather than only in its caller:
+
+  ```
+  **Mode scope.** This category applies in Mode A only. Step 4's Mode B and Mode C conservative rule admits only
+  focus-area items, source-file items, and file-boundary items, and without a base-branch diff the run cannot tell
+  what the change altered about packaging. Same reason the YAGNI checklist is suspended in those modes.
+  ```
+
+- **Rationale:** The operator was asked how far a review run should reach into build output and chose the
+  disclosure. Their words: **"option b"**, against a question that named the alternative as opening the archive and
+  reporting the dangling reference, and named the cost of that alternative as a standing command permission
+  auto-approved on every future review including on repositories that build nothing.
+
+  C-7 supplies the shape, so this is an extension of an extensible list rather than a change to the review procedure.
+  Stating the mode scope inside the category answers C-18 directly: that finding records the YAGNI section asserting
+  its procedure unconditionally while its caller suspends it in two modes, and a new category repeating that mistake
+  would be avoidable at the cost of one paragraph.
+- **Evidence:** operator answer (verbatim: "option b"), C-6, C-7, C-18. The work item asks for the trigger and for
+  the dev-classpath caveat, both of which this carries. It asks for the inspection, which this does not do; see
+  Behavior impact. The variance requirement and the summary-row cue were both raised by
+  `han-core:user-experience-designer` in the review round, the second against the plan's own stated risk that this
+  finding degrades into a warning people learn to skip.
+- **Behavior impact:** **Changing.** A Mode A review of a diff that alters packaging raises a finding it did not
+  raise before. The observer is the author of the change. Settled by the operator's answer above rather than by the
+  work item, because the work item and the operator diverge here.
+
+  **Say plainly what this does not do.** The work item asks the run to inspect the produced artifact, and this does
+  not inspect it. The defect that prompted the work item, an exclude rule dropping a class that surviving classes
+  still called, is not caught by this category. What changes is that a reviewer is told the review has that hole and
+  what to check by hand, instead of a silent pass. That is a smaller fix than the work item asked for, and it is the
+  fix the operator chose after being told so.
+- **Rejected alternatives:**
+  - **Opening the artifact with a narrow read-only command permission** — rejected by the operator. It was the
+    recommended option and it is the only one that closes the reported defect. Reopening it means adding the
+    narrowest reader prefixes plus a "could not inspect" branch for a missing reader or an unbuilt artifact.
+  - **Asking the operator mid-run to run one command and paste the output** — rejected: the skill's design writes a
+    file and explicitly never pastes the review into the conversation, so a stop for input cuts across it.
+  - **Grepping source imports against the build config's exclude patterns** — rejected on stronger grounds than
+    cost. Bytecode references are a superset of source imports, so this method produces confident passes on exactly
+    the reported failure mode. It is worse than disclosing, because disclosing admits the gap and this hides it.
+  - **Three bullets appended to `Code Organization`** — rejected because C-7 records that category as a
+    file-placement rule with no conditional suffix, so a diff-triggered item there would run on every review and
+    would have nowhere to state its mode scope.
+  - **A row in the coverage block from D-2** — rejected because that block records coverage that was planned and did
+    not happen. Under this decision the run never plans to inspect an artifact, so the absence is the skill's
+    designed scope rather than a gap in a particular run.
+- **Revisit criterion:** A reported instance of a packaging defect reaching production through a review that carried
+  this finding reopens the inspection option.
+- **Left open rather than settled:** this finding is a warning, and the template turns any warning into a recommendation
+  that the code not be approved as-is. So a Mode A review of a build-configuration change with nothing wrong stops
+  saying the code can be approved. The summary-row cue is the mitigation available inside the template's existing
+  vocabulary. Exempting the recommendation line itself changes what an approval means, which is the operator's call and
+  not this plan's; it is carried in `## Open Items`.
+- **Dissent (if any):** None recorded. The plan recommended the inspecting option and the operator chose otherwise;
+  that is a decision, not a dissent.
+- **Settles delta entry:** S-8
+- **Dependent decisions:** D-6
+- **Referenced in plan:** Target State, Surface Delta, Behavior Changes
+
+### D-6: The location rule fires on the region-read path, which is the one that survives D-5
+
+- **Question:** D-5 means a run never opens compiled output, so no finding can cite a location inside an archive. Does
+  defect 3's fix still have anything to fire on, and if so, what?
+- **Decision:** Yes, on one specific current path. Step 4 reads a file over a thousand lines by its changed regions and
+  their surrounding context rather than whole. **A location established from a region read is the work item's failure
+  at a reachable altitude**: you find a hit in a region, you look upward for the nearest declaration, and the
+  declaration the region happened to include may not be the one that encloses it.
+
+  The rule: when a finding's location was established by reading a region of a file rather than the unit that contains
+  it, read the enclosing unit in isolation before writing the finding, and never carry forward the nearest declaration
+  the region included. It lives in `finding-content.md`, which owns what every finding carries and is loaded at the
+  drafting step, the moment the work item names.
+
+  The location form:
+
+  ```
+  **CRIT-003** `src/billing/reconciler.rb:2841` (enclosing member: `Reconciler.retry_batch`, confirmed by reading
+  lines 2790-2860 in isolation) {explanation} … **Fix:** by hand.
+  ```
+
+  A finding from a file the run read whole carries no such note.
+
+- **Rationale:** This is the second home this rule has had, and the review round is why. An earlier draft aimed it at
+  "machine-generated output the run reads", naming two populations. `han-core:junior-developer` established that
+  neither is real: C-6 quotes Step 4 instructing the run to skip generated files outright, and automated-check output
+  already emits its own file and line rather than requiring a scan. The draft was spending three delta entries and a
+  change unit on a rule with nothing to fire on, and the finding was right.
+
+  The region-read path is different in kind, because the run is instructed to take it. It is not a population the plan
+  went looking for to keep a fix alive; it is the one place the procedure itself creates the conditions the work item
+  describes.
+- **Evidence:** C-8 (the skill's only instruction about a location is to include one, and the check that looks like
+  verification resolves the path against a file list instead of reading the code), C-6 and D-5 (why the archive and
+  generated-file populations are unreachable), and Step 4's own instruction to read a large file by its changed regions
+  and their surrounding context. The correction was raised by `han-core:junior-developer`.
+- **Behavior impact:** **Changing.** Such a finding carries a form it did not carry, and confirming the unit can change
+  which unit the finding names, which can change its severity. The observer is the report's reader.
+
+  **Say plainly what this does not do.** The work item's own example is a hit inside a class's static initializer
+  attributed to the method printed before it in disassembler output. Under D-5 a run never disassembles anything, so
+  that case cannot arise and this rule does not catch it.
+- **Rejected alternatives:**
+  - **Deferring defect 3's fix entirely**, which the review round offered as the alternative — rejected because the
+    region-read path makes the failure reachable, so a deferral would leave a real gap while claiming the situation
+    could not arise.
+  - **Aiming the rule at generated files on the diff or at automated-check output** — rejected on the evidence above.
+    This was the draft's own position and it was wrong.
+  - **Keeping the `{artifact-path}!{member-path}#{member-name}` grammar** — rejected because after D-5 nothing can
+    produce such a location.
+  - **Generalizing to every cited location** — rejected as a YAGNI candidate. The cost would land on all thirty
+    findings a capped review can carry, and no finding supports it.
+  - **Amending `output-verification.md` item 6** — rejected. Item 6 resolves a path against the Step 1 file list, and a
+    large source file read in regions is on that list, so item 6 passes unamended.
+- **Revisit criterion:** If D-5 is reopened and a run gains the ability to read an archive, the archive grammar comes
+  back with it.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-9
+- **Dependent decisions:** D-7
+- **Referenced in plan:** Target State, Surface Delta, Behavior Changes
+
+### D-7: The attribution rule is guarded in two places, because each is absent when the other runs
+
+- **Question:** Where does the check on D-6's rule live?
+- **Decision:** Both places. A fifth challenge axis in the Step 7.4 validator brief, appended to the lettered list
+  C-9 records:
+
+  ```
+  (e) findings whose cited location was carried forward from a scan of machine-generated output rather than
+  confirmed by reading the enclosing unit, and any finding whose severity depends on which unit the location names.
+  ```
+
+  And a new structural verification item that runs in every mode, asserting that a finding whose location came from
+  scanning machine-generated output names its enclosing unit and how that unit was confirmed.
+- **Rationale:** Neither guard covers the other's gap. C-9 records that Step 7.4 does not run when a review produced
+  no corrective findings, and after D-1 it cannot run at all in manual-only mode, since it dispatches an agent. So
+  the axis alone would be absent in exactly the degraded run defect 1 describes. The verification item alone would
+  confirm a form was followed without anyone re-reading the code, which is the existence-versus-correctness failure
+  the work item is about.
+- **Evidence:** C-8, C-9, D-6. The work item: "treat a severity that depends on the location as a reason to confirm
+  it twice."
+- **Behavior impact:** **Changing.** A finding may now be demoted or dropped that previously stood. The observer is
+  the report's reader.
+- **Rejected alternatives:**
+  - **Axis (e) alone** — rejected on the C-9 evidence above: it is absent in the run that needs it most.
+  - **The verification item alone** — rejected because it checks compliance with a form, not the attribution.
+- **Revisit criterion:** A misattributed location surviving both guards in a real run.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-10, S-11
+- **Dependent decisions:** —
+- **Referenced in plan:** Target State, Surface Delta, Behavior Changes
+
+### D-8: The traceability invariant is two-part, and it is defined in one place
+
+- **Question:** What is the invariant after this change, and which of its four current statements defines it?
+- **Decision:** Two-part, defined in `research/SKILL.md`'s Operating Principles and nowhere else. The sentence it
+  carries:
+
+  ```
+  The traceability invariant is two-part. Resolvability: every `A#` cited inline resolves to a registry entry carrying
+  its link, retrieval date, trust class, and evidence status. Support: the cited entry's `Summary (one line)` states
+  something that bears on the claim the citation is attached to. Resolvability is necessary and not sufficient.
+  ```
+
+  Step 6, Step 8, and the report template's `Sources` comment stop defining it and cite it by name. Step 8's existing
+  resolution line becomes the two-part check rather than gaining a new pass beside it.
+
+- **Rationale:** C-10 records the invariant stated identically in four places. Strengthening it in one place and
+  leaving three copies asserting the weaker form is the drift the repository's authoritative-home convention exists
+  to prevent, and C-16 records that convention with a worked instance in this same area. The support half needs no new
+  input: C-12 records that the registry table already carries the one-line summary the check reads, so the check adds
+  no field to the template and asks nothing new of any analyst.
+- **Evidence:** C-10, C-12, C-16. The work item: "State in the skill that syntactic resolvability is necessary but
+  not sufficient."
+- **Behavior impact:** **Changing.** A run must now check support, so a citation may be rewritten that previously
+  stood. The observer is the report's reader. The work item asks for it directly.
+- **Rejected alternatives:**
+  - **Amending all four statements in place** — rejected because it preserves the four-way duplication C-10 records,
+    and the next change to the invariant would have to be made four times again.
+  - **A new `references/citation-integrity.md`** — rejected under D-11.
+- **Revisit criterion:** If a second skill adopts the invariant, its home moves to a shared reference file and both
+  skills cite it.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-12, S-15, S-16, S-20
+- **Dependent decisions:** D-9, D-10
+- **Referenced in plan:** Target State, Surface Delta, Behavior Changes
+
+### D-9: The merge records an old-to-new mapping, and the rewrite covers the evidence-status field
+
+- **Question:** What form does the mapping take, and which citation surfaces are rewritten through it?
+- **Decision:** A mapping built at Step 6, the step that already renumbers, pinned as a field layout with worked
+  rows:
+
+  ```markdown
+  | Analyst angle       | Local ID | Source                          | Merged ID | Disposition                        |
+  | ------------------- | -------- | ------------------------------- | --------- | ---------------------------------- |
+  | messaging-patterns  | A1       | Kafka docs, exactly-once        | A1        | renumbered                         |
+  | messaging-patterns  | A2       | Fowler, "What do you mean by X" | A2        | renumbered                         |
+  | delivery-semantics  | A1       | Fowler, "What do you mean by X" | A2        | merged into A2 (same source as messaging-patterns A2) |
+  | delivery-semantics  | A2       | vendor blog, undated            | —         | dropped (not relevant to the results) |
+  ```
+
+  The mapping is a working record the run holds while it renders, not a report section: nothing in the report reads it,
+  and persisting it is a deferral with its own trigger. The `Source` column is what makes it checkable, since without it
+  nobody can join a row back to the analyst output it came from.
+
+  Both of the skill's inline enumerations of the registry table's columns gain the one-line summary column in the same
+  unit. The support check reads that column, and a run following the skill rather than the template would render a
+  table the check cannot read.
+
+  The rewrite covers every `A#` in Research Results, in each Option's `Rests on`, in the Recommendation's
+  `Evidence basis`, **and inside every `Evidence status` field** — `corroborated by {A#}` and
+  `contradicted by {A#}` — in both the registry table's last column and each `A#` detail block. Step 7 passes the
+  mapping to the validator alongside the registry it already receives.
+- **Rationale:** C-11 establishes that the collision is structural rather than incidental above the small band,
+  because every analyst in a wave restarts at `A1`, and that "merging duplicates" is itself a renumbering, so the
+  merge cannot preserve any analyst's numbering even in principle. The evidence-status field is on the list because
+  C-19 records it as a citation surface nobody names: it is written by an analyst against that analyst's own local
+  numbering and it lives inside the registry being renumbered. A rewrite covering only prose would leave it stale,
+  which fixes half the defect.
+- **Evidence:** C-11, C-19, C-20. The work item: "Where a merge renumbers identifiers, record the old-to-new mapping
+  and rewrite citations through it rather than by hand." Three corrections came from `han-core:junior-developer` in the
+  review round: the earlier worked example mapped three different local identifiers to one merged identifier with
+  contradictory dispositions and carried no source column; the mapping's home was specified two contradictory ways; and
+  the summary column the support check reads is absent from both of the skill's own column enumerations.
+- **Behavior impact:** **Changing.** A citation may be rewritten to a different identifier than the one an analyst
+  wrote. The observer is the report's reader. The work item asks for it directly.
+- **Rejected alternatives:**
+  - **The support check alone, rewriting citations by reading** — rejected because rewriting by hand is the thing
+    that already failed, and C-11 establishes that at medium and large every analyst restarts at `A1`, so there is
+    nothing for a careful reader to anchor on.
+  - **Per-analyst identifier prefixes so no collision occurs** — rejected as a YAGNI candidate, and on a concrete
+    ground beyond that. C-21 records why the equivalent immunity is free in `code-review`: its prefixes are
+    per-agent-type identities. In `research` every analyst is the same agent type, so a prefix would have to be a
+    dispatch-order index passed in the brief, adding a brief field and coupling the identifier space to roster order.
+- **Revisit criterion:** A run where a citation was rewritten wrongly despite the mapping reopens the prefix option.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-13, S-14
+- **Dependent decisions:** D-10
+- **Referenced in plan:** Target State, Surface Delta, Behavior Changes
+
+### D-10: A claim whose only source the merge dropped is labeled no-evidence, not single-source
+
+- **Question:** What happens to a claim whose cited source the merge dropped as not relevant to the results?
+- **Decision:** The claim either loses its citation and carries the canonical no-evidence label with a reopen
+  trigger, or it is dropped along with its source. It is **not** relabeled `[single-source]`, and in strict mode it
+  cannot support the recommendation.
+- **Rationale:** This corrects the architect's proposal, which pinned the dropped case as
+  "marked `[single-source]` or `[reasoning]` per the evidence mode". Two things are wrong with that. A claim whose
+  only source was dropped has no source, not one, and the canonical evidence rule forbids exactly that collapse in as
+  many words. And `[reasoning]` is defined as an exploratory-mode-only label, so in strict mode it is not available.
+- **Evidence:** C-20 (the dropped case has no stated handling today) and the canonical evidence rule's third
+  principle, verbatim: "Do not collapse 'no evidence' into 'very weak evidence.' They are different states." Settled
+  from evidence; no operator question was needed.
+- **Behavior impact:** **Changing**, inheriting D-9's classification. A claim's evidence label can change and a
+  recommendation can lose support it appeared to have. The observer is the report's reader. The direction is toward
+  the canonical rule the skill already loads, so the change reduces a divergence rather than introducing one.
+- **Rejected alternatives:**
+  - **Marking the claim `[single-source]`** — rejected because the canonical rule this skill loads forbids the
+    collapse, and because it would overstate the evidence in the one case the reader most needs it not overstated.
+  - **Keeping the source in the registry rather than dropping it** — rejected because it would override the merge's
+    own relevance filter from downstream, and a registry padded with sources nothing cites is a different defect.
+- **Revisit criterion:** If the canonical evidence rule's no-evidence pattern changes, this follows it.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-13
+- **Dependent decisions:** —
+- **Referenced in plan:** Target State, Surface Delta, Behavior Changes
+
+### D-11: No new reference file, and no shared rule generalizing the three citation defects
+
+- **Question:** Does any of the four fixes earn a new reference file, and does the shared shape the work item names
+  earn a shared rule?
+- **Decision:** No to both. Every rule lands in a file that already exists. The shared shape is stated in the work
+  item and in this plan's own framing, and nothing executable is extracted from it.
+- **Rationale:** Two independent reasons for the file half. Three of the four fixes land in lists that are already
+  extensible: C-7's conditional-category shape, C-9's lettered challenge axes, and the numbered verification items. And
+  C-15 quotes the authoring rule that every reference file is linked directly from its `SKILL.md`, never
+  reference-to-reference, so each new file spends body lines a 495-line file against a 500-line ceiling does not
+  have.
+
+  For the shared-rule half, the shape is a description rather than an instruction. The three mechanisms are
+  inspecting an archive's internal references, isolating an enclosing member from compiled output, and rewriting
+  identifiers through a merge mapping; they share a moral, not a procedure. C-21 removes the only candidate second
+  consumer for the identifier half by establishing that `code-review`'s own fan-out cannot produce the collision. And
+  C-17 records that the natural home would be a vendored file, making it a multi-plugin edit with a re-sync
+  obligation. An abstraction with one consumer per mechanism and no named second consumer is the
+  single-implementation anti-pattern the YAGNI rule names.
+- **Evidence:** C-7, C-9, C-15, C-17, C-21.
+- **Behavior impact:** Preserving. This decision is about where rules live, not what a run does.
+- **Rejected alternatives:**
+  - **`references/degraded-modes.md`, `references/built-output-review.md`, `references/citation-integrity.md`** —
+    each rejected on the two grounds above. Recorded as YAGNI candidates with reopen triggers.
+  - **A shared "a reference must point at the right thing" rule in `han-core/references/`** — rejected as above, and
+    deferred rather than dropped, with the trigger named.
+- **Revisit criterion:** A third skill needing identifier-mapping-after-merge, or a second skill consuming any one of
+  these rules, reopens the corresponding file.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** — (shapes the plan without committing one entry)
+- **Dependent decisions:** D-1, D-5, D-8
+- **Referenced in plan:** Target State, Deferred (YAGNI)
+
+### D-12: Escalation register — the one question this run took to the operator
+
+- **Question:** How much reach should a `code-review` run have into build output: should the skill acquire the
+  permission to open and read a compiled artifact, or stop at naming the gap and disclosing it?
+- **Decision:** Stop at naming the gap. The operator's answer, verbatim: **"option b"**.
+- **Rationale:** This is the run's only escalation, and it reached the operator because the repository could not
+  settle it. What the repository did settle, and what therefore stayed out of the question: no rule forbids a new
+  command permission, the authoring guidance's standard on the subject is granularity rather than an allowlist, and
+  the security guidance says nothing about which commands a skill may run. What was left was a judgment about what
+  this skill is for, and what a standing permission costs on every future run.
+
+  The question as put named three candidate answers and a recommendation. It opened with a concrete outcome rather
+  than a mechanism: someone reviews a branch that changes which compiled classes get bundled into a shipped jar, the
+  exclude list drops a class three surviving classes still call, the build passes, and the reviewer is asked what
+  they should see. Option A opened the archive and reported the dangling reference, at the cost of a command
+  permission auto-approved on every later review including on repositories that build nothing. Option B reported
+  that the review did not look. Option C stopped mid-run to ask the operator for one command's output. The
+  recommendation was A, with the reason stated plainly: B does not close the defect the work item reported. The
+  operator was told that before answering and chose B.
+- **Evidence:** operator answer. The reframe that preceded it came from `han-core:junior-developer` in conversational
+  mode and settled five sub-questions from the repository, leaving one for the operator. One claim in that reframe
+  was wrong and was corrected before the question went out: it reported `Bash(make *)` and `Bash(npm *)` as stale
+  grants unused by the skill, but Step 2 runs whatever test, lint, and build commands it discovered from project
+  config, which is what those prefixes exist for.
+- **Behavior impact:** Changing, through D-5 and D-6, which this decision governs.
+- **Rejected alternatives:** Recorded in full under D-5.
+- **Revisit criterion:** Recorded under D-5.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-8, S-9
+- **Dependent decisions:** D-5, D-6
+- **Referenced in plan:** Behavior Changes, Open Items
+
+### D-18: The disclosure has to survive to the pull request, so the skill that posts it is in scope
+
+- **Question:** The coverage disclosure is written into a report file. Does it reach the people who read that report on
+  a pull request?
+- **Decision:** Not as things stand, so `han-github/skills/post-code-review-to-pr` is brought into the change. It names
+  Review Coverage among the optional sections it carries across from the report, and exempts it from the clarity pass's
+  length-matching instruction alongside the Review Summary table and the Review Recommendation.
+- **Rationale:** That skill builds the public pull request body from the report file and enumerates the optional
+  sections it expects to find, a list this new section would not be on. Its clarity pass then instructs the run that
+  every finding earns its place by naming a specific problem at a specific location, and to skip filler sections. **A
+  coverage disclosure names no problem at any location by construction**, so it is the most deletable block in the body
+  by that skill's own stated bar, and the pass is carried out by a dispatched agent applying the bar as written.
+
+  Left alone, the fix for the first defect would survive on the two surfaces with the narrowest audiences and vanish
+  from the one with the widest. A reviewer on a pull request sees neither the terminal nor the report file. That is the
+  reported failure reproduced one level out, in a skill the plan had not looked at.
+- **Evidence:** raised by `han-core:user-experience-designer` in the review round and confirmed by reading the skill's
+  own step text. The scope authority is the operator's answer in the confirmation turn, quoted in
+  `artifacts/scope-boundary.md`: "expand to other files where it fits." This fits: the YAGNI evidence is a named direct
+  dependency, since S-4 cannot reach that audience without it.
+- **Behavior impact:** **Changing.** A pull request body from a degraded run carries the coverage section. The observer
+  is every reviewer on that pull request.
+- **Rejected alternatives:**
+  - **Leaving the skill alone and accepting the loss** — rejected because the pull request is the widest audience the
+    disclosure has, and losing it there is losing most of the fix.
+  - **Wording the section so it reads as a finding at a location** — rejected because it is not one, and dressing it as
+    one to survive a filter would put it in the summary table, which indexes findings.
+- **Revisit criterion:** If the posting skill's clarity pass is ever rewritten to reason about section kinds rather than
+  about findings, the exemption may become unnecessary.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-21
+- **Dependent decisions:** —
+- **Referenced in plan:** Surface Delta, Behavior Changes, Change Units
+
+### D-19: The guidance's placement rule is noted and not followed, with the reason recorded
+
+- **Question:** The authoring guidance says conditional logic belongs in a `SKILL.md` body and domain knowledge such as
+  templates, checklists, and decision matrices belongs in a reference file. S-1 puts an execution mode's detection rule
+  and branch in a reference file. Is the placement wrong?
+- **Decision:** Keep the placement. Record the tension rather than leaving it implicit.
+- **Rationale:** Two things outweigh the general rule here. That reference file already carries the dispatch steps the
+  mode belongs to, and C-16 records it as an authoritative home for a cross-file rule, so the in-file precedent is
+  specific where the guidance is general. And the body has no room: C-15 puts it five lines under a ceiling that two
+  commits in the recorded history exist to enforce.
+
+  What the review round correctly objected to was the plan's reasoning rather than its conclusion. The draft justified
+  the location by line count, and the guidance would ask what kind of content it is. Both answers point the same way
+  here; recording that they are different questions is what keeps a later reader from generalizing the line-count
+  argument to a case where they diverge.
+- **Evidence:** raised by `han-core:junior-developer` in the review round. C-15, C-16.
+- **Behavior impact:** Preserving. This decision changes where a rule is written, not what a run does.
+- **Rejected alternatives:**
+  - **Putting the detection rule in the body** — rejected on the headroom evidence, and because it would split the mode
+    across two files with the branch in one and its mapping in the other.
+- **Revisit criterion:** If the body gains substantial headroom and the mode grows a second branch, the placement is
+  worth reconsidering on the guidance's own terms.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** —
+- **Dependent decisions:** —
+- **Referenced in plan:** Review Findings
+
+### D-16: The headroom unit runs only if the measured line count at build time requires it
+
+- **Question:** Does the change need to free lines in `code-review/SKILL.md` before adding pointers to it?
+- **Decision:** Conditionally. Step 8 of that skill restates the template's own lazy-section and fixed-order rules in
+  substantially the same words, and `template.md` is loaded at Step 8 on every run, so the restatement can collapse
+  to a pointer under the same convention C-16 records. That unit runs only when the line count measured at build time
+  leaves less headroom than the pointers this change adds. The measurement decides, not this plan.
+- **Rationale:** C-15 records the file at 495 lines against a 500-line ceiling and twenty-eight commits in ninety
+  days. Both numbers matter: the first says headroom is nearly gone, the second says the number will have moved by
+  the time anyone builds this. Committing the unit unconditionally would spend a change nobody may need; omitting it
+  would leave the builder stuck.
+- **Evidence:** C-15, C-16.
+- **Behavior impact:** Preserving. No output changes. The only reader at risk is a run that skips reading
+  `template.md`, which Step 8 already instructs it to read.
+- **Rejected alternatives:**
+  - **Running it unconditionally** — rejected because the file may have headroom by build time and the change would
+    then be unmotivated.
+  - **Letting the body exceed the ceiling** — rejected because two commits in the recorded history exist only to
+    bring skill bodies back under it.
+- **Revisit criterion:** Measured headroom at build time is the criterion; it is not revisited otherwise.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** S-17
+- **Dependent decisions:** —
+- **Referenced in plan:** Change Units
+
+### D-17: Two gaps the discovery round found are cut for scope, and named for the operator
+
+- **Question:** The discovery round found two real gaps feedback issue #194 does not report. Do they join this change?
+- **Decision:** No. Both are cut, recorded in the plan's cut list, and named in the run's closing summary so the
+  operator can reinstate either.
+- **Rationale:** The recorded boundary is issue #194 and its four defects. The operator widened the area to files
+  outside the two skill folders where a fix belongs there, which is a statement about *where* the four fixes may
+  land, not about which defects the change addresses. Neither gap is a necessity of any of the four, so the scope
+  gate's floor does not save them.
+
+  The two:
+
+  - **C-18.** `review-checklist.md`'s YAGNI section states its two-pass procedure unconditionally, while Step 4
+    suspends it in the two modes that have no diff. A reader who opens the checklist alone, which its "canonical
+    home" framing invites, follows an instruction its caller overrides. This is the same class of edit as D-5's
+    mode-scope paragraph, in the same file, so reinstating it would be cheap.
+  - **C-22.** The rubric tells a run not to duplicate a generalist finding another agent already raised and to
+    reference the specialist's classification instead. Nothing states how "the same issue" is determined, and the
+    generalist runs in an isolated context in the same parallel wave, so only the orchestrator can carry the
+    substitution out. The verification item checks that the reference exists, never that it points at the right
+    finding. That is the work item's own shared shape in a defect the work item does not report.
+- **Evidence:** C-18, C-22, and `artifacts/scope-boundary.md`'s Stated Scope and Operator-Stated Scope sections. C-22
+  is labeled `Unverified` and carries no blocking weight in any case.
+- **Behavior impact:** Preserving. Nothing is changed for either.
+- **Rejected alternatives:**
+  - **Absorbing C-18 into D-5's unit** — rejected because it is a separate defect in the same file, and folding an
+    unrequested fix into a requested unit is how a cut stops being visible. It is one line for the operator to ask
+    for.
+  - **Absorbing C-22** — rejected on the same ground, plus its `Unverified` label.
+- **Revisit criterion:** The operator saying so. Their direction is itself a valid justification, and a reinstated
+  entry records it as one.
+- **Dissent (if any):** None recorded.
+- **Settles delta entry:** — (produces the cut list)
+- **Dependent decisions:** —
+- **Referenced in plan:** Cut for Scope

--- a/docs/plans/code-review-research-feedback-issue-194/artifacts/current-state-findings.md
+++ b/docs/plans/code-review-research-feedback-issue-194/artifacts/current-state-findings.md
@@ -1,0 +1,698 @@
+# Current State Findings: Code Review and Research Response to Feedback Issue #194
+
+## Provenance
+
+This run's own discovery round, dispatched at Step 2. Feedback issue #194 is a defect report, not a current-state
+findings report: it names four defects and their general principles but carries no file paths, no verbatim skill
+content, and no account of the files as they stand. So no extraction path was available and the round ran in full.
+
+Three agents were dispatched in parallel on 2026-09-09, each given the area, the recorded reason, and the path to
+`artifacts/scope-boundary.md`:
+
+- `han-core:structural-analyst` — module boundaries, load conditions, duplication, and the shape a new rule would
+  have to match. Findings `S-1` through `S-16`.
+- `han-core:behavioral-analyst` — the data flow through a run's steps, what happens on an empty-input path, and every
+  stated check over a run's own output. Findings `B-1` through `B-10`.
+- `han-core:concurrency-analyst` — the parallel fan-out and the merge of what comes back, because defect 4 is a
+  merge-coordination failure. Findings `R-1` through `R-7` on `research`, and `CR-1` through `CR-4` on `code-review`.
+
+The area is Markdown instruction files, not a compiled language, so each analyst was briefed on the translation: a
+`SKILL.md` is the entry point and main procedure, a `references/` file is a module the procedure loads by instruction,
+an `Agent` dispatch is a call into another unit, and the parallel dispatch of several agents whose output merges into
+one document is the concurrency.
+
+The Project Context and Gaps sections below come from the run's own sweep, not from the specialists.
+
+## Project Context
+
+- **Stack:** Markdown (skill, agent, and doc content) and Bash (skill `scripts/`, plus the shared repo-root
+  `scripts/`). npm manages dev tooling only; there is no application build or dev server. Lint is
+  `npm run lint` (`prek run --all-files`: Prettier, ShellCheck, file hygiene). Test is `npm test` (Bats over every
+  `*.bats` file outside `node_modules`).
+- **Conventions source:** `CLAUDE.md` at the repository root, its `## Project Discovery` section. No
+  `project-discovery.md` exists.
+- **ADRs found:** one, `docs/adr/0001-project-configurable-default-swarm-size.md`, which records the
+  `default-swarm-size` config setting the two skills in this area both read. Nothing in it bears on the four defects.
+- **Coding standards found:** none under a `docs/coding-standards/` path. The repository's equivalent is the
+  plugin-authoring guidance under `han-plugin-builder/skills/guidance/references/`, which `CLAUDE.md` names as
+  mandatory for any change to a skill or agent. Two files in it govern this change directly and are recorded as
+  findings below: `skill-building-guidance/progressive-disclosure.md` (C-15) and
+  `skill-building-guidance/graceful-degradation.md` (C-13).
+- **Recent churn:** heavy and recent across the area. Over the last ninety days, `code-review/SKILL.md` was touched
+  in twenty-eight commits and `research/SKILL.md` in thirteen, with `references/template.md`,
+  `references/output-verification.md`, and `references/finding-content.md` each touched repeatedly. Two of those
+  commits were made to bring the file back under a size ceiling: `ab0476c refactor(code-review): bring the skill body
+  under the 500-line ceiling` and `33ed427 fix(han): bring skills back under Anthropic's authoring limits`. The
+  `code-review` skill is under active revision, so the plan should expect its line numbers to have moved by build
+  time and should name content rather than positions.
+
+## Gaps
+
+What the sweep searched for and did not find:
+
+- **No dedicated coding-standards directory.** Searched `docs/coding-standards/`. The authoring guidance under
+  `han-plugin-builder/` fills that role instead, and `CLAUDE.md` says so.
+- **No ADR on degraded execution modes, agent availability, or citation verification.** The single ADR covers swarm
+  sizing only. So the two rules this change introduces have no prior decision record to align with or supersede, and
+  the precedent has to come from the authoring guidance and from sibling skills instead (C-13, C-14).
+- **No repository-wide convention for disclosing a coverage gap in a report.** Searched every `SKILL.md` for
+  phrasings around absent specialist coverage. One skill has it (C-14). Nothing shared states it, so there is no
+  canonical file to cite.
+- **No test coverage over skill instruction content.** The Bats suite covers the shell scripts beside it. Nothing
+  executes or asserts on a `SKILL.md`'s procedure, so no test pins the behavior this change alters, and no test will
+  break if the change is wrong. Verification is reading and running the skills.
+- **No runtime evidence of the four defects.** Every finding below rests on the procedure text as written. Nobody in
+  this run could observe a live run in an environment that forbids agent dispatch, or a live fan-out whose registries
+  collided. The behavioral analyst labeled its own defect-1 finding `Unverified` for exactly this reason. The issue
+  itself supplies the runtime evidence: each defect is a run that already happened.
+
+## Findings
+
+### C-1: The only handling of "no agents ran" is a step-skip guard, not a mode
+
+- **Claim:** One sentence in Step 7 is the entire procedure's handling of agent dispatch producing nothing. It names
+  which sub-steps to skip and nothing else: no fallback mode, no statement of what coverage is lost, no disclosure
+  requirement.
+- **Location:** `han-coding/skills/code-review/SKILL.md`, Step 7 ("Collect and Classify Agent Results")
+- **Evidence:**
+
+  ```markdown
+  Wait for all agents dispatched in Step 3 to complete. Each agent returns a summary with finding counts and a file
+  path. **Skip Steps 7.1–7.3 if no agents were dispatched in Step 3; Step 7.4 still runs whenever the review has
+  produced at least one corrective finding (manual or agent).**
+  ```
+
+- **Raised by:** `han-core:structural-analyst` (S-1) and `han-core:behavioral-analyst` (B-1), independently, in the
+  same words
+- **Confidence:** Verified. Both agents grepped the full skill body and every reference file for "unavailable",
+  "Agent tool", and "no agents" and found no other site.
+- **Bears on:** S-1, S-2, S-3, D-1, D-3
+
+### C-2: No downstream surface renders a coverage disclosure
+
+- **Claim:** The report template has no slot for a statement of which specialist coverage ran, and the structural
+  verification list has no item requiring one. The template's only always-present elements are the summary table and
+  the recommendation, and every other section renders only when it has content. So a zero-agent run and a
+  full-roster run produce structurally indistinguishable reports.
+- **Location:** `han-coding/skills/code-review/references/template.md`, the `LAZY SECTIONS` comment;
+  `han-coding/skills/code-review/references/output-verification.md`, Step 9.1
+- **Evidence:**
+
+  ```markdown
+  LAZY SECTIONS: render a section ONLY when it has content. Do not emit a heading
+  followed by empty-state placeholder text. The Review Summary table and the Review
+  Recommendation are always present; every other section below appears only when it has
+  at least one item.
+  ```
+
+  The one verification item that reads dispatch state guards the opposite failure, findings leaking in from an agent
+  that never ran:
+
+  ```markdown
+  2. Agent findings from every dispatched agent (testing, edge-case, structural, behavioral, concurrency, data,
+     devops, han-core:junior-developer) have valid task IDs continuing from manual review IDs. Findings from agents
+     that were not dispatched in Step 3 must not appear.
+  ```
+
+- **Raised by:** `han-core:structural-analyst` (S-2) and `han-core:behavioral-analyst` (B-2, B-10)
+- **Confidence:** Verified
+- **Bears on:** S-4, S-5, S-6, D-2
+
+### C-3: The closing message has four fixed parts and coverage is not one of them
+
+- **Claim:** Step 10 specifies the closing message as four ordered parts. None of them carries the roster or the
+  coverage it achieved, so a manual-only run and a full-roster run produce identically shaped messages.
+- **Location:** `han-coding/skills/code-review/SKILL.md`, Step 10 ("Present")
+- **Evidence:**
+
+  ```markdown
+  1. **The recommendation**, in the words the report's own Review Recommendation uses.
+  2. **The counts by severity** — critical, warning, suggestion. Name any YAGNI count separately, never folded into
+     the total.
+  3. **The path** to the report file. Name the report you replaced when Step 8.6 replaced one, and the destination
+     you could not use when it fell back.
+  4. **The run's own facts, last:** the size band and why, and the validator reconciliation line. Or nothing at all.
+  ```
+
+  Part 4 is the natural home: it is already where the run's own conduct is reported, and it already names the size
+  band and the validator reconciliation.
+
+- **Raised by:** `han-core:structural-analyst` (S-3) and `han-core:behavioral-analyst` (B-2)
+- **Confidence:** Verified
+- **Bears on:** S-7, D-2
+
+### C-4: Agent selection reasons only about file-list signals, never about whether dispatch is reachable
+
+- **Claim:** The selection step decides the roster entirely from signals in the changed-file list. Two agents are
+  dispatched unconditionally at every size. Nothing in the selection logic asks whether the `Agent` tool is
+  available, and the frontmatter lists `Agent` beside every other tool with no guard. So an environment that forbids
+  dispatch is invisible to the procedure until a tool call fails, and the guard in C-1 is the only thing that reacts.
+- **Location:** `han-coding/skills/code-review/references/agent-dispatch.md`, Step 3.2;
+  `han-coding/skills/code-review/SKILL.md`, frontmatter `allowed-tools`
+- **Evidence:**
+
+  ```markdown
+  **Always dispatch — minimum roster across all sizes:**
+
+  1. `han-core:junior-developer` — generalist clarity and standards check, applicable to any change.
+  2. `han-core:adversarial-security-analyst` — security findings have a non-negotiable evidence standard that already
+     prevents theoretical reports; the agent stays silent when the standard is not met.
+  ```
+
+- **Raised by:** `han-core:structural-analyst` (S-4)
+- **Confidence:** Verified
+- **Bears on:** S-1, D-1, D-3
+
+### C-5: The manual review is never scoped to substitute for the specialist categories
+
+- **Claim:** The manual checklist is the same fixed set of categories whether the run dispatched every agent or none.
+  Nothing conditions its scope or depth on the dispatch outcome. The procedure treats the manual passes and the agent
+  results as two independent tributaries that merge at report time, never as a primary path and a fallback.
+- **Location:** `han-coding/skills/code-review/SKILL.md`, Step 3 opening and Step 4;
+  `han-coding/skills/code-review/references/review-checklist.md`
+- **Evidence:** Step 3 states the asymmetry in what the agents are responsible for:
+
+  ```markdown
+  Agents analyze source code to identify coverage gaps, edge cases, security vulnerabilities, structural problems,
+  ```
+
+  None of those categories has a manual-mode instruction to substitute when the agents are absent. The checklist's
+  own coverage of them is generic where the agents are deep: `Testing` asks whether unit and integration tests exist
+  and says detailed coverage analysis is done by the testing agent instead.
+
+  ```markdown
+  - If no test files exist for the reviewed code, flag as a Warning — detailed coverage analysis is also performed by
+    testing agents in Step 7, but complete absence of tests must be caught here
+  ```
+
+- **Raised by:** `han-core:behavioral-analyst` (B-3)
+- **Confidence:** Verified
+- **Bears on:** S-1, D-4
+
+### C-6: The checklist governs source text only, and the procedure actively steers away from built output
+
+- **Claim:** No checklist category instructs reading anything but the code as written, and Step 4 tells the run to
+  skip compiled output outright. A change that alters what gets packaged is therefore reviewed against the source
+  diff alone, which is the one place the defect does not appear.
+- **Location:** `han-coding/skills/code-review/SKILL.md`, Step 4, sub-step 1;
+  `han-coding/skills/code-review/references/review-checklist.md`, every category
+- **Evidence:**
+
+  ```markdown
+  1. **Skip generated files** (lock files, compiled output, vendor directories, auto-generated code) — note them as
+     skipped in the review
+  ```
+
+  The behavioral analyst grepped the skill and its references for `disassemb`, `compiled`, `packag`, `artifact`,
+  `jar`, `bundl`, `shad`, and `vendor`. The only hits were the skip rule above, Step 1.5's unrelated "planning
+  artifact", and the security agent's "dependency manifests".
+
+- **Raised by:** `han-core:behavioral-analyst` (B-4) and `han-core:structural-analyst` (S-16)
+- **Confidence:** Verified
+- **Bears on:** S-8, D-5, D-6
+
+### C-7: The checklist's shape a new category has to match
+
+- **Claim:** The checklist is a list of named categories, each a bullet list of concrete triggers, opened by a
+  contents list that names every category in order. Categories that apply only to some changes carry a
+  `(when applicable)` suffix on both the contents entry and the heading. That suffix convention is the existing shape
+  a conditional new category matches, and `Code Organization` is the nearest semantic neighbour but is a
+  file-placement rule rather than an inspection rule.
+- **Location:** `han-coding/skills/code-review/references/review-checklist.md`, the contents list and the
+  `Data Isolation`, `Database`, and `Architecture Decision Records` headings
+- **Evidence:**
+
+  ```markdown
+  - Data Isolation (when applicable)
+  ...
+  - Database (when applicable)
+  - Architecture Decision Records (when applicable)
+  ```
+
+  And `Code Organization` in full, showing it does not reach built output:
+
+  ```markdown
+  **Code Organization**
+
+  - Files placed in the correct package/directory per project structure
+  - Related code grouped together, naming follows project conventions
+  ```
+
+- **Raised by:** `han-core:structural-analyst` (S-16)
+- **Confidence:** Verified
+- **Bears on:** S-8, D-5
+
+### C-8: No rule resolves the enclosing member of a cited location, and the check that looks like one tests the file
+
+- **Claim:** The procedure's only instruction about a finding's location is to include it. Nothing states how a
+  location is established, and no pass re-reads a cited unit in isolation before severity is final. The verification
+  item that appears to cover this confirms the file appears in the reviewed file list, never that the line or symbol
+  is the correct enclosing unit for the claim.
+- **Location:** `han-coding/skills/code-review/SKILL.md`, Review Constraints;
+  `han-coding/skills/code-review/references/output-verification.md`, Step 9.1 items 3 and 6
+- **Evidence:** The whole of what the skill says about establishing a location:
+
+  ```markdown
+  Include `file_path:line_number` references and code examples for suggested fixes.
+  ```
+
+  And the two checks that read like verification of it:
+
+  ```markdown
+  3. Agent findings have valid `file_path:line_number` references
+  ...
+  6. All `file_path:line_number` references point to real files from the file list determined in Step 1
+  ```
+
+  Item 3's "valid" means present and well-formed. Item 6 resolves the path against a list. Neither reads the code at
+  the cited line.
+
+- **Raised by:** `han-core:behavioral-analyst` (B-5, B-9) and `han-core:structural-analyst` (S-7)
+- **Confidence:** Verified
+- **Bears on:** S-9, S-10, D-6, D-7
+
+### C-9: The one pass in `code-review` that re-reads the code has four named challenge axes and location is not one
+
+- **Claim:** Step 7.4 dispatches a critic that judges findings against the code rather than against the producing
+  agent's rationale, and it is the only pass in the skill that does. Its brief names four things to challenge. None
+  of them is whether a finding's cited location is the right enclosing unit, and the brief's own demand for
+  counter-evidence at a path and line presumes the finding's location is already right. It also does not run at all
+  when the review produced no corrective findings.
+- **Location:** `han-coding/skills/code-review/references/finding-filters.md`, Step 7.4
+- **Evidence:**
+
+  ```markdown
+  > Treat every finding as wrong until the code proves it right. For each finding, return exactly one verdict —
+  > **Confirmed**, **Partially Refuted**, or **Refuted** — and for anything other than Confirmed, cite concrete
+  > counter-evidence at `file_path:line_number`. Challenge specifically: (a) findings that misread the change's intent or
+  > the surrounding code; (b) findings that target pre-existing code this change did not introduce or worsen, unless the
+  > issue is critical irrespective of who introduced it; (c) findings whose rationale hedges its own reachability in
+  > paraphrase ("unlikely in practice", "would need an unusual sequence", "only under a race we don't see") that the
+  > literal-phrase gate did not catch; (d) severity that overstates impact, where the true worst case is "an operator sees
+  > an error and retries". Do not invent new findings — you are validating the list, not extending it.
+  ```
+
+  The lettered list is an extensible sequence, so a fifth axis has an existing home and an existing form.
+
+- **Raised by:** `han-core:structural-analyst` (S-8) and `han-core:behavioral-analyst` (B-9)
+- **Confidence:** Verified
+- **Bears on:** S-3, S-10, S-11, D-7
+
+### C-10: `research`'s traceability invariant is resolvability, stated identically in four places
+
+- **Claim:** The invariant is defined as resolution to an entry. Every one of the four sites that states or checks it
+  describes the existence of a target, never a match between what the entry says and what the claim it supports
+  asserts. A citation that lands on a real but unrelated entry passes at all four.
+- **Location:** `han-research/skills/research/SKILL.md`, Operating Principles, Step 6, and Step 8;
+  `han-research/skills/research/references/research-report-template.md`, the `Sources` comment
+- **Evidence:**
+
+  ```markdown
+  The traceability invariant is **resolvability**: every artifact ID
+  (`A#`) cited inline must resolve to a registry entry carrying its link, retrieval date, trust class, and evidence
+  status.
+  ```
+
+  ```markdown
+  Every entry gets an ID that Research Results, Options, and the Recommendation cross-reference inline, so every
+  conclusion traces to its sources — every `A#` cited inline must resolve to a registry entry.
+  ```
+
+  ```markdown
+  On top of the fidelity criterion, confirm every cited `A#` still resolves to its registry entry.
+  ```
+
+  ```markdown
+  Every A# cited inline in Research Results, Options, or the
+  Recommendation must RESOLVE to an entry here; that resolvability is the
+  traceability invariant.
+  ```
+
+- **Raised by:** `han-core:behavioral-analyst` (B-6) and `han-core:structural-analyst` (S-9, S-10)
+- **Confidence:** Verified
+- **Bears on:** S-12, S-15, S-16, D-8
+
+### C-11: Every parallel analyst mints `A1` independently and the merge renumbers with no mapping
+
+- **Claim:** The output format handed to every dispatched analyst starts its sources registry at `A1`, and the band
+  caps put two to eight analysts in a single wave at medium and large. The merge step consolidates them into one
+  sequence. No step records an old-to-new mapping, and no step rewrites inline citations through one. The
+  orchestrator synthesizes from each analyst's verbatim output, which still carries that analyst's own numbering.
+- **Location:** `han-research/agents/research-analyst.md`, the `Output Format` section;
+  `han-research/skills/research/SKILL.md`, Step 4 roster caps, Step 6, Step 7
+- **Evidence:** The per-analyst format, identical for every instance:
+
+  ```markdown
+  ### Sources
+
+  **A1: [short source title]**
+  ...
+  **A2: [short source title]** ...
+  ```
+
+  The merge, in full:
+
+  ```markdown
+  Collect the full verbatim output from every agent. Consolidate every information source used that is relevant to
+  the results into a single indexed Sources registry (`A1, A2, …`), merging duplicates.
+  ```
+
+  And the band caps that guarantee more than one analyst above small:
+
+  ```markdown
+  **medium** runs two to three parallel
+  `han-research:research-analyst` angles split by domain or option cluster, plus `han-core:codebase-explorer` when relevant,
+  then `han-core:adversarial-validator` (3–5 agents); **large** runs a `han-research:research-analyst` per major domain or
+  option cluster plus `han-core:codebase-explorer`, then `han-core:adversarial-validator` (5–8 agents).
+  ```
+
+  Two facts follow that the plan depends on. The collision is not incidental: at medium and large it is structural,
+  because every analyst in the wave restarts at `A1`. And "merging duplicates" is itself a renumbering, so the merge
+  cannot preserve any analyst's numbering even in principle.
+
+- **Raised by:** `han-core:behavioral-analyst` (B-7) and `han-core:structural-analyst` (S-11, S-12)
+- **Confidence:** Verified
+- **Bears on:** S-13, D-9
+
+### C-12: The sources table already carries the one-line summary a semantic check would read
+
+- **Claim:** The registry table has a `Summary (one line)` column holding what each source says that is relevant.
+  That is the exact input a check comparing a citation against the claim it supports needs, so such a check requires
+  no new field in the template and no new content from any analyst.
+- **Location:** `han-research/skills/research/references/research-report-template.md`, the `Sources` table header;
+  `han-research/skills/research/SKILL.md`, Step 6
+- **Evidence:**
+
+  ```markdown
+  | ID  | Source        | Link / location                              | Retrieved           | Trust class               | Summary (one line)         | Evidence status                                                        |
+  ```
+
+  Step 6 already requires the content of that cell:
+
+  ```markdown
+  a plain-language
+  summary of what the source says that is relevant (a one-line cell by default; a full prose summary for the sources the
+  recommendation rests on)
+  ```
+
+- **Raised by:** the run's own sweep
+- **Confidence:** Verified
+- **Bears on:** S-12, S-20, D-8
+
+### C-13: The repository already has a named-mode degradation pattern, and `code-review` already uses it
+
+- **Claim:** The authoring guidance carries a rule for exactly the shape defect 1 needs: detect the environment,
+  branch to a mode that has a name, and continue producing useful output. `code-review` already applies it to git
+  availability, with three named modes the rest of the skill refers to by name. So the fix for defect 1 has a
+  precedent inside the file it changes, and its worked example in the guidance is this very skill.
+- **Location:** `han-plugin-builder/skills/guidance/references/skill-building-guidance/graceful-degradation.md`;
+  `han-coding/skills/code-review/SKILL.md`, Step 1
+- **Evidence:** The rule, and its distinction from a hard prerequisite:
+
+  ```markdown
+  ### Rule: Detect environment state with a script, then branch to a named mode
+  ...
+  Define modes explicitly by name so the skill body and review output can reference them clearly
+  ```
+
+  ```markdown
+  This doc covers _partial context_ — situations where the environment is usable but some data (a git history, project
+  config, docs directory) is absent. Graceful degradation means detecting what is available, selecting a named execution
+  mode, and continuing to produce useful output.
+  ```
+
+  And the skill's own existing use of it:
+
+  ```markdown
+  **Mode A: Full git context** — script reports `git-available: true` and `changed-files-start` block has content.
+  ...
+  **Mode B: Git but no branch changes** — script reports `git-available: true` but `changed-files: none`.
+  ...
+  **Mode C: No git / no changes found**
+  ```
+
+  One difference the plan has to hold: the git modes are detected by a script that probes the environment before the
+  work starts. Whether agent dispatch is permitted is not something the existing script can probe.
+
+- **Raised by:** the run's own sweep
+- **Confidence:** Verified
+- **Bears on:** S-1, D-1, D-3
+
+### C-14: One sibling skill already carries the coverage-disclosure pattern, in both its artifact and its summary
+
+- **Claim:** `plan-implementation` records an evidence class no specialist could audit in its written history and
+  names it again in its closing summary, explicitly so the coverage gap is visible rather than silent. It also
+  presents that disclosure as non-blocking. That is the same two-place disclosure defect 1 asks for, already stated
+  in the repository's own words, so the fix follows a precedent rather than inventing a convention. Nothing shared
+  states the pattern, so there is no canonical file to cite: the wording has to be written into `code-review` itself.
+- **Location:** `han-planning/skills/plan-implementation/SKILL.md`, the round-aggregation step and the closing
+  summary step
+- **Evidence:**
+
+  ```markdown
+  Record any evidence class no specialist could audit. When decisions rest on material no specialist received, say so in the
+  iteration history, so the coverage gap is visible rather than silent.
+  ```
+
+  ```markdown
+  - Any finding that stayed `Unverified` because a specialist could not inspect its input, each with its disposition, and
+    any evidence class no specialist could audit. Neither is presented as build-blocking.
+  ```
+
+- **Raised by:** the run's own sweep
+- **Confidence:** Verified
+- **Bears on:** S-4, S-7, D-2
+
+### C-15: `code-review/SKILL.md` sits five lines under a ceiling the guidance sets and two commits have already enforced
+
+- **Claim:** The authoring guidance sets 500 lines as the ceiling for a `SKILL.md` body and says to treat it as a
+  ceiling rather than a target. The file is 495 lines. Two commits in the last ninety days exist only to bring skill
+  bodies back under it. So new instruction content cannot land in the body: it goes into a reference file, and the
+  body gains at most a pointer.
+- **Location:** `han-plugin-builder/skills/guidance/references/skill-building-guidance/progressive-disclosure.md`;
+  `han-coding/skills/code-review/SKILL.md` (495 lines, measured 2026-09-09)
+- **Evidence:**
+
+  ```markdown
+  Anthropic and the cross-tool Agent Skills standard both
+  recommend keeping the SKILL.md body under **500 lines**; past that, move detail into `references/`. Treat 500 lines as
+  the ceiling, not the target.
+  ```
+
+  The same file also carries the rule that governs how content moves, and names this repository as the place the
+  failure happened:
+
+  ```markdown
+  **The unit of a move is a whole sentence or a whole bullet, never a fragment.** A move that cuts mid-sentence leaves the
+  SKILL.md stating half an instruction and the reference file opening with the other half, and neither file read alone
+  says what the step does. This has happened twice in this repository, both times in a commit made to get a skill back
+  under the ceiling.
+  ```
+
+  And Level 3's own constraints on where a new reference file can sit:
+
+  ```markdown
+  Level 3 is one level, not
+  a chain: link every reference file directly from SKILL.md, and open any reference file over roughly 100 lines with a
+  contents list, so a partial read still shows what the file holds.
+  ```
+
+- **Raised by:** the run's own sweep
+- **Confidence:** Verified
+- **Bears on:** S-2, S-17, D-11, D-16, D-19
+
+### C-16: The repository's authoritative-home convention exists, and neither new rule has one
+
+- **Claim:** Where a rule has several consumers, this skill names one file as its authoritative home and every other
+  site cites it by name instead of restating it. Size-based demotion works that way. Neither of the two rules this
+  change introduces has such a home yet, and the sites that would consume each one are already separate files.
+- **Location:** `han-coding/skills/code-review/SKILL.md`, Step 3.3 pointer;
+  `han-coding/skills/code-review/references/agent-dispatch.md`, Step 3.3
+- **Evidence:**
+
+  ```markdown
+  **Step 3.3 is the authoritative home for size-based demotion.** Every other site that needs the size-based rule
+  references this step by name rather than restating it: the Review Constraints rule for manual findings, the Step 7.2
+  demotion gate for agent findings, the rubric in `references/agent-finding-classification.md`, and the YAGNI two-pass
+  procedure in `references/review-checklist.md`.
+  ```
+
+- **Raised by:** `han-core:structural-analyst` (S-14)
+- **Confidence:** Verified
+- **Bears on:** S-17, D-11, D-19
+
+### C-17: The vendored rule files are byte-identical, so a fix inside one lands in every copy
+
+- **Claim:** `evidence-rule.md`, `yagni-rule.md`, and `config-rule.md` are identical across the plugins that carry
+  them, by the repository's own stated convention rather than by accident. A change to any of them has to be made to
+  the canonical copy and re-synced to the rest. This bounds where the fix can go: a rule placed in a vendored file
+  becomes a multi-plugin edit.
+- **Location:** `han-core/references/`, `han-coding/references/`, `han-research/references/`; `CLAUDE.md`
+- **Evidence:** `CLAUDE.md` states the convention:
+
+  ```markdown
+  Vendored byte-identical into every skill-carrying plugin's `references/`; edit the canonical copy and re-sync the others.
+  ```
+
+  The structural analyst confirmed the three files are in fact identical across the three plugins by diff, so nothing
+  has drifted.
+
+- **Raised by:** `han-core:structural-analyst` (S-13)
+- **Confidence:** Verified
+- **Bears on:** D-11
+
+### C-18: The YAGNI checklist's mode exception lives only in its caller, not in the file named canonical
+
+- **Claim:** Step 4 suspends the YAGNI checklist in the two modes that have no diff. The checklist file the skill
+  calls the canonical home for that procedure states it unconditionally. A reader who opens the checklist alone,
+  which the "canonical home" framing invites, sees an instruction its caller overrides without any cross-reference
+  from inside the checklist.
+- **Location:** `han-coding/skills/code-review/SKILL.md`, Step 4 mode scope note;
+  `han-coding/skills/code-review/references/review-checklist.md`, the YAGNI section
+- **Evidence:**
+
+  ```markdown
+  - **Skip the YAGNI checklist entirely in Mode B and Mode C unless the user explicitly requests it in `$focus_areas`.**
+  ```
+
+  ```markdown
+  Apply YAGNI in two passes for every change in the diff.
+  ```
+
+- **Raised by:** `han-core:structural-analyst` (S-6)
+- **Confidence:** Verified
+- **Bears on:** D-5 (its mode-scope paragraph), D-17 (cut list)
+
+### C-19: A second citation surface sits inside the registry being renumbered
+
+- **Claim:** Each source entry carries an evidence-status field that cross-references other sources by `A#`. It is a
+  citation in every respect that matters, written by an analyst against that analyst's own local numbering, and it
+  lives inside the registry the merge renumbers rather than in prose a reader would recognize as a citation. No step
+  names it when stating the invariant, when merging, or when checking resolution. A fix that rewrites only the inline
+  citations in Results, Options, and the Recommendation therefore leaves this surface stale.
+- **Location:** `han-research/agents/research-analyst.md`, the `Sources` entry format;
+  `han-research/skills/research/references/research-report-template.md`, the table's last column and the `A#` detail
+  block
+- **Evidence:**
+
+  ```markdown
+  - **Evidence status:** corroborated by {A#} | single source — caveated | contradicted by {A#}
+  ```
+
+  The same field appears twice in the template, once as the table's last column and once in the recommendation-bearing
+  detail block:
+
+  ```markdown
+  - **Evidence status:** corroborated by {A#} | single source (caveated) | contradicted by {A#}
+  ```
+
+  And Step 6 requires the field on every entry without saying anything about the identifiers inside it:
+
+  ```markdown
+  and an evidence status.
+  ```
+
+- **Raised by:** `han-core:concurrency-analyst` (R-5)
+- **Confidence:** Verified
+- **Bears on:** S-13, D-9
+
+### C-20: Two of the three merge collision cases have no stated handling
+
+- **Claim:** The merge addresses one collision case and leaves two unstated. Two analysts citing the same underlying
+  source is handled by "merging duplicates". Two analysts using the same identifier for different sources, which is
+  the reported defect's precondition, is not named. Nor is an analyst's source being dropped at the merge because it
+  is not relevant to the results, which leaves a citation to it with no home at all.
+- **Location:** `han-research/skills/research/SKILL.md`, Step 6
+- **Evidence:** The whole of the merge's collision handling, and the relevance filter that can drop a source:
+
+  ```markdown
+  Consolidate every information source used that is relevant to
+  the results into a single indexed Sources registry (`A1, A2, …`), merging duplicates.
+  ```
+
+  Note the two jobs that one sentence does: it filters by relevance and it renumbers. Either alone would break a
+  carried-over citation.
+
+- **Raised by:** `han-core:concurrency-analyst` (R-6)
+- **Confidence:** Verified
+- **Bears on:** S-13, D-9, D-10
+
+### C-21: `code-review`'s own fan-out is structurally immune to the same defect
+
+- **Claim:** The parallel specialists in `code-review` cannot produce the collision `research` produces, for two
+  independent reasons. Each specialist has its own fixed identifier prefix, so two specialists' local first finding
+  can never occupy the same identifier. And the single renumbering into the review's own sequence happens before any
+  cross-reference between findings is minted, so no reference is ever written against a pre-merge identifier and then
+  carried past the renumbering. This is a negative result and it bounds the change: defect 4's fix belongs in
+  `research` and has no counterpart to add here.
+- **Location:** `han-coding/skills/code-review/references/agent-finding-classification.md`, the per-agent series
+  prefixes; `han-coding/skills/code-review/SKILL.md`, Step 7.3;
+  `han-coding/skills/code-review/references/output-verification.md`, Step 9.0;
+  `han-coding/skills/code-review/references/finding-filters.md`, Step 7.4
+- **Evidence:** The prefixes are distinct per agent, so each numbers locally from 1 without colliding: `T`, `EC`,
+  `SEC`, `S`, `B`, `C`, `D`, `DV`, `OCE`. Renumbering into the review's own sequence happens at Step 7.3:
+
+  ```markdown
+  Continue task ID numbering sequentially from Steps 4-6
+  ```
+
+  Both cross-reference mechanisms run after that. Step 9.0's tension note is written at Step 9, and Step 7.4's
+  validator is handed identifiers that are already final:
+
+  ```markdown
+  2. **The complete corrective finding list**, with each finding's task ID, current severity,
+     `file_path:line_number`, the finding's claim, and the producing agent's rationale **verbatim**.
+  ```
+
+- **Raised by:** `han-core:concurrency-analyst` (CR-1, CR-2, CR-4)
+- **Confidence:** Verified
+- **Bears on:** D-11 (the shared-rule rejection)
+
+### C-22: The junior-developer deduplication instruction names no mechanism
+
+- **Claim:** The classification rubric tells the run not to duplicate a generalist finding another agent already
+  raised, and to reference the specialist's classification instead. The generalist runs in the same parallel wave as
+  the specialists and in an isolated context, so it cannot know what any specialist concluded; only the orchestrator
+  can carry the substitution out at merge time. Nothing states how "the same issue" is determined. The verification
+  list checks that the reference exists, never that it points at the right finding, which is the issue's own shared
+  shape in a different defect.
+- **Location:** `han-coding/skills/code-review/references/agent-finding-classification.md`, the
+  junior-developer rule; `han-coding/skills/code-review/references/output-verification.md`, Step 9.1 item 10
+- **Evidence:**
+
+  ```markdown
+  Do not duplicate a junior-developer finding when another agent has already raised the same issue — prefer the
+  specialist's classification and reference it from the JD finding instead
+  ```
+
+  ```markdown
+  10. Junior-developer findings that overlap with a specialist agent's finding reference the specialist finding instead
+      of duplicating it
+  ```
+
+- **Raised by:** `han-core:concurrency-analyst` (CR-3)
+- **Confidence:** Unverified. The analyst could not inspect a completed run's output to see whether the substitution
+  is carried out correctly in practice, so the claim is about the instruction rather than about observed behavior.
+- **Bears on:** D-17 (cut list)
+
+## Findings No Agent Could Audit
+
+Two evidence classes nobody in this run could reach.
+
+**A live run with agent dispatch forbidden.** No agent could observe `code-review` executing in an environment that
+denies the `Agent` tool, so every claim about what such a run produces rests on reading the procedure. The behavioral
+analyst labeled its own finding `Unverified` on this ground. Closing it would take running the skill with dispatch
+denied and reading the report it writes. The issue supplies the substitute: it reports that run as something that
+already happened, and what it produced.
+
+**A live fan-out whose analyst registries collided.** Likewise, nobody could observe a medium or large `research` run
+merging two analysts' registries. C-11 establishes from the procedure that the collision is structural above the
+small band, which is stronger than an observation of one run, but it is not the same as watching a citation land on
+the wrong entry. The issue reports that too as something that already happened.
+
+**A completed run's output showing how a duplicate generalist finding was reconciled.** C-22 rests on the instruction
+alone for the same reason: no run transcript was available. That finding is labeled `Unverified` and is outside the
+four defects in any case.
+
+Neither of the first two blocks the plan. Both are cases where the recorded reason carries the runtime evidence the
+code cannot.

--- a/docs/plans/code-review-research-feedback-issue-194/artifacts/scope-boundary.md
+++ b/docs/plans/code-review-research-feedback-issue-194/artifacts/scope-boundary.md
@@ -1,0 +1,127 @@
+# Scope Boundary: Code Review and Research Response to Feedback Issue #194
+
+## Work Item
+
+GitHub issue [testdouble/han#194](https://github.com/testdouble/han/issues/194), "Han Feedback:
+code-review-research (2026-08-23)". Read in full via `gh issue view 194` on 2026-09-09. The issue carries no
+comments and no labels.
+
+The issue is a retrospective feedback filing, not a current-state findings report. It names four defects with
+suggested fixes and a general principle each, but it carries no file paths, no verbatim skill content, and no
+account of the skill files as they stand today. This run therefore performs its own current-state discovery
+rather than extracting findings from the issue.
+
+## Stated Scope
+
+Four defects, quoted from the issue.
+
+**Defect 1, `han-coding:code-review` — "No documented path when agent dispatch is unavailable".**
+
+> The skill dispatches a roster of specialist agents as its primary analysis engine, with the manual steps framed
+> as a supplement. In an environment that forbids agent dispatch, it degrades silently: the collection step says to
+> skip its sub-steps when no agents ran, but nothing tells the reviewer that a manual-only run is a legitimate
+> mode, what coverage it loses, or whether the report should disclose it. The run produced a complete-looking
+> report that never disclosed that no specialist had passed over the change.
+
+> **Suggested fix.** Add an explicit "agents unavailable" branch: state that the manual review steps are the
+> fallback, that the specialist categories the roster would have covered should be swept by hand at the same size
+> band, and that the report must record which specialist coverage was absent. Add a matching line to the report
+> template so the disclosure has a fixed home.
+
+> **The general principle.** A workflow whose primary engine can be unavailable in some environments needs a named
+> degraded mode with an explicit disclosure requirement, not a step that silently no-ops.
+
+**Defect 2, `han-coding:code-review` — "Packaging changes need the built artifact inspected, not just the build
+script".**
+
+> A change altered which compiled classes were bundled into a shipped archive, using include and exclude patterns
+> in the build configuration. Two critical defects were invisible in the diff: the exclude list removed classes
+> that surviving classes still referenced, so the shipped artifact carried dangling references that fail at
+> runtime. The build passed. Reading the patterns alone could not reveal it — only disassembling the produced
+> archive and diffing referenced class names against present class names did.
+
+> **Suggested fix.** Add a packaging trigger to the review checklist. When a diff changes what gets packaged —
+> shading, vendoring, include and exclude rules, dependency scope, bundling — inspect the produced artifact: verify
+> every internal reference resolves inside it, that no third-party package is exported unrelocated, and that
+> required licence notices are present. Worth noting in the same place that a development run configuration often
+> has a wider classpath than the shipped artifact, so a passing smoke test is not evidence.
+
+> **The general principle.** When a change alters what ships rather than what the source says, the artifact is the
+> review surface. A green build proves the source compiles, not that the packaged output is internally complete.
+
+**Defect 3, `han-coding:code-review` — "Attribute a disassembly hit to its enclosing member structurally, not by a
+running text scan".**
+
+> A finding named the wrong enclosing method. The reference was located by scanning disassembler output line by
+> line and carrying forward the most recent line that looked like a member declaration. That heuristic silently
+> attributed a hit inside the class's static initializer to the method printed just before it, because an
+> initializer's header does not match a normal method-declaration shape. The misattribution understated severity:
+> the real site runs on every use of a subclass, while the named site runs only under an accessibility feature. It
+> was caught by accident, when a later step re-read the same method for an unrelated reason.
+
+> **Suggested fix.** When citing a location inside compiled output, resolve the enclosing member structurally —
+> disassemble the single member, or parse the output into member blocks and search within a block — rather than
+> scanning running text and remembering the last header seen. Re-read the cited member in isolation before writing
+> the finding, and treat a severity that depends on the location as a reason to confirm it twice.
+
+> **The general principle.** A location derived by carrying forward the last matching line of a text scan is a
+> guess, not a citation. Confirm the enclosing unit by isolating it, especially where the finding's severity
+> depends on which unit it is.
+
+**Defect 4, `han-research:research` — "'Every citation resolves' does not catch a citation that resolves to the
+wrong entry".**
+
+> The skill's traceability invariant is that every source identifier cited inline must resolve to an entry in the
+> sources registry. That check is purely syntactic. In a fan-out run, two analysts each numbered their own sources
+> from the start of the sequence, and the orchestrator merged them into one renumbered index. A citation carried
+> over from one analyst's numbering still resolved — to a real entry saying something unrelated. The run produced
+> exactly that: an option's evidence line cited an identifier that had become an unrelated entry after the merge,
+> and the resolvability check passed. Only the adversarial validator, which reads the cited entry's content, caught
+> it.
+
+> **Suggested fix.** After merging analyst registries, add a semantic pass: for each inline citation, confirm the
+> cited entry's one-line summary actually supports the claim it is attached to. Where a merge renumbers
+> identifiers, record the old-to-new mapping and rewrite citations through it rather than by hand. State in the
+> skill that syntactic resolvability is necessary but not sufficient.
+
+> **The general principle.** An index that renumbers its entries turns every stale citation into a silently wrong
+> one rather than a broken one. Verify that a citation points at the right thing, not merely at something.
+
+**The issue's own framing of the shared shape**, from its closing section:
+
+> Three of the four are the same failure at different altitudes: a check that confirms a _reference exists_ while
+> never confirming it _points at the right thing_.
+
+## Stated Exclusions
+
+None stated. The issue rules nothing out.
+
+## Operator-Stated Scope
+
+The operator invoked the skill with `for https://github.com/testdouble/han/issues/194` and nothing else.
+
+Asked in the confirmation turn whether the two skill folders were the whole area, they answered:
+
+> expand to other files where it fits
+
+That answer widens the area beyond `han-coding/skills/code-review/` and `han-research/skills/research/`: a file
+outside those two folders is in scope when the fix genuinely belongs there. It does not license changes unrelated
+to the four defects.
+
+## Direction of Travel
+
+Asked whether the `code-review` agent-dispatch path, the `research` fan-out, or the source registry that renumbers
+entries is being replaced or deprecated, the operator answered: **no**. Nothing in the area is being deprecated,
+replaced, or migrated away from.
+
+## Visual Material Received
+
+`None received`
+
+This skill plans code structure rather than screens, so the visual-material convention does not apply to it. No
+`ui-designs/` folder is written and no completeness gate runs.
+
+## Record Provenance
+
+Established by `han-planning:plan-a-change` on 2026-09-09, at the start of this run. Not inherited from another
+folder. No conflicting record was found and no conflict was resolved.

--- a/docs/plans/code-review-research-feedback-issue-194/change-plan.md
+++ b/docs/plans/code-review-research-feedback-issue-194/change-plan.md
@@ -1,0 +1,1039 @@
+# Change Plan: Code Review and Research Response to Feedback Issue #194
+
+## Why This Change
+
+Feedback issue #194 reports four defects in two Han skills, three in `code-review` and one in `research`. This is a
+finding already established: the issue is a retrospective filing from a local observation log. Each defect is a run
+that already happened, with the failure written down at the time by the run that hit it. The issue names what unites
+three of them in its own words: "a check that confirms a _reference exists_ while never confirming it _points at the
+right thing_."
+
+The fourth, and the one the issue lists first, is a different failure. A `code-review` run in an environment that
+forbids agent dispatch produced a complete-looking report that never disclosed that no specialist had read the change.
+
+Source: [testdouble/han#194](https://github.com/testdouble/han/issues/194), quoted in full in
+[`artifacts/scope-boundary.md`](artifacts/scope-boundary.md).
+
+## What Changes, In One Paragraph
+
+After this change, both skills say out loud what they did not do, and both check that a reference points at the right
+thing rather than merely at something. `code-review` gains a named mode it enters when it cannot dispatch specialists,
+a by-hand sweep that substitutes for them, and a report section that records which coverage was absent. It gains a
+checklist category that fires when a diff changes what gets packaged. That category tells the reviewer the review did
+not open the built artifact, and names what to check by hand. It gains a rule that a finding's location must be confirmed by reading
+the unit that contains it, never carried forward from the last header a scan passed. And `research` gains a two-part
+traceability invariant, a recorded old-to-new mapping across the merge that renumbers its source identifiers, and a
+rewrite through that mapping covering every surface a citation lives on.
+
+## Current State
+
+`code-review` dispatches specialist agents as its primary analysis engine and has no name for the state where it
+cannot. One sentence in its collection step is the whole of its response, and it says only which sub-steps to skip
+([C-1](artifacts/current-state-findings.md#c-1-the-only-handling-of-no-agents-ran-is-a-step-skip-guard-not-a-mode)).
+Nothing downstream renders a disclosure: the report template's only always-present elements are its summary table and
+its recommendation, and the structural verification list has no item requiring a coverage statement
+([C-2](artifacts/current-state-findings.md#c-2-no-downstream-surface-renders-a-coverage-disclosure)). The closing
+message has four fixed parts and coverage is not among them
+([C-3](artifacts/current-state-findings.md#c-3-the-closing-message-has-four-fixed-parts-and-coverage-is-not-one-of-them)).
+Agent selection reasons only about signals in the changed-file list, so an environment that forbids dispatch is
+invisible until a tool call fails
+([C-4](artifacts/current-state-findings.md#c-4-agent-selection-reasons-only-about-file-list-signals-never-about-whether-dispatch-is-reachable)),
+and the manual review runs at its normal depth either way, never scoped to substitute for what the agents cover
+([C-5](artifacts/current-state-findings.md#c-5-the-manual-review-is-never-scoped-to-substitute-for-the-specialist-categories)).
+
+The checklist governs source text only. No category reaches built output, and the review step actively skips compiled
+output ([C-6](artifacts/current-state-findings.md#c-6-the-checklist-governs-source-text-only-and-the-procedure-actively-steers-away-from-built-output)).
+The skill's only instruction about a finding's location is to include one. The verification item that looks like a
+check on it resolves the path against a file list, rather than reading the code
+([C-8](artifacts/current-state-findings.md#c-8-no-rule-resolves-the-enclosing-member-of-a-cited-location-and-the-check-that-looks-like-one-tests-the-file)).
+
+In `research`, the traceability invariant is resolvability, stated identically in four places. Each place describes the
+existence of a target rather than a match between what an entry says and what the claim it supports asserts
+([C-10](artifacts/current-state-findings.md#c-10-researchs-traceability-invariant-is-resolvability-stated-identically-in-four-places)).
+Every parallel analyst mints its sources from `A1`, and the band caps put two to eight analysts in one wave above the
+small band. The collision is structural rather than incidental. The merge consolidates them into one sequence with
+no recorded mapping and no instruction to rewrite citations through one
+([C-11](artifacts/current-state-findings.md#c-11-every-parallel-analyst-mints-a1-independently-and-the-merge-renumbers-with-no-mapping)).
+A second citation surface sits inside the registry being renumbered. Each entry's evidence-status field cross-references
+other sources by identifier, written by an analyst against that analyst's own numbering, and no step names it
+([C-19](artifacts/current-state-findings.md#c-19-a-second-citation-surface-sits-inside-the-registry-being-renumbered)).
+
+**The structural property this change addresses.** In both skills, the site that verifies and the claim it guards have
+come apart. Each verification reads a property that is cheap to check and adjacent to the one that matters: that a path
+appears in a list, that an identifier resolves to an entry, that a step was skipped. Nothing reads the thing the
+reference points at.
+
+Three findings shape how the change can be built, more than the defects themselves do. The `code-review` skill body
+sits five lines under a ceiling the authoring guidance sets, with two commits in the recorded history spent enforcing
+it. New instruction content goes into reference files, and the body gains at most a pointer
+([C-15](artifacts/current-state-findings.md#c-15-code-reviewskillmd-sits-five-lines-under-a-ceiling-the-guidance-sets-and-two-commits-have-already-enforced)).
+The repository already carries both patterns this change needs. The first is a named-mode degradation rule whose own
+worked example is this skill's git modes ([C-13](artifacts/current-state-findings.md#c-13-the-repository-already-has-a-named-mode-degradation-pattern-and-code-review-already-uses-it)).
+The second is a sibling skill that discloses an unaudited evidence class in both its artifact and its summary, for the
+stated purpose of making a coverage gap visible rather than silent
+([C-14](artifacts/current-state-findings.md#c-14-one-sibling-skill-already-carries-the-coverage-disclosure-pattern-in-both-its-artifact-and-its-summary)).
+And `code-review`'s own parallel fan-out cannot produce the collision `research` produces, for two independent reasons,
+which bounds the change rather than widening it
+([C-21](artifacts/current-state-findings.md#c-21-code-reviews-own-fan-out-is-structurally-immune-to-the-same-defect)).
+
+## Target State
+
+### `code-review`: a named mode, a sweep, and a disclosure
+
+The skill has a mode called **manual-only mode**, which it enters when the dispatch attempt produces no agent results.
+The name is not a fourth letter in the existing Mode A / Mode B / Mode C series
+([D-1](artifacts/change-decision-log.md#d-1-the-degraded-mode-is-named-and-it-is-not-a-fourth-letter-in-the-existing-series)).
+Those letters enumerate how much git context a run has, and agent availability is a second, independent axis.
+A Mode A run with a full branch diff can be manual-only.
+
+`agent-dispatch.md` owns the mode. It is already loaded at the dispatch step, already the authoritative home for one
+cross-file rule, and already carries the roster the absent-coverage list is derived from. It owns four things: the
+mode's name, how a run detects it, what selection produces in that mode, and which checklist categories substitute for
+each absent agent. It does not restate the report's block format or the verification item.
+
+Detection is by the **dispatch mechanism failing**, not by the results being empty, and not by a probe
+([D-3](artifacts/change-decision-log.md#d-3-the-mode-is-detected-by-the-dispatch-mechanism-failing-never-by-an-empty-result)).
+The two triggers are a dispatch tool that is unavailable and a dispatch call that is denied. **An agent that returns
+with nothing to say is not a trigger.** The always-dispatched security agent is specified to stay silent when
+its evidence standard is not met. Reading silence as failure would print a disclosure saying security coverage was
+absent on a run where it ran and passed. A false disclosure is worse than the silent one this change is fixing.
+
+The line the run emits:
+
+```
+Manual-only mode: agent dispatch unavailable ({verbatim tool error, or "Agent tool not in allowed-tools"}).
+Manual review is the primary path. Coverage absent: junior-developer, security, and every conditional agent
+Step 3.2 selected. See the sweep mapping for what substitutes.
+```
+
+The sweep is a stated mapping, one line per agent, so two runs do the same thing
+([D-4](artifacts/change-decision-log.md#d-4-the-by-hand-sweep-is-a-stated-mapping-from-each-absent-agent-to-checklist-categories)).
+The mapping is written out for every agent on the roster, because writing it out is what reveals how much the sweep
+recovers:
+
+```
+- `han-core:junior-developer` → Code Maintainability, Documentation, Code Style & Patterns, Architecture Decision Records — at the {size} band from Step 3.1.
+- `han-core:adversarial-security-analyst` → Data Isolation, Error Handling, API Design — at the {size} band. Partial: nothing substitutes for an exploit path demonstrated against the code.
+- `han-core:test-engineer` → Testing, Correctness — at the {size} band.
+- `han-core:edge-case-explorer` → Correctness, Error Handling — at the {size} band. Partial: the checklist asks whether edge cases are handled, not which ones exist.
+- `han-core:structural-analyst` → Code Organization, Code Maintainability — at the {size} band.
+- `han-core:behavioral-analyst` → Error Handling, Correctness — at the {size} band.
+- `han-core:data-engineer` → Database, Performance, Data Isolation — at the {size} band.
+- `han-core:on-call-engineer` → Error Handling, Performance — at the {size} band. Partial: no category covers timeouts, retry backoff, or idempotency.
+- `han-core:concurrency-analyst` → nothing substitutes. No checklist category covers races, lock ordering, or shared mutable state.
+- `han-core:devops-engineer` → nothing substitutes. No checklist category covers rollout, observability, or infrastructure.
+- An agent from a project config's `## Extra Agents` list → nothing substitutes. Name the agent and say its coverage was not swept.
+```
+
+**Writing the mapping out changes what the sweep is worth, and the plan says so rather than implying more.** Four of
+the roster's agents have no counterpart or a partial one. A manual-only run recovers most of what the structural,
+behavioral, data, and testing agents cover, and recovers nothing of what the concurrency and devops agents cover. Those
+last two produce coverage rows reading `not swept`, which is the honest result and the reason the disclosure matters
+more than the sweep does.
+
+The report carries a `## Review Coverage` section immediately after the Review Summary block closes, rendered **only
+when some planned coverage was absent**
+([D-2](artifacts/change-decision-log.md#d-2-the-coverage-disclosure-renders-only-when-coverage-was-absent-and-it-reaches-the-closing-message-too)).
+Its absence means every planned coverage ran.
+The heading is `##`, a peer of Recommended Changes rather than a child of Review Summary, and it joins the template's
+fixed section order by name at that position. `template.md` owns the block, its heading level, its position, its
+opening line, and its row grammar.
+
+**The block stands alone for a reader who never saw the terminal.** The report's reader and the operator are different
+people: a reviewer on a pull request never sees the closing message, and the operator may never open the file. So the
+block opens by naming its own cause rather than relying on the message to have explained it.
+
+```markdown
+## Review Coverage
+
+Agent dispatch was unavailable on this run, so no specialist read this change (manual-only mode).
+
+- **Absent:** {coverage name} — {reason}; {swept by hand under {categories} | not swept — {what to do instead}}.
+```
+
+Worked, and this example, the detection line above, and the closing message below all describe the same run:
+
+```markdown
+## Review Coverage
+
+Agent dispatch was unavailable on this run, so no specialist read this change (manual-only mode).
+
+- **Absent:** security review — swept by hand under Data Isolation, Error Handling, API Design. Nothing substitutes for an exploit path demonstrated against the code.
+- **Absent:** concurrency review — not swept; no checklist category covers races or lock ordering. Check shared state and async ordering by hand before merging.
+- **Absent:** independent validation of the findings — not swept; the findings below were not re-checked against the code by a second pass. Weigh each on its own evidence.
+```
+
+Two things the grammar does deliberately. The plain-English coverage name comes first and the agent identifier is
+dropped, because a reviewer on a pull request has no roster and no plugin. And the `not swept` branch carries a clause
+saying what to do instead, because a line with no verb aimed at the reader gets read as bookkeeping about the run.
+
+The population is settled once: **every agent Step 3.2 selected, plus the independent validation pass**, which is
+planned coverage that a manual-only run cannot reach because it dispatches an agent. Selection is a fact by the time
+detection fires, not a counterfactual, since the dispatch attempt is what detects.
+
+The closing message carries one clause in its run's-own-facts part, which is already where the run's conduct is
+reported. It names the cause and the consequence rather than a mode name and a count, because "manual-only mode" reads
+as a setting somebody chose and the operator chose nothing:
+
+```
+Medium: 6 files touched, adds one index. Agent dispatch was unavailable, so no specialist read this change; 8 of 11
+coverage areas were swept by hand and 3 were not. See Review Coverage in the report.
+```
+
+`output-verification.md` owns the check: when the run was manual-only, the block is present and carries one row per
+agent selection produced or would have produced. When coverage was complete, the block is absent.
+
+### `code-review`: a packaging category that names the gap
+
+A new `Packaging (when applicable)` category in `review-checklist.md` fires on a diff that changes what gets packaged.
+Its triggers are shading or relocation rules, vendoring, include and exclude patterns, dependency scope changes, and
+bundling configuration. **It does not open the built artifact.** The run acquires no new command permission
+([D-5](artifacts/change-decision-log.md#d-5-the-packaging-category-names-the-gap-rather-than-inspecting-the-artifact)).
+
+The finding it raises, pinned by worked example so two runs write the same thing:
+
+```markdown
+**WARN-002** `build.gradle:41` Someone installs the published jar and calls `WidgetFactory.create`, and it fails at
+startup with a missing-class error, because the exclude rule added here drops a class that surviving classes still
+reference. This review did not open the built artifact and cannot tell you whether that happened: the exclude
+patterns say what was removed, not what still points at it. A green build is not evidence either, because a
+development run has a wider classpath than the shipped artifact. Check the produced artifact before merging: that
+every internal reference resolves inside it, that no third-party package is exported unrelocated, and that the
+licence notices the packaging requires are present. **Fix:** by hand.
+```
+
+**The first sentence is derived from the diff; the rest is fixed.** The category says so, because a builder who
+pastes the worked example with the path swapped produces five identical sentences on every packaging review. A
+reader stops reading them by the third. The first sentence names the specific rule or pattern the diff added and the
+specific symptom it could produce. Sentences two onward are invariant.
+
+**The summary-table row opens with `Not checked —`**, matching the existing `May never fire —` cue the template already
+uses to mark a finding class a triaging reader should weigh differently. Without it, a row that says the review did not
+look sits at the same visual weight as a proven defect. A reader triaging thirty findings cannot tell them apart
+until they open one.
+
+The category states its own mode scope, inside the category rather than only in its caller, which is the defect
+[C-18](artifacts/current-state-findings.md#c-18-the-yagni-checklists-mode-exception-lives-only-in-its-caller-not-in-the-file-named-canonical)
+records against the neighbouring YAGNI section:
+
+```
+**Mode scope.** This category applies in Mode A only. Step 4's Mode B and Mode C conservative rule admits only
+focus-area items, source-file items, and file-boundary items, and without a base-branch diff the run cannot tell
+what the change altered about packaging. Same reason the YAGNI checklist is suspended in those modes.
+```
+
+### `code-review`: a location is confirmed, not carried forward
+
+The rule fires on a specific, current path rather than on a population the skill does not reach
+([D-6](artifacts/change-decision-log.md#d-6-the-location-rule-fires-on-the-region-read-path-which-is-the-one-that-survives-d-5)).
+Step 4 reads a file over a thousand lines by its changed regions and their surrounding context rather than whole. **A
+location established from a region read is exactly the failure the work item describes.** You see a hit, and you look
+upward for the nearest declaration. The declaration you find may not be the one that encloses it.
+
+`finding-content.md` gains the rule. It owns what every finding carries and is loaded at the drafting step, which is
+the moment the work item names: re-read the cited unit in isolation before writing the finding.
+
+```
+A location established by reading a region of a file rather than the unit that contains it is a guess until the unit
+is read. Read the enclosing unit in isolation before writing the finding, and never carry forward the nearest
+declaration a region read happened to include. Where a finding's severity depends on which unit the location names,
+confirm the unit twice.
+```
+
+The location form is the existing one plus the enclosing unit and how it was confirmed:
+
+```
+**CRIT-003** `src/billing/reconciler.rb:2841` (enclosing member: `Reconciler.retry_batch`, confirmed by reading
+lines 2790-2860 in isolation) {explanation} … **Fix:** by hand.
+```
+
+**The population is region reads, and it does not reach every cited location.** A finding from a file the run read
+whole carries no such note. That keeps the rule off the twenty-nine other findings a capped review can hold, which is
+the cost that made the general version a deferral.
+
+Two guards, because each is absent when the other runs
+([D-7](artifacts/change-decision-log.md#d-7-the-attribution-rule-is-guarded-in-two-places-because-each-is-absent-when-the-other-runs)).
+A fifth challenge axis joins the lettered list in the validation pass's brief:
+
+```
+(e) findings whose cited location came from a region read and names an enclosing unit that was never read in
+isolation, and any finding whose severity depends on which unit the location names.
+```
+
+And a structural verification item runs in every mode where the validation pass does not. It asserts that such a
+finding names its enclosing unit and the lines read to confirm it.
+
+### `research`: one home for the invariant, and a mapping across the merge
+
+The traceability invariant is two-part and defined in Operating Principles alone
+([D-8](artifacts/change-decision-log.md#d-8-the-traceability-invariant-is-two-part-and-it-is-defined-in-one-place)):
+
+```
+The traceability invariant is two-part. Resolvability: every `A#` cited inline resolves to a registry entry carrying
+its link, retrieval date, trust class, and evidence status. Support: the cited entry's `Summary (one line)` states
+something that bears on the claim the citation is attached to. Resolvability is necessary and not sufficient.
+```
+
+The merge step, which already renumbers and already filters by relevance, gains ownership of the record of what those
+two jobs did ([D-9](artifacts/change-decision-log.md#d-9-the-merge-records-an-old-to-new-mapping-and-the-rewrite-covers-the-evidence-status-field)).
+The mapping is a working record the run holds while it renders, not a report section. Nothing in the report reads it,
+and persisting it is a deferral with its own trigger.
+
+```markdown
+| Analyst angle       | Local ID | Source                          | Merged ID | Disposition                        |
+| ------------------- | -------- | ------------------------------- | --------- | ---------------------------------- |
+| messaging-patterns  | A1       | Kafka docs, exactly-once        | A1        | renumbered                         |
+| messaging-patterns  | A2       | Fowler, "What do you mean by X" | A2        | renumbered                         |
+| delivery-semantics  | A1       | Fowler, "What do you mean by X" | A2        | merged into A2 (same source as messaging-patterns A2) |
+| delivery-semantics  | A2       | vendor blog, undated            | —         | dropped (not relevant to the results) |
+```
+
+The `Source` column is what makes the mapping checkable. Without it, nobody can join a row back to the analyst output
+it came from, and the plan's own mitigation for a wrongly-built mapping has nothing to check against.
+
+The rewrite through that mapping covers every `A#` in Research Results, in each option's `Rests on`, and in the
+recommendation's `Evidence basis`. **It also covers every `Evidence status` field** — both in the registry table's last
+column and in each detail block. That last surface is the one nobody names today, and a rewrite covering only prose
+leaves it stale.
+
+A claim whose only source the merge dropped carries the canonical no-evidence label with a reopen trigger, or is
+dropped with its source. It is not relabelled single-source, because the evidence rule this skill already loads forbids
+that collapse in as many words
+([D-10](artifacts/change-decision-log.md#d-10-a-claim-whose-only-source-the-merge-dropped-is-labeled-no-evidence-not-single-source)).
+
+**Two column enumerations are reconciled in the same unit.** The merge step and the final step each list the registry
+table's columns inline, and neither list includes the one-line summary the support check reads. A run following the
+skill rather than the template would render a registry the check cannot read. Both lists gain the column.
+
+The validation pass receives the mapping alongside the registry it already gets. The final check becomes two-part
+rather than gaining a pass beside it, and the report template's sources comment cites the invariant instead of defining
+it.
+
+### What deliberately does not change
+
+No new reference file, in either skill, for any of the four defects. Three of the four land in lists that are already
+extensible, and each new file would spend body lines a file five under its ceiling does not have. No shared rule
+generalizing the three citation defects. The shape they share is a moral rather than a procedure, and the only
+candidate second consumer inside `code-review` is ruled out by
+[C-21](artifacts/current-state-findings.md#c-21-code-reviews-own-fan-out-is-structurally-immune-to-the-same-defect)
+([D-11](artifacts/change-decision-log.md#d-11-no-new-reference-file-and-no-shared-rule-generalizing-the-three-citation-defects)).
+The `research-analyst` agent is unchanged: it keeps numbering its own sources from `A1`, because the whole fix sits on
+the orchestrator's side of the merge ([D-15](artifacts/change-decision-log.md#trivial-decisions)). No plugin version is
+bumped and no changelog entry is written ([D-14](artifacts/change-decision-log.md#trivial-decisions)).
+
+## Surface Delta
+
+### S-1: `agent-dispatch.md` § manual-only mode — Added
+
+**Target state.** `agent-dispatch.md` carries a section defining manual-only mode: its name, the detection line a run
+emits when the dispatch attempt produces no agent results, what selection produces in that mode, and a mapping from
+each roster agent to the checklist categories that substitute for it at the run's size band. It is the authoritative
+home for the mode; every other site names it rather than describing it.
+
+**Behavior.** Changing. A manual-only run raises findings it did not raise before, in the mapped categories. The
+observer is the author of the change under review. Settled by the recorded boundary, which asks for the by-hand sweep
+at the same size band in as many words.
+
+**Why.** [C-1](artifacts/current-state-findings.md#c-1-the-only-handling-of-no-agents-ran-is-a-step-skip-guard-not-a-mode)
+records the only handling today as a step-skip sentence naming no mode;
+[C-5](artifacts/current-state-findings.md#c-5-the-manual-review-is-never-scoped-to-substitute-for-the-specialist-categories)
+records the manual review running at its normal depth either way.
+
+**Decision.** [D-1](artifacts/change-decision-log.md#d-1-the-degraded-mode-is-named-and-it-is-not-a-fourth-letter-in-the-existing-series),
+[D-3](artifacts/change-decision-log.md#d-3-the-mode-is-detected-by-the-dispatch-mechanism-failing-never-by-an-empty-result),
+[D-4](artifacts/change-decision-log.md#d-4-the-by-hand-sweep-is-a-stated-mapping-from-each-absent-agent-to-checklist-categories)
+
+### S-2: `code-review/SKILL.md` Step 3's pointer to `agent-dispatch.md` — Re-scoped
+
+**Target state.** The pointer names the manual-only mode among what the reference file specifies. It states no
+detection rule, no mapping, and no disclosure.
+
+**Behavior.** Preserving. The run loads the same file at the same point.
+
+**Why.** [C-15](artifacts/current-state-findings.md#c-15-code-reviewskillmd-sits-five-lines-under-a-ceiling-the-guidance-sets-and-two-commits-have-already-enforced):
+the body gains at most a pointer.
+
+**Depends on.** S-1.
+
+**Decision.** [D-1](artifacts/change-decision-log.md#d-1-the-degraded-mode-is-named-and-it-is-not-a-fourth-letter-in-the-existing-series)
+
+### S-3: `code-review/SKILL.md` Step 7's skip sentence — Re-scoped
+
+**Target state.** The sentence owns which sub-steps skip and under what condition, and nothing else. It names
+manual-only mode, defined in `agent-dispatch.md`. Its clause about the independent validation pass says that pass skips
+too in manual-only mode, because that pass dispatches an agent and dispatch is what is unavailable. Outside manual-only
+mode the clause is unchanged: the pass still runs whenever the review produced at least one corrective finding.
+
+**Behavior.** **Changing.** Two things differ. The condition changes from "no agents were dispatched" to "the dispatch
+mechanism failed." The independent validation pass now skips in that mode, where the sentence today says it still
+runs. The observer is the report's reader, who gets findings that were not re-checked against the code by a second
+pass, and who is told so by the coverage row S-4 renders.
+
+**Why.** [C-1](artifacts/current-state-findings.md#c-1-the-only-handling-of-no-agents-ran-is-a-step-skip-guard-not-a-mode)
+records that sentence carrying an entire execution mode as a guard clause. The validation clause has to change because
+[C-9](artifacts/current-state-findings.md#c-9-the-one-pass-in-code-review-that-re-reads-the-code-has-four-named-challenge-axes-and-location-is-not-one)
+records that the pass dispatches an agent. Leaving "still runs" in place would instruct a run to do the thing it
+discovered it cannot do.
+
+**Depends on.** S-1.
+
+**Decision.** [D-1](artifacts/change-decision-log.md#d-1-the-degraded-mode-is-named-and-it-is-not-a-fourth-letter-in-the-existing-series),
+[D-3](artifacts/change-decision-log.md#d-3-the-mode-is-detected-by-the-dispatch-mechanism-failing-never-by-an-empty-result)
+
+### S-4: `template.md` § Review Coverage — Added
+
+**Target state.** The report template defines a `## Review Coverage` section at heading level two, a peer of Recommended
+Changes rather than a child of Review Summary. It renders immediately after the Review Summary block closes, and only
+when some planned coverage was absent. Its absence means every planned coverage ran, and the template says so where the
+block is defined. It opens with a line naming its own cause, so it stands alone for a reader who never saw the terminal.
+It then carries one row per absent item in the pinned grammar. The rows name coverage in plain English and carry no agent
+identifier or internal step number.
+
+**Behavior.** Changing. A degraded run's report gains a section it did not carry. The observer is the report's reader,
+who is a different person from the operator: a reviewer on a pull request sees this file and never sees the closing
+message. Settled by the recorded boundary, which asks for a matching line in the report template so the disclosure has a
+fixed home.
+
+**Why.** [C-2](artifacts/current-state-findings.md#c-2-no-downstream-surface-renders-a-coverage-disclosure): no surface
+exists today, and a zero-agent report is structurally indistinguishable from a full-roster one.
+
+**Depends on.** S-1, which supplies the absent-coverage list the rows render.
+
+**Decision.** [D-2](artifacts/change-decision-log.md#d-2-the-coverage-disclosure-renders-only-when-coverage-was-absent-and-it-reaches-the-closing-message-too)
+
+### S-5: `template.md` § the fixed section order — Re-scoped
+
+**Target state.** The template's fixed-order list names Review Coverage in its position, between the Review Summary
+block and Critical. The list is the authority on where a present section goes, and a section absent from it has no
+defined position.
+
+**Behavior.** Preserving. The list is an instruction to the run about ordering; naming a section in it changes no
+output beyond what S-4 already produces.
+
+**Why.** The order list today names Critical, Warnings, Suggestions, YAGNI, Security Vulnerabilities, Remediation, and
+What's Good, and a section not on it has nowhere defined to sit. The structural verification item that checks fixed
+order reads this list, so a block missing from it cannot be checked for position.
+
+**Depends on.** S-4.
+
+**Decision.** [D-2](artifacts/change-decision-log.md#d-2-the-coverage-disclosure-renders-only-when-coverage-was-absent-and-it-reaches-the-closing-message-too)
+
+### S-6: `output-verification.md` § Step 9.1, coverage-block item — Added
+
+**Target state.** A structural verification item asserting that a manual-only run's report carries the Review Coverage
+block with one row per agent selection produced or would have produced, and that a full-coverage run's report does not
+carry it.
+
+**Behavior.** Preserving. Its only effect is to enforce S-4, so the observable difference belongs to that entry.
+
+**Why.** [C-2](artifacts/current-state-findings.md#c-2-no-downstream-surface-renders-a-coverage-disclosure): the
+verification list has no item requiring a coverage statement, so a missing block would go uncaught.
+
+**Depends on.** S-4.
+
+**Decision.** [D-2](artifacts/change-decision-log.md#d-2-the-coverage-disclosure-renders-only-when-coverage-was-absent-and-it-reaches-the-closing-message-too)
+
+### S-7: `code-review/SKILL.md` Step 10's run's-own-facts part — Re-scoped
+
+**Target state.** That part of the closing message carries the size band and the validator reconciliation line, plus one
+clause naming the cause and the consequence. That clause states that agent dispatch was unavailable, so no specialist
+read the change; it states how many coverage areas were swept by hand and how many were not; and it points to the
+report's Review Coverage section. It names a consequence rather than a mode name, and it does not list the absent
+areas; the report's block does.
+
+**Behavior.** Changing. The closing message gains a clause on degraded runs. The observer is the operator in the turn.
+The work item names the report rather than the message. The message clause is a necessity of the disclosure it asks
+for, because the run never pastes the report into the conversation.
+
+**Why.** [C-3](artifacts/current-state-findings.md#c-3-the-closing-message-has-four-fixed-parts-and-coverage-is-not-one-of-them):
+part 4 is already where the run's own conduct is reported.
+
+**Depends on.** S-4.
+
+**Decision.** [D-2](artifacts/change-decision-log.md#d-2-the-coverage-disclosure-renders-only-when-coverage-was-absent-and-it-reaches-the-closing-message-too)
+
+### S-8: `review-checklist.md` § Packaging (when applicable) — Added
+
+**Target state.** The checklist carries a `Packaging (when applicable)` category, listed in the file's contents and
+headed with the same suffix. It names the diff triggers, what the finding it raises must state, its default severity,
+and its own mode scope. It directs no artifact inspection and requires no command the skill is not already permitted.
+
+**Behavior.** Changing. A Mode A review of a diff that alters packaging raises a finding it did not raise before. The
+observer is the author of the change. Settled by the operator's answer, which departs from the work item; the work item
+asks for the artifact to be inspected and this does not inspect it.
+
+**Why.** [C-6](artifacts/current-state-findings.md#c-6-the-checklist-governs-source-text-only-and-the-procedure-actively-steers-away-from-built-output)
+records that no category reaches built output and the review step actively skips it;
+[C-7](artifacts/current-state-findings.md#c-7-the-checklists-shape-a-new-category-has-to-match) records the shape this
+matches.
+
+**Decision.** [D-5](artifacts/change-decision-log.md#d-5-the-packaging-category-names-the-gap-rather-than-inspecting-the-artifact),
+[D-12](artifacts/change-decision-log.md#d-12-escalation-register-the-one-question-this-run-took-to-the-operator)
+
+### S-9: `finding-content.md` § enclosing-unit attribution — Added
+
+**Target state.** `finding-content.md` carries the rule that a finding's location, when it was established by reading a
+region of a file rather than the unit that contains it, is confirmed by reading that unit in isolation before the
+finding is written. The rule never lets that location be carried forward from the nearest declaration the region
+happened to include. It carries the location form: the existing reference plus the enclosing unit and the lines read to confirm it. Its population is
+region reads, which is the path Step 4 takes on a file over a thousand lines. A finding from a file read whole carries
+no such note.
+
+**Behavior.** Changing. Such a finding carries a form it did not carry, and confirming the unit can change which unit
+the finding names, which can change its severity. The observer is the report's reader.
+
+**Why.** [C-8](artifacts/current-state-findings.md#c-8-no-rule-resolves-the-enclosing-member-of-a-cited-location-and-the-check-that-looks-like-one-tests-the-file):
+the skill's only instruction about a location is to include one. The population is Step 4's own instruction to read a
+file over a thousand lines by its changed regions and their surrounding context. That is the same failure the work
+item describes at a different altitude: a hit found in a region, attributed upward to the nearest declaration the
+region included.
+
+**Depends on.** S-8, which settles that no archive path can produce such a location and therefore what altitude the
+rule is written at.
+
+**Decision.** [D-6](artifacts/change-decision-log.md#d-6-the-location-rule-fires-on-the-region-read-path-which-is-the-one-that-survives-d-5)
+
+### S-10: `output-verification.md` § Step 9.1, attribution item — Added
+
+**Target state.** A structural verification item asserting that a finding whose location came from a region read names
+its enclosing unit and the lines read to confirm it. It runs in every mode. The file gains a contents list in the same
+unit, because it sits exactly at the length past which the authoring guidance requires one and this change pushes it
+over.
+
+**Behavior.** Preserving. Its only effect is to enforce S-9.
+
+**Why.** [C-9](artifacts/current-state-findings.md#c-9-the-one-pass-in-code-review-that-re-reads-the-code-has-four-named-challenge-axes-and-location-is-not-one):
+the validation pass does not run when a review produced no corrective findings, and after S-1 it cannot run at all in
+manual-only mode. A guard that lives only there is absent in the run that needs it most.
+
+**Depends on.** S-9.
+
+**Decision.** [D-7](artifacts/change-decision-log.md#d-7-the-attribution-rule-is-guarded-in-two-places-because-each-is-absent-when-the-other-runs)
+
+### S-11: `finding-filters.md` § Step 7.4 brief, axis (e) — Added
+
+**Target state.** The validation pass's verbatim brief carries a fifth lettered challenge axis, naming findings whose
+location came from a region read and names an enclosing unit never read in isolation, and any finding whose severity
+depends on which unit the location names.
+
+**Behavior.** Changing. A finding may be demoted or dropped that previously stood. The observer is the report's reader.
+Settled by the recorded boundary, which asks that a severity depending on the location be confirmed twice.
+
+**Why.** [C-9](artifacts/current-state-findings.md#c-9-the-one-pass-in-code-review-that-re-reads-the-code-has-four-named-challenge-axes-and-location-is-not-one):
+this is the only pass that judges a finding by re-reading the code, and its axes are an extensible lettered list. Its
+demand for counter-evidence at a path and line presumes the location is already right.
+
+**Depends on.** S-9, which defines the form the axis challenges.
+
+**Decision.** [D-7](artifacts/change-decision-log.md#d-7-the-attribution-rule-is-guarded-in-two-places-because-each-is-absent-when-the-other-runs)
+
+### S-12: `research/SKILL.md` Operating Principles § traceability invariant — Re-scoped
+
+**Target state.** Operating Principles is the only place the invariant is defined, and it defines it as two-part:
+resolvability, and support by the cited entry's one-line summary, with resolvability necessary and not sufficient.
+
+**Behavior.** Changing. A run must now check support, so a citation may be rewritten that previously stood. The
+observer is the report's reader. Settled by the recorded boundary, which asks the skill to state that syntactic
+resolvability is necessary but not sufficient.
+
+**Why.** [C-10](artifacts/current-state-findings.md#c-10-researchs-traceability-invariant-is-resolvability-stated-identically-in-four-places):
+four co-equal statements, each describing existence of a target.
+[C-12](artifacts/current-state-findings.md#c-12-the-sources-table-already-carries-the-one-line-summary-a-semantic-check-would-read)
+is why the support half needs no new field: the registry table already carries the summary the check reads.
+
+**Decision.** [D-8](artifacts/change-decision-log.md#d-8-the-traceability-invariant-is-two-part-and-it-is-defined-in-one-place)
+
+### S-13: `research/SKILL.md` Step 6 — Re-scoped
+
+**Target state.** The merge step owns the old-to-new mapping in its pinned field layout, the rewrite of every citation
+surface through it, and the handling of a dropped source. It cites the invariant by name and does not restate it.
+
+**Behavior.** Changing. A citation may be rewritten to a different identifier than an analyst wrote, and a claim whose
+only source was dropped loses its citation and carries the no-evidence label. The observer is the report's reader.
+Settled by the recorded boundary for the mapping and the rewrite, and by the canonical evidence rule for the dropped
+case.
+
+**Why.** [C-11](artifacts/current-state-findings.md#c-11-every-parallel-analyst-mints-a1-independently-and-the-merge-renumbers-with-no-mapping),
+[C-19](artifacts/current-state-findings.md#c-19-a-second-citation-surface-sits-inside-the-registry-being-renumbered),
+[C-20](artifacts/current-state-findings.md#c-20-two-of-the-three-merge-collision-cases-have-no-stated-handling).
+
+**Depends on.** S-12.
+
+**Decision.** [D-9](artifacts/change-decision-log.md#d-9-the-merge-records-an-old-to-new-mapping-and-the-rewrite-covers-the-evidence-status-field),
+[D-10](artifacts/change-decision-log.md#d-10-a-claim-whose-only-source-the-merge-dropped-is-labeled-no-evidence-not-single-source)
+
+### S-14: `research/SKILL.md` Step 7's validator brief — Re-scoped
+
+**Target state.** The validation dispatch passes the mapping alongside the registry, the results, the options, and the
+recommendation it already passes, and its charter names citation support as something to attack.
+
+**Behavior.** Changing. The validator may raise a finding it would not have raised. The observer is the report's
+reader.
+
+**Why.** The issue records the validator as the only thing that caught the defect. It caught the defect by reading
+entry contents for other reasons, rather than because its charter named this
+([C-12](artifacts/current-state-findings.md#c-12-the-sources-table-already-carries-the-one-line-summary-a-semantic-check-would-read)
+covers the input it reads).
+
+**Depends on.** S-13.
+
+**Decision.** [D-9](artifacts/change-decision-log.md#d-9-the-merge-records-an-old-to-new-mapping-and-the-rewrite-covers-the-evidence-status-field)
+
+### S-15: `research/SKILL.md` Step 8's resolution check — Re-scoped
+
+**Target state.** The final check is two-part: every cited identifier resolves, and the entry it resolves to states
+something bearing on the claim it is attached to. It cites the invariant by name and does not restate it.
+
+**Behavior.** **Changing.** This is where the support judgment first executes over a finished report. It catches a
+citation pointing at the wrong entry for reasons having nothing to do with a merge. An analyst that cited the wrong
+source in a run with no collision at all previously passed here and now does not. The observer is the report's reader.
+Settled by the recorded boundary, which asks for a pass confirming the cited entry's one-line summary supports
+the claim it is attached to.
+
+**Why.** [C-10](artifacts/current-state-findings.md#c-10-researchs-traceability-invariant-is-resolvability-stated-identically-in-four-places):
+this is the site that checks the invariant, and it checks existence today. S-12 states the invariant as drafting
+guidance and S-13 corrects identifiers across the merge; neither performs the check, so classifying this entry as their
+enforcement understated what it does.
+
+**Depends on.** S-12.
+
+**Decision.** [D-8](artifacts/change-decision-log.md#d-8-the-traceability-invariant-is-two-part-and-it-is-defined-in-one-place)
+
+### S-16: `research-report-template.md` § Sources comment — Re-scoped
+
+**Target state.** The comment tells a reader that every cited identifier resolves to an entry below, and cites the
+invariant by name rather than defining it.
+
+**Behavior.** Preserving. The rendered report is unchanged.
+
+**Why.** [C-10](artifacts/current-state-findings.md#c-10-researchs-traceability-invariant-is-resolvability-stated-identically-in-four-places):
+the fourth of the four statements.
+
+**Depends on.** S-12.
+
+**Decision.** [D-8](artifacts/change-decision-log.md#d-8-the-traceability-invariant-is-two-part-and-it-is-defined-in-one-place)
+
+### S-17: `code-review/SKILL.md` Step 8's restatement of the template's render rules — Re-scoped
+
+**Target state.** Step 8 points at `template.md` for the lazy-section and fixed-order rules rather than restating them,
+under the same authoritative-home convention the skill applies to size-based demotion. Conditional: this entry lands
+only if the line count measured at build time leaves less headroom than this change's pointers need.
+
+**Behavior.** Preserving. No output changes; the file is already read at that step.
+
+**Why.** [C-15](artifacts/current-state-findings.md#c-15-code-reviewskillmd-sits-five-lines-under-a-ceiling-the-guidance-sets-and-two-commits-have-already-enforced)
+and [C-16](artifacts/current-state-findings.md#c-16-the-repositorys-authoritative-home-convention-exists-and-neither-new-rule-has-one).
+
+**Decision.** [D-16](artifacts/change-decision-log.md#d-16-the-headroom-unit-runs-only-if-the-measured-line-count-at-build-time-requires-it)
+
+### S-18: `han-coding/docs/skills/code-review.md` — Re-scoped
+
+**Target state.** The long-form doc describes manual-only mode alongside the git modes and says the two are
+independent axes rather than one enumeration. Its account of the report names the Review Coverage section and what its
+absence means. Its account of the closing message carries the manual-only clause. And its key concepts name the
+Packaging category and the location-attribution rule. It states the modes without a running total, so a later mode
+cannot make a count wrong.
+
+**Behavior.** Preserving. The doc carries no behavior of its own; it stops stating what S-1 through S-11 made wrong.
+
+**Why.** The repository's convention makes the long-form doc canonical for its skill, and the doc currently states
+"Three review modes" as a key concept and describes a report with no coverage section.
+
+**Depends on.** S-1 through S-11.
+
+**Decision.** [D-13](artifacts/change-decision-log.md#trivial-decisions)
+
+### S-19: `han-research/docs/skills/research.md` — Re-scoped
+
+**Target state.** The doc states the traceability invariant in its two-part form, matching Operating Principles, and
+says what the merge records.
+
+**Behavior.** Preserving, on the same grounds as S-18.
+
+**Why.** The doc currently states the invariant as resolvability alone, which S-12 makes incomplete.
+
+**Depends on.** S-12, S-13.
+
+**Decision.** [D-13](artifacts/change-decision-log.md#trivial-decisions)
+
+### S-20: `research/SKILL.md` the registry's column enumerations — Re-scoped
+
+**Target state.** Both places that list the registry table's columns inline name the one-line summary column, matching
+the template. A run that follows the skill rather than the template renders a registry the support check can read.
+
+**Behavior.** Preserving on the rendered report, which already carries the column via the template. It removes a state
+where a run following the skill alone would render a table the check cannot read.
+
+**Why.** [C-12](artifacts/current-state-findings.md#c-12-the-sources-table-already-carries-the-one-line-summary-a-semantic-check-would-read)
+is the evidence that the support check needs no new field, and it rests on the template. Both of the skill's own
+enumerations omit that column, so the evidence held for one of three surfaces.
+
+**Depends on.** S-12.
+
+**Decision.** [D-8](artifacts/change-decision-log.md#d-8-the-traceability-invariant-is-two-part-and-it-is-defined-in-one-place)
+
+### S-21: `post-code-review-to-pr` § the PR body's sections — Re-scoped
+
+**Target state.** The skill that posts a review to a pull request names Review Coverage among the optional sections it
+carries across. It exempts Review Coverage from the clarity pass's length-matching instruction, alongside the Review
+Summary table and the Review Recommendation. A coverage disclosure survives to the pull request.
+
+**Behavior.** Changing. A pull request body from a degraded run carries the coverage section. The observer is every
+reviewer on that pull request, which is the widest audience any of these surfaces has and the only one that sees
+neither the terminal nor the report file.
+
+**Why.** That skill builds the public body from the report file and lists the optional sections it expects, a list
+Review Coverage would not be on. Its clarity pass then instructs a run that every finding earns its place by naming a
+specific problem at a specific location, and to skip filler sections. A section that names no problem at any location
+is the most deletable block in the body by that bar. The pass is carried out by a dispatched agent applying the bar
+as written. Without this entry, the fix for the first defect is deleted on the surface with the widest audience,
+reproducing the original failure one level out.
+
+**Depends on.** S-4.
+
+**Decision.** [D-18](artifacts/change-decision-log.md#d-18-the-disclosure-has-to-survive-to-the-pull-request-so-the-skill-that-posts-it-is-in-scope)
+
+## Behavior Changes
+
+Eleven entries change something a person can observe. Nothing here is pinned by a test. The repository's Bats suite
+covers the shell scripts beside it, nothing executes or asserts on a skill's procedure, and no part of this change is
+scriptable enough to test that way. Each of these is caught by a reader or not at all.
+
+**Two of them do less than feedback issue #194 asked for, and both departures are your decision.**
+
+- **S-8, the packaging finding.** The issue asks the run to open the built artifact and check it. It does not open it.
+  A reviewer whose diff changes packaging is told the review has that hole and what to check by hand. The defect the
+  issue reported, an exclude rule dropping a class that surviving classes still called, is not caught. You chose this
+  after being told it does not close the defect
+  ([D-12](artifacts/change-decision-log.md#d-12-escalation-register-the-one-question-this-run-took-to-the-operator)).
+- **S-9, the location rule.** The issue's example is a hit inside a class's static initializer attributed to the method
+  printed before it in disassembler output. Because S-8 means a run never disassembles anything, that case cannot
+  arise. The rule fires instead on the path that does exist. Step 4 reads a file over a thousand lines by its changed
+  regions, and a location found in a region can be attributed upward to the wrong declaration. Same failure, reachable
+  altitude. The review round caught an earlier version of this entry aiming at a population the skill does not read at
+  all, and this is the corrected form.
+
+The other nine do what the issue asks, and the recorded boundary is the decision on each.
+
+- **S-1.** A review that cannot reach its specialists raises findings by hand that it previously left to them. Someone
+  reviewing a change in a restricted environment sees more findings, in the mapped categories. Observer: the author of
+  the change. **The mapping written out in full shows this recovers less than it sounds like**: four roster agents have
+  no counterpart or a partial one, and concurrency and infrastructure coverage is recovered not at all.
+- **S-3.** In that same run, the pass that re-checks findings against the code no longer runs, because it dispatches an
+  agent. Findings reach the report without a second opinion, and the coverage block says so. Observer: the report's
+  reader.
+- **S-4.** A report from such a run carries a section naming what was not covered and why; a report from a healthy run
+  carries no such section. Observer: the report's reader, who on a pull request is not the person who ran it.
+- **S-7.** The message the run closes with says dispatch was unavailable, that no specialist read the change, and how
+  many coverage areas were swept by hand. Observer: the operator in the turn.
+- **S-11.** A finding whose enclosing unit was guessed rather than read can be demoted a severity or dropped, so a
+  report can carry fewer findings than it would have. Observer: the report's reader.
+- **S-12.** A research report's citations are now checked against what the cited source says, so a citation pointing at
+  an unrelated entry gets corrected before the report is presented. Observer: the report's reader.
+- **S-13.** A claim whose source the merge dropped loses its citation and is labelled as having no evidence, rather
+  than keeping a citation to something else. In a strict-mode run that can mean a recommendation no longer rests on
+  what it appeared to rest on. Observer: the report's reader.
+- **S-14.** The pass that attacks the report's evidence can raise a finding about a citation that does not support its
+  claim. Observer: the report's reader.
+- **S-15.** The final check catches a citation that points at the wrong entry even when no merge collision occurred, so
+  a run that never fanned out is covered too. Observer: the report's reader.
+- **S-21.** A pull request body from a degraded run carries the coverage disclosure. Observer: every reviewer on that
+  pull request. This is the widest audience of the three surfaces and the only one that sees neither the terminal nor
+  the report file.
+
+## Change Units
+
+Each unit leaves every skill file internally consistent: no pointer without a target, no rule with two homes, no
+verification item asserting something no template produces.
+
+### Unit 0: Free headroom in the `code-review` body
+
+**What it does.** Collapses Step 8's restatement of the template's own render rules to a pointer, under the convention
+the same skill already applies to size-based demotion.
+
+**Delta entries.** S-17.
+
+**Ordering constraint.** Runs before **Units 3 and 4**, and only if the measured line count leaves less headroom than
+the pointers those two units add to the body. Measure first: the file has moved in twenty-eight commits in ninety days,
+so the number in the findings is a reading, not a constant.
+
+**How you know it worked.** Two measurements, not one. Before Unit 3, the body has room for the pointers Units 3 and 4
+add. **After Unit 4 lands, measure again.** That second reading is the only conclusive test of whether this unit did
+its job, because the content it made room for does not exist until then. And the render rules read the same way to
+someone following Step 8 with `template.md` open.
+
+### Unit 1: `research`, one home for the invariant
+
+**What it does.** Rewrites the invariant in Operating Principles as two-part. Converts the merge step, the final check,
+and the report template's comment from definitions to citations. Adds the one-line summary column to both of the
+skill's inline column enumerations.
+
+**Delta entries.** S-12, S-15, S-16, S-20.
+
+**Ordering constraint.** Before Unit 2, or the strengthened check contradicts three surviving statements of the weaker
+form.
+
+**How you know it worked.** Searching the skill and its template for the invariant finds one definition and three
+citations of it, and both column enumerations name every column the template's table renders.
+
+### Unit 2: `research`, the mapping and the rewrite
+
+**What it does.** Gives the merge step the mapping, the rewrite across every citation surface including the
+evidence-status field, and the dropped-source handling. Passes the mapping to the validation dispatch.
+
+**Delta entries.** S-13, S-14.
+
+**Ordering constraint.** After Unit 1.
+
+**How you know it worked.** Run any genuinely two-domain question at the medium band, which is enough to dispatch
+parallel analysts that each restart their own numbering. Then check the rendered report against what the analysts
+returned. Every identifier inside an evidence-status field points at the source that analyst cited, and a
+claim whose source was dropped carries no citation rather than a rewritten one. The mapping itself is a working record
+the run holds, not a report section, so it is checked during the run rather than read afterward.
+
+### Unit 3: `code-review`, manual-only mode
+
+**What it does.** Adds the mode section to `agent-dispatch.md` with its detection rule and the full sweep mapping, and
+points Step 3 and Step 7 at it, including Step 7's changed clause about the validation pass.
+
+**Delta entries.** S-1, S-2, S-3.
+
+**Ordering constraint.** After Unit 0 if headroom is short.
+
+**How you know it worked.** Deny the session's dispatch permission and run the skill on a real diff. The run names the
+mode, sweeps the mapped categories, skips the validation pass, and reaches the report step. Then run it again normally
+and confirm an agent that returns with nothing to say does not trip the mode. Nothing yet says any of this in the
+report; that is Unit 4.
+
+### Unit 4: `code-review`, the coverage disclosure
+
+**What it does.** Adds the Review Coverage block to the template with its heading level, opening line, and row grammar.
+Names it in the fixed section order. Adds the verification item and the closing-message clause.
+
+**Delta entries.** S-4, S-5, S-6, S-7.
+
+**Ordering constraint.** After Unit 3, which produces the absent-coverage list the rows render.
+
+**How you know it worked.** The dispatch-denied run from Unit 3 now produces a report whose coverage block names its
+own cause and carries one row per absent area. A healthy run produces a report with no such section. Read the
+closing message alone, without opening the file, and check that it tells you no specialist read the change.
+
+### Unit 5: `code-review`, the packaging category
+
+**What it does.** Adds the `Packaging (when applicable)` category with its triggers, its finding content and which
+sentence varies, its summary-row prefix, its severity default, and its mode scope.
+
+**Delta entries.** S-8.
+
+**Ordering constraint.** None. Independent of Units 0 through 4.
+
+**How you know it worked.** A small fixture diff touching include or exclude patterns, reviewed twice. In Mode A it
+raises one warning whose first sentence names the rule the diff added, with a row opening `Not checked —`. In Mode C
+the same diff raises nothing from this category.
+
+### Unit 6: `code-review`, location attribution and its two guards
+
+**What it does.** Adds the attribution rule and location form to `finding-content.md`, the fifth challenge axis to the
+validation brief, and the structural verification item, plus a contents list on the verification file.
+
+**Delta entries.** S-9, S-10, S-11.
+
+**Ordering constraint.** After Unit 5, which settles what altitude the rule is written at.
+
+**How you know it worked.** Review a file over a thousand lines with a finding in a region far from the top. The
+finding names its enclosing unit and the lines read to confirm it. **The second guard cannot be staged.** Nobody can
+inject a malformed finding and force the verification pass to reject it, so that half is verified by reading the item
+rather than by running it. This plan says so, rather than claiming a check nobody can run.
+
+### Unit 7: The disclosure survives to the pull request
+
+**What it does.** Names Review Coverage among the optional sections `post-code-review-to-pr` carries across, and
+exempts it from the clarity pass's length-matching instruction.
+
+**Delta entries.** S-21.
+
+**Ordering constraint.** After Unit 4, which creates the section.
+
+**How you know it worked.** Post a review from the dispatch-denied run to a pull request and read the posted body. The
+coverage section is in it.
+
+### Unit 8: The long-form docs
+
+**What it does.** Brings both skills' canonical docs into line with what the skills now do.
+
+**Delta entries.** S-18, S-19.
+
+**Ordering constraint.** Last. Documenting a behavior before it lands is how the two drift.
+
+**How you know it worked.** Neither doc states a fact this change made wrong, and the `code-review` doc names its modes
+without a running total.
+
+## Risks
+
+**The disclosure gets deleted on its way to the pull request.** This is the risk the review round caught and Unit 7
+answers. The skill that posts a review publicly is instructed to skip sections that name no problem at a location, and
+a coverage disclosure names none by construction. If Unit 7 is dropped or its exemption is worded loosely, the fix for
+the first defect survives on the two surfaces with the narrowest audiences. It vanishes from the one with the widest.
+Detectable by posting a degraded run's review to a pull request and reading the posted body.
+
+**The disclosure lands in a file nobody reads.** The coverage block renders into a report the run deliberately never
+pastes into the conversation. If the closing-message clause in S-7 is dropped or weakened back to a mode name and a
+count, a person who stops at the terminal learns nothing. That reproduces the original failure one level up.
+Detectable by running the skill with dispatch denied and reading only what the terminal says.
+
+**Conditional rendering leaves a reader wanting assurance with none.** The absence of the coverage section means full
+coverage ran. A reader who wants positive confirmation of that — an auditor, or someone weighing an old approval months
+later — has nothing to read, because absence is not a statement. This is a real cost, and it is a smaller one than it
+first looks. A reader who never sees the section correctly assumes the review did what reviews do, and the section's
+absence matches that assumption. The always-present alternative is recorded with its reopen trigger, and the trigger is
+this reader appearing, not a reader drawing a wrong inference.
+
+**Unit 5 raises a finding on every packaging diff, including ones that are fine.** The category cannot tell a dangerous
+exclude rule from a harmless one, because it does not open the artifact. Its blast radius is every Mode A review of a
+build-configuration change. Two mitigations are in the plan and both matter. The first sentence is derived from the
+diff, so the finding does not degrade into identical boilerplate. The summary row opens with a cue marking it as
+something the review did not check rather than something it proved. A third question stays open, below.
+
+**Unit 6's rule fires on a narrower population than a loose reading suggests.** The population is region reads on files
+over a thousand lines. Written loosely it reaches every finding; written tightly it reaches none. An earlier draft of
+this entry aimed at a population the skill does not read at all, and the review round caught it. The worked example is
+what holds the scope in place, so a builder who drops the example for brevity removes the calibration.
+
+**Unit 2 has the widest blast radius in `research`.** Every citation in every medium or large report passes through the
+mapping. A mapping built wrongly relabels citations that were correct, which is worse than the defect it fixes, because
+the defect was rare and this would be systematic. The mapping's source column exists so a run can be checked against
+one analyst's raw output before the rewrite is trusted.
+
+**Nothing here is pinned by a test.** No runner in this repository can execute a skill's procedure, and no part of this
+change is scriptable enough for a Bats test. Both conditions the change exists to handle are reproducible locally at
+the cost of one deliberate run each, and the unit checks above say how. What does not exist is anything that would
+catch a regression later.
+
+## Deferred (YAGNI)
+
+- **A shared rule generalizing the three citation defects**, in a vendored reference file. The shape they share is a
+  moral rather than a procedure, and the only candidate second consumer inside `code-review` is ruled out by C-21.
+  **Reopen when** a third skill needs identifier-mapping-after-merge.
+- **A new reference file per defect** — `degraded-modes.md`, `built-output-review.md`, `citation-integrity.md`. Each
+  would cost a body link against a five-line budget, and each rule has a home in a file that already exists. **Reopen
+  when** a second skill consumes the same rule.
+- **`Mode D` as a fourth letter in the existing series.** **Reopen when** git context and agent availability become
+  mutually exclusive.
+- **An always-present Review Coverage section on full-coverage runs.** **Reopen when** a run is observed where a reader
+  missed the gap because the section rendered only on absence.
+- **Per-analyst identifier prefixes in `research`.** In `code-review` the equivalent immunity is free because prefixes
+  are per-agent-type identities. In `research` every analyst is the same agent type, so a prefix would have to be a
+  dispatch-order index passed in the brief. **Reopen when** a citation is rewritten wrongly despite the mapping.
+- **Generalizing the location-attribution rule to every cited location.** The cost would land on all thirty findings a
+  capped review can carry. **Reopen when** a misattributed ordinary source location is reported.
+- **An agent-availability probe in the shared `scripts/`.** A shell script cannot observe whether a model's tool call
+  will be permitted. **Reopen when** a host exposes tool availability to a script.
+- **Teaching the shared `han-core` specialist agents the location-attribution rule.** Those agents serve every skill
+  that dispatches them, so changing their output contract reaches past these two skill folders. **Reopen when** an
+  agent brief is given a generated artifact to scan.
+- **Persisting the `research` mapping to a file.** The report is that skill's only output. **Reopen when** an operator
+  asks to audit a merge after the fact.
+- **A test harness pinning report structure.** No runner in this repository can execute a `SKILL.md`. **Reopen when**
+  one exists.
+
+## Cut for Scope
+
+Both entries are yours to reinstate, and your saying so is itself a valid justification the reinstated entry records
+([D-17](artifacts/change-decision-log.md#d-17-two-gaps-the-discovery-round-found-are-cut-for-scope-and-named-for-the-operator)).
+
+- **The YAGNI section's missing mode scope**
+  ([C-18](artifacts/current-state-findings.md#c-18-the-yagni-checklists-mode-exception-lives-only-in-its-caller-not-in-the-file-named-canonical)).
+  Someone opening `review-checklist.md` to follow its YAGNI procedure applies it to an uncommitted-changes review,
+  because the file states the procedure unconditionally while Step 4 suspends it there. Cut because feedback issue
+  #194 does not report it and it is not a necessity of any of the four defects. It is the same class of edit as the
+  mode-scope paragraph Unit 5 already writes, in the same file, so reinstating it is close to free.
+- **The unnamed mechanism behind generalist-finding deduplication**
+  ([C-22](artifacts/current-state-findings.md#c-22-the-junior-developer-deduplication-instruction-names-no-mechanism)).
+  A review can carry a generalist finding pointing at a specialist finding that says something else, because nothing
+  states how "the same issue" is decided. The check confirms the reference exists, rather than that it fits. That is
+  the issue's own shared shape in a defect the issue does not report. Cut on the same grounds, and it is labelled
+  `Unverified` in any case: nobody could inspect a completed run's output to see whether the substitution is carried
+  out correctly today.
+
+## Open Items
+
+- **Non-blocking, and the one I would put back in front of you: a packaging diff can no longer produce a clean
+  review.** The finding S-8 raises is a warning, and the template turns any warning into "this code can be merged, but
+  the identified warnings should be reviewed first." So every Mode A review of a build-configuration change stops
+  saying the code can be approved, including changes with nothing wrong. The summary-row prefix marks the row as
+  something unchecked rather than something proven, which is the mitigation available inside the template's existing
+  vocabulary. Exempting the recommendation line itself is a change to what an approval means, so it is yours rather
+  than mine to make. What would settle it: your call, or a few runs showing whether readers start discounting the
+  recommendation line on packaging diffs.
+- **Non-blocking: defect 2 is closed by disclosure, not by inspection.** Issue #194 asks the run to inspect the
+  produced artifact; you chose the disclosure knowing it does not catch the reported defect
+  ([D-12](artifacts/change-decision-log.md#d-12-escalation-register-the-one-question-this-run-took-to-the-operator)).
+  What would settle it differently: a packaging defect reaching production through a review that carried the S-8
+  finding.
+- **Non-blocking: no runtime evidence exists for either reported failure.** Nobody in this run could observe a
+  `code-review` run with dispatch denied, or a `research` fan-out whose registries collided. Every claim about what
+  those runs produce rests on reading the procedure. The issue supplies the substitute: it reports both as runs that
+  already happened, and the unit checks say how to stage each one locally.
+
+## Review Findings
+
+One round, at the medium band's cap of two, stopped after one. Every finding was a correction this plan could
+apply, rather than a question needing a specialist whose domain had not run. Three specialists reviewed the draft:
+`han-core:junior-developer`, `han-core:test-engineer`, and `han-core:user-experience-designer`. Decisions are in
+[`artifacts/change-decision-log.md`](artifacts/change-decision-log.md); what follows is what changed and why.
+
+**Findings that changed a delta entry, sending it back through the behavior gate:**
+
+- **S-9's population did not exist.** The draft aimed the location rule at generated files on the diff, which Step 4
+  instructs the run to skip. It also aimed at automated-check output, which already emits its own file and line. The rule was
+  keeping a fix alive with nothing to fire on. Re-scoped to the region-read path, which is real and current. Raised by
+  `han-core:junior-developer`.
+- **S-3 was not behavior-preserving.** Its condition changes, and the pass that re-checks findings against the code
+  must now skip in manual-only mode because it dispatches an agent. The draft's own reasoning elsewhere relied on that
+  fact, while the entry said the opposite. Reclassified and the clause written. Raised by `han-core:junior-developer`.
+- **S-15 was not behavior-preserving.** It is where the support judgment first executes, so it catches a wrong citation
+  in a run with no merge collision at all. Reclassified. Raised by `han-core:test-engineer`.
+- **A third surface would have deleted the disclosure.** The skill that posts a review to a pull request is instructed
+  to skip sections naming no problem at a location. Added as S-21 and Unit 7. Raised by
+  `han-core:user-experience-designer`.
+
+**Findings that corrected a pinned contract:**
+
+- The detection rule counted an empty agent result as a dispatch failure. That would have printed a disclosure saying
+  security coverage was absent on a run where the always-dispatched security agent ran and stayed silent by design. A
+  false disclosure is worse than the silent one this change fixes. Dropped that trigger.
+- The three worked examples of a degraded run described three different runs, with four items in one, two in another,
+  and a count of six in the third. Made to describe one run, and the coverage population stated once.
+- The mapping's worked example mapped three different local identifiers to one merged identifier with contradictory
+  dispositions, and carried no column naming the source. Nothing could be joined back to an analyst's output.
+  Rewritten with a source column.
+- Where the `research` mapping lives was specified two contradictory ways: a unit check said the report carries it
+  while the deferral list said persisting it was out of scope. Settled as a working record the run holds.
+- The support check reads a column that both of the skill's own inline column enumerations omit. Added as S-20.
+- The sweep mapping showed two rows of roughly eleven. Written out in full, which is what revealed that four agents
+  have no counterpart or a partial one, and that a config-declared extra agent cannot be pre-mapped at all.
+
+**Findings that corrected the plan's own bookkeeping:**
+
+- Unit 0's ordering constraint named the wrong units, sequencing a `research` unit behind a `code-review` headroom
+  edit. Corrected, and the second measurement it needs is now scheduled.
+- S-5 was a no-op: a lazily-rendered block already satisfies the verification item the draft proposed to amend.
+  Repurposed to the fixed-order list, which genuinely does need the section named in it.
+- Unit 6's second check is not stageable, and the plan now says so instead of claiming a check nobody can run.
+- Three reference files need contents-list maintenance, one of them because this change pushes it past the length that
+  requires one ([D-20](artifacts/change-decision-log.md#trivial-decisions)).
+
+**Findings not acted on, with the reason:**
+
+- The authoring guidance puts conditional logic in a `SKILL.md` body and domain knowledge in a reference file, which
+  argues against S-1's placement. Not acted on. That file already carries the dispatch steps and is already named an
+  authoritative home, so the in-file precedent is stronger than the general rule, and the body has no room. Recorded
+  because the plan justified the placement by line count where the guidance would ask what kind of content it is
+  ([D-19](artifacts/change-decision-log.md#d-19-the-guidances-placement-rule-is-noted-and-not-followed-with-the-reason-recorded)).
+- The always-present coverage section was re-examined and left rejected, with the reopen trigger sharpened to name the
+  reader it would serve.
+
+**Nothing was labeled `Unverified` in a way that blocks.** Two findings rested on inputs nobody could inspect, both
+about surfaces no run has produced yet: a rendered report from a degraded run, and a posted pull request body. The
+instruction text underlying both was read directly and confirmed, so the fixes rest on what the files say rather than
+on what a run would do.

--- a/han-coding/docs/skills/automated-test-planning.md
+++ b/han-coding/docs/skills/automated-test-planning.md
@@ -36,8 +36,9 @@ to use the skill. For what the skill does internally, read the skill definition 
   Classification comes from both agents' rankings mapped into a unified scheme.
 - **Unified IDs with cross-reference.** `TP-001`, `TP-002`, … with the original agent ID recorded (for example, _"TP-001
   (from T3)"_).
-- **Three review modes.** Mode A (full git context, branch vs default), Mode B (uncommitted/staged changes), Mode C (no
-  git, glob-discovered files).
+- **Git context modes.** Mode A (full git context, branch vs default), Mode B (uncommitted/staged changes), Mode C (no
+  git, glob-discovered files). These describe how much git context the run has; the focused / full distinction below is
+  a separate axis set by the size band.
 - **Plain-language spine, technical reference below.** The plan leads with a Summary, a What Needs Testing and Why
   themes section, and a What Each Test Covers walkthrough, all in plain language. The per-item detail (test level, code
   paths, approach, priority justification), deferred and dropped items, coverage counts, and scope sit below under a

--- a/han-coding/docs/skills/code-review.md
+++ b/han-coding/docs/skills/code-review.md
@@ -26,9 +26,22 @@ to use the skill. For what the skill does internally, read the skill definition 
   governed by Step 3.3 in the skill body, the authoritative home for size-based demotion. Manual findings (Steps 4 to 6)
   and agent findings (Step 7) follow the same rules: small changes escalate only Critical and prefer the lower severity
   on uncertainty; medium escalates Critical and Warning; large prefers the higher severity when in doubt.
-- **Three review modes.** Mode A uses the full git branch diff. Mode B reviews uncommitted work when no branch diff
-  exists. Mode C reviews specified files when git is absent. **In Mode B and Mode C the YAGNI checklist is skipped
-  unless explicitly requested**, because no diff exists to distinguish introduced code from pre-existing code.
+- **Review modes on two independent axes.** The git axis: Mode A uses the full git branch diff, Mode B reviews
+  uncommitted work when no branch diff exists, and Mode C reviews specified files when git is absent. **In Mode B and
+  Mode C the YAGNI checklist is skipped unless explicitly requested**, because no diff exists to distinguish introduced
+  code from pre-existing code. The agent axis: **manual-only mode** is the state a run enters when the dispatch
+  mechanism fails (the `Agent` tool is unavailable or a dispatch call is denied), so no specialist reads the change. It
+  is independent of the git axis; a Mode A run with a full branch diff can be manual-only. An agent that returns with
+  nothing to say does not trigger it, because the security agent stays silent by design when its evidence bar is not
+  met. In manual-only mode the manual review also sweeps, by hand, the checklist categories that substitute for each
+  absent agent, and the report says which coverage was absent and which of it the sweep could not recover.
+- **Packaging findings name a gap, not a defect.** When a Mode A diff changes what gets packaged (shading or relocation
+  rules, vendoring, include or exclude patterns, dependency scope, bundling config), the checklist raises a Warning
+  saying the review did not open the built artifact and what to check by hand before merging. Its summary row opens
+  with `Not checked —` so you can tell it from a proven defect while triaging. It does not inspect the artifact.
+- **A location is confirmed, not carried forward.** When the review reads a file over 1000 lines by its changed regions,
+  a finding's location can be attributed upward to the wrong declaration. Such a finding names its enclosing unit and
+  the lines the review read in isolation to confirm it. A finding from a file read whole carries no such note.
 - **Size-aware agent dispatch.** Two agents always run on every review (`junior-developer` for clarity and standards,
   `adversarial-security-analyst` for exploit-path security). The rest of the roster (`test-engineer`,
   `edge-case-explorer`, `structural-analyst`, `behavioral-analyst`, `concurrency-analyst`, `data-engineer`,
@@ -61,7 +74,8 @@ to use the skill. For what the skill does internally, read the skill definition 
   a bare assertion demotes rather than drops, and an uncertain verdict leaves the finding standing. Security findings
   are dropped only when the demonstrated exploit is refuted with counter-evidence. The pass is a finding _filter, not a
   finding source_: it never contributes findings of its own, and it skips entirely when the review produced no
-  corrective findings.
+  corrective findings. It also skips in manual-only mode, because it dispatches an agent; the report's Review Coverage
+  section then says the findings were not re-checked by a second pass.
 - **Branch context loaded at Step 1.5.** Before agents are dispatched, the skill loads four sources of branch-level
   context in order: PR description (via `gh pr view` when `gh` is available, Mode A only), a local `pr-body`,
   `PR_BODY.md`, or `.pr-body` file at the repo root, branch commit messages, and an implementation plan from the
@@ -165,8 +179,13 @@ Each finding's prose appears exactly once (its finding block, or its full securi
 block; the summary-table row is an index, not a copy), and sections render only when they have content: a review of a
 small change produces a small document. The Review Summary table and the Review Recommendation are always present; every
 other section appears only when it has at least one item, and when several are present they keep a fixed order
-(Critical, Warnings, Suggestions, YAGNI, Security Vulnerabilities, Remediation, What's Good). The document can contain:
+(Review Coverage, Critical, Warnings, Suggestions, YAGNI, Security Vulnerabilities, Remediation, What's Good). The
+document can contain:
 
+- **A Review Coverage section**, present only when the run was manual-only. It opens by saying agent dispatch was
+  unavailable so no specialist read the change, then carries one row per absent coverage area in plain English: what
+  was swept by hand and under which checklist categories, and what was not swept with what to do instead. Its absence
+  means every planned coverage ran.
 - **A Review Summary table** indexing every corrective finding and every security finding across categories (automated
   checks, correctness, testing, security, ADR/standard/docs compliance, documentation freshness), ordered by severity. A
   corrective finding's tier is carried by its task-ID prefix; a security finding shows its tier inline in the row (for
@@ -278,7 +297,8 @@ project config), a file-by-file manual review, a documentation compliance pass, 
 - **Large change.** Typically 6–9 agents plus the manual pass.
 
 When the review produces at least one corrective finding, one additional `adversarial-validator` runs after the roster
-to validate the finding list (Step 7.4); a clean review skips it. One `han-communication:readability-editor` then
+to validate the finding list (Step 7.4); a clean review skips it, and so does a manual-only run, which cannot dispatch
+it. One `han-communication:readability-editor` then
 rewrites the assembled review's prose against the shared readability standard (Step 8.5), leaving every task ID,
 severity, `file_path:line_number` reference, and code snippet unchanged.
 
@@ -313,10 +333,13 @@ readability pass inserted between Steps 8 and 9):
    data-access files only; `junior-developer` and `adversarial-security-analyst` receive the full list). Step 3.5
    launches all selected agents in parallel, appending the shared `$focus_areas` and `$branch_context` blocks to every
    prompt and the per-agent dispatcher directives to `structural-analyst`, `behavioral-analyst`, `junior-developer`, and
-   `edge-case-explorer`.
+   `edge-case-explorer`. If the dispatch mechanism fails, the run enters manual-only mode: it keeps the selected roster
+   as the absent-coverage list and the manual review sweeps the mapped checklist categories in the agents' place.
 4. **Manual file-by-file review.** Every changed file (alphabetical) against the review checklist: correctness, data
    isolation, performance, error handling, testing, API design, maintainability, organization, docs, style, database,
-   ADR compliance. In Mode B and Mode C, the YAGNI checklist is skipped unless the user requests it in `$focus_areas`.
+   packaging (Mode A only), ADR compliance. In Mode B and Mode C, the YAGNI checklist is skipped unless the user
+   requests it in `$focus_areas`. A finding located through a region read of a file over 1000 lines has its enclosing
+   unit confirmed by reading that unit in isolation before the finding is written.
 5. **Documentation compliance analysis.** Read only the ADRs, coding standards, and docs whose subject matter the change
    touches, not the whole directory, and weight correctness-bearing rules over style minutiae the linter already covers.
    Verify each standard's premise applies by reading at least one architectural file in this codebase before raising a
@@ -328,8 +351,9 @@ readability pass inserted between Steps 8 and 9):
    the size-aware rubric in `agent-finding-classification.md`, governed by Step 3.3's size rules. Junior-developer
    findings that overlap with a specialist's finding reference the specialist instead of duplicating. 7.4 dispatches one
    `adversarial-validator` over the consolidated corrective finding list to confirm, demote, or (with concrete
-   counter-evidence) drop each finding; it runs whenever any corrective finding exists, even when no agents were
-   dispatched, and skips when the review is clean.
+   counter-evidence) drop each finding; it runs whenever any corrective finding exists, and skips when the review is
+   clean or the run is manual-only. Its brief also challenges any finding whose location came from a region read and
+   names an enclosing unit never read in isolation.
 8. **Generate review output.** Assemble the final review using the review template, rendering each section only when it
    has content and keeping the fixed section order.
    8.5. **Rewrite the finding prose for readability.** Dispatch `readability-editor` over the assembled review so its prose
@@ -347,7 +371,9 @@ readability pass inserted between Steps 8 and 9):
    recommendation still reflects their severity, and the YAGNI section's verbatim opening is preserved. The same step
    confirms the newer content arrived: every finding you are expected to act on carries its plain-language explanation,
    every corrective one names a fix route, and a finding that may never fire says so both in its own explanation and in
-   its summary row. Anything missing is fixed before the review reaches you, not reported to you as a caveat.
+   its summary row. It checks that a manual-only run's report carries the Review Coverage section with one row per
+   absent area, and that a full-coverage run's report does not, and that every region-read finding names its confirmed
+   enclosing unit. Anything missing is fixed before the review reaches you, not reported to you as a caveat.
 10. **Present.** A short message that leads with the recommendation and the counts by severity, then the path, then the
     run's own facts. The review is never pasted into the conversation.
 
@@ -358,7 +384,9 @@ A short message, in a fixed order, so the answer is the first thing you read:
 1. The recommendation, in the report's own words.
 2. The counts by severity, with any advisory count named separately rather than folded into the total.
 3. The path to the report, plus any report it replaced and any destination it could not write to.
-4. The run's own facts last: the size band and why, and the validator reconciliation.
+4. The run's own facts last: the size band and why, and the validator reconciliation. When no specialist read the
+   change, this part says so: agent dispatch was unavailable, how many coverage areas were swept by hand and how many
+   were not, and that the report's Review Coverage section lists them.
 
 A clean review says the code can be approved and gives you the path. A review whose only findings are advisory still
 recommends approval, says the count needing action is zero, and names the advisory count beside it, so you are never

--- a/han-coding/skills/code-review/SKILL.md
+++ b/han-coding/skills/code-review/SKILL.md
@@ -230,11 +230,12 @@ the rubric in `references/agent-finding-classification.md`. Do not re-derive siz
 These four sub-steps are specified in [agent-dispatch.md](./references/agent-dispatch.md), and every reference to
 Step 3.2, 3.3, 3.4, or 3.5 elsewhere in this skill points there. It carries the minimum roster dispatched at every size
 and the file-list signals that select each conditional agent (3.2), the brief-scoping rules including the authoritative
-size-based demotion rule (3.3), the domain-scoped file lists (3.4), and the two named-binding blocks plus the exact
-prompt for each agent (3.5).
+size-based demotion rule (3.3), the domain-scoped file lists (3.4), the two named-binding blocks plus the exact
+prompt for each agent (3.5), and **manual-only mode**: the mode a run enters when the dispatch mechanism itself fails at
+3.5, with its detection rule, the absent-coverage list selection leaves behind, and the by-hand sweep that substitutes.
 
 Select against the `{size}` from Step 3.1, scope each brief to the change, and dispatch every selected agent in a
-single message so they run in parallel.
+single message so they run in parallel. If dispatch fails, enter manual-only mode as that file specifies.
 
 Continue to Step 4 immediately. Results will be collected in Step 7.
 
@@ -333,8 +334,9 @@ Documentation freshness findings merge into the same output sections as the othe
 ## Step 7: Collect and Classify Agent Results
 
 Wait for all agents dispatched in Step 3 to complete. Each agent returns a summary with finding counts and a file path.
-**Skip Steps 7.1–7.3 if no agents were dispatched in Step 3; Step 7.4 still runs whenever the review has produced at
-least one corrective finding (manual or agent).**
+**In manual-only mode (the dispatch mechanism failed at Step 3.5; defined in `agent-dispatch.md`), skip Steps 7.1–7.3,
+and skip Step 7.4 too, because it dispatches an agent. Outside that mode, Step 7.4 runs whenever the review has produced
+at least one corrective finding (manual or agent).**
 
 This step runs in four numbered sub-steps. Order matters: read the agent output, apply the reachability demotion gate,
 apply the size-aware rubric, then validate the consolidated finding list with an independent adversarial pass.
@@ -397,13 +399,10 @@ open the file: what they could observe going wrong, what has to be true for it t
 [finding-content.md](./references/finding-content.md) for which findings carry it, what it answers, where the answers
 come from, and why working them out NEVER changes a finding's severity, task ID, or position. **Every CRIT, WARN, and
 SUGG finding also names how it gets fixed** — test-first, restructure, or by hand — chosen by the rule in that same
-file. Name the route; never start it. Use the template at
-[template.md](./references/template.md) for the output structure. **Render a section only when it has content** — never
-emit a heading followed by empty-state placeholder text. The Review Summary table and the Review Recommendation are
-always present; every other section (Critical, Warnings, Suggestions, YAGNI, Security Vulnerabilities, Remediation,
-What's Good) appears only when it has at least one item. When more than one section is present, keep them in the fixed
-order the template defines and never vary it. A clean review is the table's no-issues row plus an approval
-recommendation, and nothing else.
+file. Name the route; never start it. Use the template at [template.md](./references/template.md) for the output
+structure. It is the authoritative home for which elements are always present, which sections render only when they
+have content, and the fixed order present sections keep; apply those rules from there and never restate them here. A
+clean review is the table's no-issues row plus an approval recommendation, and nothing else.
 
 Each finding's prose appears exactly once — in its finding block, or in its full security block. The Review Summary
 table row is an index entry, not a second copy of the prose; a `Tension with …` pointer note is a pointer, not prose.
@@ -479,7 +478,10 @@ report yet.
    total.
 3. **The path** to the report file. Name the report you replaced when Step 8.6 replaced one, and the destination you
    could not use when it fell back.
-4. **The run's own facts, last:** the size band and why, and the validator reconciliation line. Or nothing at all.
+4. **The run's own facts, last:** the size band and why, and the validator reconciliation line. In manual-only mode,
+   one clause: agent dispatch was unavailable, so no specialist read this change; how many coverage areas were swept by
+   hand and how many were not; and a pointer to the report's Review Coverage section. Name the cause and the
+   consequence, never the mode name, and do not list the areas; the report's block does. Or nothing at all.
 
 **NEVER paste the review into the conversation.** The report is the deliverable and it is a file. Pasting it is what
 made the one fact a person needed after a review, the path, unfindable inside a message long enough to hold everything

--- a/han-coding/skills/code-review/references/agent-dispatch.md
+++ b/han-coding/skills/code-review/references/agent-dispatch.md
@@ -5,9 +5,10 @@
 - Step 3.2: Select agents
 - Step 3.3: Scope every agent brief to the change
 - Step 3.4: Domain-scoped file lists
+- Manual-only mode: when the dispatch mechanism fails
 
 The review roster, the signals that select each agent, the brief-scoping rules, the domain-scoped file
-lists, and the exact per-agent dispatch prompts. Step 3 selects and dispatches using this file. The sub-step numbering below is the skill's own; other sites cite
+lists, the exact per-agent dispatch prompts, and the manual-only mode a run enters when it cannot dispatch at all. Step 3 selects and dispatches using this file. The sub-step numbering below is the skill's own; other sites cite
 these sections as Step 3.2 through Step 3.5.
 
 ### Step 3.2: Select agents
@@ -208,3 +209,59 @@ from earlier steps):
     `han-core:devops-engineer`. Apply the calibration directive. Write every finding clear of the four named tone
     anti-patterns (sugarcoated criticism, thin blame, tourist citation, bibliographic empathy).
     Write your output to {output_directory}/on-call-analysis.md"
+
+### Manual-only mode: when the dispatch mechanism fails
+
+This section is the authoritative home for **manual-only mode**. Every other site (Step 3's pointer, Step 7's skip
+sentence, the template's Review Coverage block, the verification item, and Step 10's closing clause) names the mode and
+points here rather than describing it. The mode is not a fourth letter in the Mode A / B / C series: those letters
+enumerate how much git context a run has, and agent availability is an independent axis. A Mode A run with a full
+branch diff can be manual-only.
+
+**Detection is by the dispatch mechanism failing at Step 3.5.** Exactly two triggers:
+
+1. The `Agent` tool is unavailable to the run (not in the session's allowed tools, or absent from the tool list).
+2. A dispatch call is made and denied (a permission refusal, or a tool error saying the call could not be placed).
+
+**An agent that returns with nothing to say is not a trigger.** The always-dispatched security agent is specified to
+stay silent when its evidence standard is not met, so an empty result is a run that ran and passed. Reading silence as
+failure would print a disclosure saying security coverage was absent on a run where it was present. A false disclosure
+is worse than the silent gap this mode exists to name. Do not probe for availability before dispatching; the attempt is
+the detection.
+
+**What selection produces in this mode.** Step 3.2 has already run by the time detection fires, so the roster it
+selected is a fact, not a counterfactual. Keep that roster as the **absent-coverage list**: every agent Step 3.2
+selected (the two always-dispatched agents, every conditional agent whose signal fired, and any extra agent from a
+project config that was included), plus the independent validation pass at Step 7.4, which dispatches an agent and so
+cannot run either. That list is what the Review Coverage block in `template.md` renders, one row per item.
+
+**Emit this line** when detection fires, filling the parenthetical with the verbatim tool error or the phrase shown:
+
+```
+Manual-only mode: agent dispatch unavailable ({verbatim tool error, or "Agent tool not in allowed-tools"}).
+Manual review is the primary path. Coverage absent: junior-developer, security, and every conditional agent
+Step 3.2 selected. See the sweep mapping for what substitutes.
+```
+
+**The by-hand sweep.** Step 4's manual review normally runs at its own depth beside the specialists. In manual-only
+mode it is also the substitute for them, so for each agent on the absent-coverage list, apply the checklist categories
+mapped below with the extra scrutiny the Step 4 focus-area rule describes, at the `{size}` band from Step 3.1. The
+mapping is written out for every agent so two runs sweep the same thing, and so that what the sweep does not recover is
+visible rather than implied:
+
+- `han-core:junior-developer` → Code Maintainability, Documentation, Code Style & Patterns, Architecture Decision Records — at the `{size}` band from Step 3.1.
+- `han-core:adversarial-security-analyst` → Data Isolation, Error Handling, API Design — at the `{size}` band. Partial: nothing substitutes for an exploit path demonstrated against the code.
+- `han-core:test-engineer` → Testing, Correctness — at the `{size}` band.
+- `han-core:edge-case-explorer` → Correctness, Error Handling — at the `{size}` band. Partial: the checklist asks whether edge cases are handled, not which ones exist.
+- `han-core:structural-analyst` → Code Organization, Code Maintainability — at the `{size}` band.
+- `han-core:behavioral-analyst` → Error Handling, Correctness — at the `{size}` band.
+- `han-core:data-engineer` → Database, Performance, Data Isolation — at the `{size}` band.
+- `han-core:on-call-engineer` → Error Handling, Performance — at the `{size}` band. Partial: no category covers timeouts, retry backoff, or idempotency.
+- `han-core:concurrency-analyst` → nothing substitutes. No checklist category covers races, lock ordering, or shared mutable state.
+- `han-core:devops-engineer` → nothing substitutes. No checklist category covers rollout, observability, or infrastructure.
+- An agent from a project config's `## Extra Agents` list → nothing substitutes. Name the agent and say its coverage was not swept.
+- The Step 7.4 independent validation pass → nothing substitutes. The findings reach the report without a second pass against the code; the coverage row says so.
+
+Four roster agents have no counterpart or a partial one, and concurrency and infrastructure coverage is recovered not at
+all. Those rows render as `not swept` in the report. That is the honest result, and it is why the disclosure matters
+more than the sweep does.

--- a/han-coding/skills/code-review/references/finding-content.md
+++ b/han-coding/skills/code-review/references/finding-content.md
@@ -8,10 +8,12 @@
 - The fix route
 - Both cues reach the summary table
 - Security findings
+- Enclosing-unit attribution
 
 Every finding a reader is expected to act on opens with a plain-language explanation written for someone who will not
-open the file. This file says which findings carry it, what it answers, and where the answers come from. The block
-format it renders into is in [template.md](./template.md).
+open the file. This file says which findings carry it, what it answers, and where the answers come from, plus the rule
+for confirming a finding's location when it came from a region read. The block format it renders into is in
+[template.md](./template.md).
 
 The register comes from Han's standard for explaining technical work to a non-implementer, sourced by invoking
 `han-communication:explanation-guidance` before any finding is drafted. Give a concrete outcome the reader could
@@ -112,3 +114,30 @@ skip the explanation.
 
 It does not gain a separately-labelled fix route. Its section already ends with a single Remediation note naming what to
 do, and a second answer to the same question in one block is worse than either alone.
+
+## Enclosing-unit attribution
+
+Step 4 reads a file over 1000 lines by its changed regions and their surrounding context rather than whole. A location
+established that way is a guess until the unit is read: you see a hit, you look upward for the nearest declaration, and
+the declaration you find may not be the one that encloses it. Nothing else in the review re-reads the code to check, and
+the pass that does (Step 7.4) runs only when there are corrective findings and never in manual-only mode.
+
+**The rule.** A location established by reading a region of a file rather than the unit that contains it is a guess until
+the unit is read. Read the enclosing unit in isolation before writing the finding, and never carry forward the nearest
+declaration a region read happened to include. Where a finding's severity depends on which unit the location names,
+confirm the unit twice.
+
+**The form.** Such a finding carries the existing reference plus the enclosing unit and how it was confirmed:
+
+```markdown
+**CRIT-003** `src/billing/reconciler.rb:2841` (enclosing member: `Reconciler.retry_batch`, confirmed by reading
+lines 2790-2860 in isolation) {explanation} … **Fix:** by hand.
+```
+
+**The population is region reads, and nothing else.** A finding from a file the run read whole carries no such note.
+That keeps the rule off the other findings a capped review can hold, and it keeps the note meaningful where it appears:
+its presence says this location was the kind that can be misattributed, and it was checked.
+
+Confirming the unit can change which unit the finding names, and that can change its severity. Unlike the explanation
+above, this is not writing work that runs after severity is set: it is part of establishing the finding, and it runs
+before the finding is drafted.

--- a/han-coding/skills/code-review/references/finding-filters.md
+++ b/han-coding/skills/code-review/references/finding-filters.md
@@ -48,8 +48,9 @@ the change rather than by trusting the producing agent's rationale.
 
 **Run condition.** Run this sub-step whenever at least one corrective finding (CRIT / WARN / SUGG, manual or agent, plus
 any SEC-### finding) has survived to this point. **Skip it when there are zero corrective findings** — a clean review
-needs no validation. YAGNI findings are out of scope here: they are advisory and are never validated, demoted, or
-dropped by this pass.
+needs no validation. **Skip it in manual-only mode** (`agent-dispatch.md`), because it dispatches an agent and dispatch
+is what is unavailable; the report's Review Coverage block records that the findings were not re-checked. YAGNI
+findings are out of scope here: they are advisory and are never validated, demoted, or dropped by this pass.
 
 **Dispatch one `han-core:adversarial-validator`** via the `Agent` tool. Give it, in this order:
 
@@ -70,7 +71,9 @@ Pass this brief verbatim:
 > issue is critical irrespective of who introduced it; (c) findings whose rationale hedges its own reachability in
 > paraphrase ("unlikely in practice", "would need an unusual sequence", "only under a race we don't see") that the
 > literal-phrase gate did not catch; (d) severity that overstates impact, where the true worst case is "an operator sees
-> an error and retries". Do not invent new findings — you are validating the list, not extending it.
+> an error and retries"; (e) findings whose cited location came from a region read and names an enclosing unit that was
+> never read in isolation, and any finding whose severity depends on which unit the location names. Do not invent new
+> findings — you are validating the list, not extending it.
 
 **Reconcile the verdicts (orchestrator).** Apply each verdict to the finding:
 

--- a/han-coding/skills/code-review/references/output-verification.md
+++ b/han-coding/skills/code-review/references/output-verification.md
@@ -1,5 +1,11 @@
 # Review Output Verification
 
+## Contents
+
+- Step 9.0: Self-consistency check
+- Step 9.1: Structural verification
+- Step 9.2: Readability self-check
+
 The checks Step 9 runs over the finished review before presenting it: the self-consistency pass that
 detects contradictory recommendations, then the structural verification items.
 
@@ -55,7 +61,7 @@ Then verify:
 12. The `### 🟡 YAGNI` section, when present, opens with the verbatim statement defined in Review Constraints, and YAGNI
     findings appear ONLY in this section — not duplicated under CRIT/WARN/SUGG and not in the Review Summary table.
 13. Any `Tension with {other-task-id}:` notes added by Step 9.0 appear on both members of each contradictory pair.
-14. No section is rendered empty, and present sections appear in the template's fixed order, per Step 8. The only
+14. No section is rendered empty, and present sections appear in the fixed order `template.md` defines. The only
     always-present elements are the Review Summary table and the Review Recommendation.
 15. Each security finding's severity tier is shown inline in its Review Summary table row (e.g., `SEC-001 (Critical)`),
     since its task ID does not encode a tier.
@@ -73,6 +79,12 @@ Then verify:
     it.
 21. A finding the review established may never fire carries that cue in two places and they agree: leading its own
     explanation, and opening its summary row's Description cell.
+22. When the run was in manual-only mode (`agent-dispatch.md`), the `## Review Coverage` block is present in the position
+    the template fixes, opens with its cause line, and carries one row per item on the absent-coverage list: every agent
+    Step 3.2 selected, plus the independent validation pass. When every planned coverage ran, the block is absent.
+23. Every finding whose location was established by a region read (Step 4's path for a file over 1000 lines) names its
+    enclosing unit and the lines read in isolation to confirm it, in the form `finding-content.md` defines. A finding from
+    a file read whole carries no such note. This item runs in every mode, including the ones where Step 7.4 does not.
 
 Every item in this list is fixed before the review is presented, never reported alongside it as a caveat. A required
 piece of content that is missing is missing; saying so in the message does not put it in the report.

--- a/han-coding/skills/code-review/references/review-checklist.md
+++ b/han-coding/skills/code-review/references/review-checklist.md
@@ -14,6 +14,7 @@
 - Documentation
 - Code Style & Patterns
 - Database (when applicable)
+- Packaging (when applicable)
 - Architecture Decision Records (when applicable)
 
 **YAGNI** (apply [../../../references/yagni-rule.md](../../../references/yagni-rule.md); these become `YAGNI-###` items
@@ -123,6 +124,35 @@ Named anti-patterns to match in Pass 2:
 - Migration files follow the project's naming convention
 - Schema changes are backward compatible, new columns have appropriate defaults or are nullable
 - Frequently queried columns have indexes
+
+**Packaging** (when applicable)
+
+Fires when the diff changes what gets packaged: shading or relocation rules, vendoring, include or exclude patterns,
+dependency scope changes, or bundling configuration. **This category does not open the built artifact.** The review
+reads source text; it acquires no new command and inspects no jar, wheel, bundle, or image. What the category does is
+tell the reader the review has that hole and name what to check by hand.
+
+- Default severity: Warning. The summary-table row's Description cell opens with `Not checked —`, so a triaging reader
+  sees a row that reports something unverified rather than something proven.
+- **The first sentence is derived from the diff; the rest is fixed.** The first sentence names the specific rule or
+  pattern the diff added and the specific symptom it could produce. Sentences two onward are invariant, so a builder who
+  pastes the worked example with the path swapped produces one varying sentence and not five identical ones.
+
+Worked example, pinned so two runs write the same thing:
+
+```markdown
+**WARN-002** `build.gradle:41` Someone installs the published jar and calls `WidgetFactory.create`, and it fails at
+startup with a missing-class error, because the exclude rule added here drops a class that surviving classes still
+reference. This review did not open the built artifact and cannot tell you whether that happened: the exclude
+patterns say what was removed, not what still points at it. A green build is not evidence either, because a
+development run has a wider classpath than the shipped artifact. Check the produced artifact before merging: that
+every internal reference resolves inside it, that no third-party package is exported unrelocated, and that the
+licence notices the packaging requires are present. **Fix:** by hand.
+```
+
+**Mode scope.** This category applies in Mode A only. Step 4's Mode B and Mode C conservative rule admits only
+focus-area items, source-file items, and file-boundary items, and without a base-branch diff the run cannot tell what
+the change altered about packaging. Same reason the YAGNI checklist is suspended in those modes.
 
 **Architecture Decision Records** (when applicable)
 

--- a/han-coding/skills/code-review/references/template.md
+++ b/han-coding/skills/code-review/references/template.md
@@ -8,8 +8,10 @@ at least one item. A clean review is the table's no-issues row plus an approval
 recommendation, and nothing else.
 
 FIXED ORDER: when more than one section is present, render them in this order and never
-vary it — Critical, Warnings, Suggestions, YAGNI, Security Vulnerabilities, Remediation,
-What's Good.
+vary it — Review Coverage (immediately after the Review Summary block closes), Critical,
+Warnings, Suggestions, YAGNI, Security Vulnerabilities, Remediation, What's Good. This list
+is the authority on where a present section goes; a section absent from it has no defined
+position.
 
 READABILITY: the finding prose and narrative sections follow the shared readability standard (sourced via han-communication:readability-guidance)
 — each finding leads with what to do and why, one idea per paragraph, short active sentences,
@@ -31,9 +33,11 @@ part of that one place, not a second copy of it.
 <!-- A corrective finding's severity is already carried by its task-ID prefix (CRIT-/WARN-/SUGG-). A security finding's task ID does not encode a tier, so show the tier inline in the Task ID cell — e.g. `SEC-001 (Critical)` — so the table stands alone as the complete severity-ordered index. -->
 
 <!-- The Description cell carries the fix route, and opens with `May never fire —` on any finding the review established
-may not be reachable. Both cues sit here so a person triaging thirty findings gets them before opening any one of them;
-a longer finding body would leave the triage exactly where it was. The cell stays an index entry, not a second copy of
-the finding's prose. Security findings show `—` for the route: their Remediation note carries it. -->
+may not be reachable, or with `Not checked —` on a Packaging finding, which reports something the review did not look
+at rather than something it proved (see review-checklist.md). The cues sit here so a person triaging thirty findings
+gets them before opening any one of them; a longer finding body would leave the triage exactly where it was. The cell
+stays an index entry, not a second copy of the finding's prose. Security findings show `—` for the route: their
+Remediation note carries it. -->
 
 <!-- If no issues were found, use the no-issues row instead. -->
 
@@ -55,6 +59,33 @@ the finding's prose. Security findings show `—` for the route: their Remediati
 <!-- No items: "This code can be approved." -->
 
 {Selected recommendation text}
+
+## Review Coverage
+
+<!-- Render this section ONLY when some planned coverage was absent: the run was in manual-only mode (defined in
+agent-dispatch.md), so no specialist read the change. Its absence means every planned coverage ran; do not render it to
+say so. It is a `##` heading, a peer of Recommended Changes, never a child of Review Summary, and it sits immediately
+after the Review Recommendation. -->
+
+<!-- The block stands alone for a reader who never saw the terminal. A reviewer on a pull request sees this file and
+never sees the closing message, so the block opens by naming its own cause. Then one row per item on the absent-coverage
+list agent-dispatch.md defines (every agent Step 3.2 selected, plus the independent validation pass), in the grammar
+below. Name coverage in plain English; carry no agent identifier and no internal step number, because a reader on a pull
+request has no roster and no plugin. A `not swept` row ends with what to do instead, because a line with no verb aimed
+at the reader gets read as bookkeeping about the run. -->
+
+Agent dispatch was unavailable on this run, so no specialist read this change (manual-only mode).
+
+- **Absent:** {coverage name} — {swept by hand under {categories}. {what the sweep does not recover, if partial} | not swept — {why}. {what to do instead}}.
+
+<!-- Worked example of one run:
+
+Agent dispatch was unavailable on this run, so no specialist read this change (manual-only mode).
+
+- **Absent:** security review — swept by hand under Data Isolation, Error Handling, API Design. Nothing substitutes for an exploit path demonstrated against the code.
+- **Absent:** concurrency review — not swept; no checklist category covers races or lock ordering. Check shared state and async ordering by hand before merging.
+- **Absent:** independent validation of the findings — not swept; the findings below were not re-checked against the code by a second pass. Weigh each on its own evidence.
+-->
 
 ## Recommended Changes
 

--- a/han-core/docs/agents/adversarial-validator.md
+++ b/han-core/docs/agents/adversarial-validator.md
@@ -163,7 +163,8 @@ URL: https://en.wikipedia.org/wiki/Red_team
   Investigators gather, validators falsify.
 - [`/investigate`](../../../han-coding/docs/skills/investigate.md). Always dispatches this agent after the fix plan is drafted.
 - [`/research`](../../../han-research/docs/skills/research.md). Always dispatches this agent as the adversarial-validation step at
-  the end of every research pass, attacking the recommendation and its sources.
+  the end of every research pass, attacking the recommendation, its sources, and citation support: whether each cited
+  registry entry's one-line summary bears on the claim it is attached to, traced through the merge's old-to-new mapping.
 - [`/gap-analysis`](../../../han-research/docs/skills/gap-analysis.md). Required swarm role at every size. The swarm runs by
   default.
 - [`/iterative-plan-review`](../../../han-planning/docs/skills/iterative-plan-review.md). Dispatches this agent in team mode.

--- a/han-core/docs/agents/adversarial-validator.md
+++ b/han-core/docs/agents/adversarial-validator.md
@@ -171,7 +171,8 @@ URL: https://en.wikipedia.org/wiki/Red_team
   accuracy against the code before the reader sees it.
 - [`/code-review`](../../../han-coding/docs/skills/code-review.md). Dispatches this agent at Step 7.4 to re-attack the
   consolidated finding list against the code, confirming, demoting, or dropping each finding before a human reads the
-  review.
+  review. Skipped when the review is clean, and in manual-only mode, where no agent can be dispatched at all; the
+  report's Review Coverage section then says the findings were not re-checked.
 - [`/manual-test-planning`](../../../han-coding/docs/skills/manual-test-planning.md). Dispatches this agent against the
   drafted manual test plan to disprove steps and expected outcomes the supplied context does not promise, before the
   file is written.

--- a/han-github/docs/skills/post-code-review-to-pr.md
+++ b/han-github/docs/skills/post-code-review-to-pr.md
@@ -73,9 +73,11 @@ A full review plus GitHub integration:
 
 - **The full `/code-review` report**, written to a file by that skill and read back from the path its closing message
   names. Review Summary table, Review Recommendation, and all findings organized by severity, plus any optional sections
-  (What's Good, Security Vulnerabilities, Remediation) that are present. The code-review skill renders a section only
-  when it has content, so the body builder treats every section other than the table and the recommendation as optional.
-  See the `/code-review` documentation for the detailed shape.
+  (Review Coverage, What's Good, Security Vulnerabilities, Remediation) that are present. The code-review skill renders a
+  section only when it has content, so the body builder treats every section other than the table and the
+  recommendation as optional. A Review Coverage section, present only when no specialist read the change, always crosses
+  to the pull request and is exempt from the clarity pass's length-matching, so the reviewers there see the same
+  disclosure the report carries. See the `/code-review` documentation for the detailed shape.
 - **An offer to post to GitHub.** `AskUserQuestion` with "Yes, post to GitHub" / "No, just the local review."
 - **When accepted.** The skill gathers PR metadata (`owner/repo`, `pr_number`, `head_sha`, author login, current user
   login) and runs a `junior-developer` clarity pass on the draft review body. That pass flags unclear wording,

--- a/han-github/skills/post-code-review-to-pr/SKILL.md
+++ b/han-github/skills/post-code-review-to-pr/SKILL.md
@@ -60,9 +60,10 @@ If the user accepts:
 2. Read the report file at the path captured in Step 2, then build the review body from it: Review Summary table, Review
    Recommendation, and all findings organized by severity, plus any optional sections that are present. Treat every section other than the Review Summary table and the Review
    Recommendation as optional — the code-review skill renders a section only when it has content, so a section (the
-   What's Good section, an absent severity section on a clean review, the Security Vulnerabilities section, the
-   Remediation note) may simply not be there. Include each section when present and omit it without error or an empty
-   heading when absent.
+   Review Coverage section, the What's Good section, an absent severity section on a clean review, the Security
+   Vulnerabilities section, the Remediation note) may simply not be there. Include each section when present and omit
+   it without error or an empty heading when absent. **Review Coverage always crosses when present.** It appears only
+   when no specialist read the change, and a reviewer on the pull request is the reader who most needs to know that.
 3. Continue to Step 4 — do **not** post yet.
 
 ## Step 4: Pre-Post Clarity Check
@@ -71,16 +72,20 @@ Because the review body will be publicly visible on the PR, run a clarity pass o
 
 Match the body's length to what the review found. Every finding earns its place by naming a specific problem at a
 specific location. Skip filler sections, a restated summary of the diff, and boilerplate the reader can see for
-themselves on the PR. Stay inside what the review covered: this step edits wording and severity, and never adds a
-finding `/code-review` did not raise.
+themselves on the PR. Three sections are exempt from that length-matching and are never cut or shortened: the Review
+Summary table, the Review Recommendation, and the Review Coverage section. Review Coverage names no problem at any
+location by construction; it says which coverage the review did not have, and deleting it as filler would hide that from
+the widest audience the review reaches. Stay inside what the review covered: this step edits wording and severity, and
+never adds a finding `/code-review` did not raise.
 
 1. Write the draft review body to a temporary file (e.g., `/tmp/post-code-review-to-pr-draft.md`) using the Write tool.
 2. Launch a single `han-core:junior-developer` agent in artifact-review mode with the prompt: "You are reviewing the
    text of a code review that is about to be posted publicly on a GitHub pull request. The review is at {draft_path}. Do
    not re-review the code — review the review. Flag findings whose wording is unclear, severity is mis-assigned (CRIT
    used where WARN would be accurate, or vice versa), language is accusatory or blaming rather than evidence-based, or
-   `file_path:line_number` references are missing or invalid. Return a short list of specific edits with before/after
-   text; return an empty list if the review reads well as-is."
+   `file_path:line_number` references are missing or invalid. Leave the Review Summary table, the Review Recommendation,
+   and any Review Coverage section as they are; they are not findings and are not subject to the length-matching bar.
+   Return a short list of specific edits with before/after text; return an empty list if the review reads well as-is."
 3. Apply every actionable edit the agent returns. If the agent raises a severity-assignment issue, adjust the finding's
    task ID and the Review Summary table to match.
 4. Generate a unique temp file path by running `${CLAUDE_SKILL_DIR}/scripts/create-review-tempfile.sh`. Write the final,

--- a/han-research/docs/skills/research.md
+++ b/han-research/docs/skills/research.md
@@ -44,9 +44,19 @@ use the skill. For what the skill does internally, read the skill definition at
   summary at the very top, carrying the formal confidence rating on one line. The results follow with minimal jargon,
   then indexed options when there are alternatives. Next comes the recommendation and its evidence basis, then
   validation, then an indexed Sources registry at the very bottom. Every section heading is present on every run; what
-  scales with the size is the depth of each entry. The traceability invariant is resolvability: every artifact ID cited
-  inline resolves to a registry entry carrying its link, retrieval date, trust class, and evidence status. The registry
-  renders as a compact table by default, with a full prose summary reserved for the sources the recommendation rests on.
+  scales with the size is the depth of each entry. The registry renders as a compact table by default, with a full prose
+  summary reserved for the sources the recommendation rests on.
+- **Every citation resolves and supports.** The traceability invariant is two-part. Resolvability: every artifact ID
+  cited inline resolves to a registry entry carrying its link, retrieval date, trust class, and evidence status.
+  Support: that entry's one-line summary states something bearing on the claim the citation is attached to.
+  Resolvability is necessary and not sufficient. The final check before the report is presented tests both parts, and
+  the validator is chartered to attack citation support too.
+- **The merge records what it renumbered.** Above the small band, each parallel analyst numbers its own sources from
+  A1, so consolidating them into one registry renumbers what each one cited. The merge step keeps an old-to-new mapping
+  (analyst, local ID, source, merged ID, disposition) as a working record, rewrites every citation surface through it,
+  including the evidence-status cross-references inside the registry itself, and hands it to the validator. A claim
+  whose only source the merge dropped as irrelevant loses its citation and is labelled as having no evidence, never
+  relabelled single-source.
 - **Sized small / medium / large.** Like the other swarming skills, `/research` scales its team to the question. It
   reads the question's conceptual scope (how many options, how many domains, how wide the reach), not its text length.
 
@@ -141,7 +151,7 @@ A research report file, plus an in-channel summary. Every report has the same fi
   retrieval date for web sources, trust class (codebase / web / provided), a one-line summary, and corroboration status.
   A full prose summary is reserved for the sources the recommendation rests on. Always present, even for a minimal run;
   the depth of each entry scales with the size. These IDs are what the rest of the report cross-references, and every
-  cited ID resolves to an entry here.
+  cited ID resolves to an entry here whose one-line summary bears on the claim citing it.
 
 The report is presented for review. Accept it, ask for specific revisions, or redirect the question.
 

--- a/han-research/skills/research/SKILL.md
+++ b/han-research/skills/research/SKILL.md
@@ -68,11 +68,15 @@ Read these before dispatching anything. They constrain every step below.
   formal High/Med/Low confidence rating on one labeled line), then Research Results with minimal technical detail, then
   indexed Options to Consider (when applicable), then the Recommendation with its evidence basis, then Validation, then
   an indexed Sources registry at the bottom. Every section heading is present on every run; what scales with the band is
-  the _depth_ of each entry, not the set of sections. The traceability invariant is **resolvability**: every artifact ID
-  (`A#`) cited inline must resolve to a registry entry carrying its link, retrieval date, trust class, and evidence
-  status. By default the Sources registry is a compact table, with a full prose summary reserved for the sources the
-  recommendation rests on; at `small` the Research Results and Options carry the decisive evidence only, not the full
-  landscape.
+  the _depth_ of each entry, not the set of sections. By default the Sources registry is a compact table, with a full
+  prose summary reserved for the sources the recommendation rests on; at `small` the Research Results and Options carry
+  the decisive evidence only, not the full landscape.
+- **The traceability invariant is two-part, and this is its only definition.** Resolvability: every `A#` cited inline
+  resolves to a registry entry carrying its link, retrieval date, trust class, and evidence status. Support: the cited
+  entry's `Summary (one line)` states something that bears on the claim the citation is attached to. Resolvability is
+  necessary and not sufficient. A citation that resolves to an entry about something else is a defect, whether an
+  analyst wrote it that way or a merge renumbered it into that shape. Every later step that checks a citation cites this
+  invariant by name and does not restate it.
 - **Readability is applied while writing, held to the default audience frame.** The skill sources the standard by
   invoking `han-communication:readability-guidance` and applies it as it writes the report, holding the default audience
   frame: a capable reader who did not do this work and lacks the author's context. It operates on prose regions only, so
@@ -225,10 +229,42 @@ trust-class vocabulary, the web-source corroboration gate, conflict surfacing be
 codebase-as-current-state-anchor rule, and the no-evidence labeling pattern. In exploratory mode an unevidenced
 reasoning step may inform the recommendation but is recorded as its own labeled entry, never disguised as a sourced
 artifact. Every entry gets an ID that Research Results, Options, and the Recommendation cross-reference inline, so every
-conclusion traces to its sources — every `A#` cited inline must resolve to a registry entry. Render the registry as a
-compact table by default (ID, title/source, link or location, retrieval date for web, trust class, evidence status),
-reserving a full prose summary for the sources the recommendation rests on. The Sources registry is always produced,
-even for a minimal run; what scales with the band is each entry's depth, not whether the section appears.
+conclusion traces to its sources under the traceability invariant in Operating Principles. Render the registry as a
+compact table by default (ID, title/source, link or location, retrieval date for web, trust class, one-line summary,
+evidence status), reserving a full prose summary for the sources the recommendation rests on. The Sources registry is
+always produced, even for a minimal run; what scales with the band is each entry's depth, not whether the section
+appears.
+
+**Record the old-to-new mapping before rewriting anything.** Every parallel analyst numbers its own sources from `A1`,
+so above the small band two or more analysts return an `A1` that name different sources, and consolidating them into
+one sequence renumbers what each analyst cited. This step owns the record of what that renumbering and the relevance
+filter did. Build it as a working record you hold while rendering, not a report section: one row per source every
+analyst returned, in this layout.
+
+```markdown
+| Analyst angle       | Local ID | Source                          | Merged ID | Disposition                                            |
+| ------------------- | -------- | ------------------------------- | --------- | ------------------------------------------------------ |
+| messaging-patterns  | A1       | Kafka docs, exactly-once        | A1        | renumbered                                             |
+| messaging-patterns  | A2       | Fowler, "What do you mean by X" | A2        | renumbered                                             |
+| delivery-semantics  | A1       | Fowler, "What do you mean by X" | A2        | merged into A2 (same source as messaging-patterns A2)  |
+| delivery-semantics  | A2       | vendor blog, undated            | —         | dropped (not relevant to the results)                  |
+```
+
+The `Source` column is what makes the mapping checkable: without it, no row can be joined back to the analyst output it
+came from. Before trusting the mapping, check one analyst's rows against that analyst's raw output.
+
+**Rewrite every citation through the mapping.** A citation surface is anywhere an `A#` appears that an analyst wrote
+against its own numbering. There are four, and the rewrite covers all of them: every `A#` in Research Results, each
+option's `Rests on`, the recommendation's `Evidence basis`, and every `Evidence status` field, both in the registry
+table's last column and in each `A#` detail block. That last surface sits inside the registry being renumbered, where
+one entry cross-references another by identifier, and a rewrite that covers only prose leaves it stale.
+
+**A dropped source takes its citations with it.** When the merge drops an entry as not relevant, every claim that cited
+it loses that citation. A claim left with no source is either dropped with its source or carried under the evidence
+rule's no-evidence label with a reopen trigger naming what evidence would restore it. It is never relabelled
+single-source, because the evidence rule forbids that collapse: single-source means one source supports it, and this
+claim has none. In strict mode a recommendation that rested on the dropped source is re-evaluated in Step 7 against what
+remains.
 
 ## Step 7: Synthesize, then Validate
 
@@ -246,11 +282,13 @@ Synthesize, in this order:
   name the evidence that would settle it.
 
 Then launch `han-core:adversarial-validator` with one `Agent` call. Pass it the full verbatim Sources registry, the
-Research Results, the Options, and the Recommendation. Charter it to attack all of: the evidence, the way the options
-were framed, the recommendation itself, and the integrity of the evidence-gathering — whether any artifact could have
-been introduced or shaped by external content designed to influence the output, whether discounting any single external
-artifact changes the recommendation, and whether external sources are stale, adversarially constructed, or implausibly
-convenient. It emits `V#` findings. Wait for it to return.
+old-to-new mapping from Step 6, the Research Results, the Options, and the Recommendation. Charter it to attack all of:
+the evidence, the way the options were framed, the recommendation itself, citation support (whether each cited entry's
+one-line summary bears on the claim it is attached to, per the traceability invariant in Operating Principles, using
+the mapping to trace any suspect citation back to what the analyst wrote), and the integrity of the evidence-gathering
+— whether any artifact could have been introduced or shaped by external content designed to influence the output,
+whether discounting any single external artifact changes the recommendation, and whether external sources are stale,
+adversarially constructed, or implausibly convenient. It emits `V#` findings. Wait for it to return.
 
 ## Step 8: Re-evaluate, Render, and Present
 
@@ -265,9 +303,9 @@ brief, one phrase on how solid it is, and the formal High/Med/Low confidence rat
 Results**; **Options to Consider** (only when applicable); the (possibly rewritten) **Recommendation** with its evidence
 basis; **Validation** with the `V#` findings, any adjustments made, and the supporting confidence reasoning and
 remaining risks; and the indexed **Sources** registry at the very bottom — a compact table by default (ID, title/source,
-link or location, retrieval date, trust class, evidence status), with a full prose summary reserved for the sources the
-recommendation rests on. Artifact IDs are cross-referenced inline throughout Results, Options, and Recommendation, and
-every cited `A#` resolves to a registry entry. Every section is rendered on every run, even for a minimal one; at
+link or location, retrieval date, trust class, one-line summary, evidence status), with a full prose summary reserved
+for the sources the recommendation rests on. Artifact IDs are cross-referenced inline throughout Results, Options, and
+Recommendation under the traceability invariant. Every section is rendered on every run, even for a minimal one; at
 `small`, Results and Options carry the decisive evidence only, not the full landscape. Write the rendered draft to the
 output location.
 
@@ -288,7 +326,13 @@ invocation above. Correct every failure before presenting. Its fidelity criterio
 how the content is said, and drops a required fact only when the reader asked for less and losing it would not change
 what they do next.
 
-On top of the fidelity criterion, confirm every cited `A#` still resolves to its registry entry.
+On top of the fidelity criterion, check the traceability invariant from Operating Principles over the finished report,
+both parts. For every `A#` cited in Research Results, Options, the Recommendation, and every `Evidence status` field:
+confirm it resolves to a registry entry, then read that entry's `Summary (one line)` and confirm it states something
+that bears on the claim the citation is attached to. A citation that resolves but does not support its claim fails this
+check on the same terms as one that does not resolve. Fix each failure before presenting: trace the citation through the
+Step 6 mapping to what the analyst wrote and correct the identifier, or, when no entry supports the claim, apply the
+dropped-source handling from Step 6.
 
 Present the report, then close with a short message: the size and roster used (and why), the evidence mode (strict or
 exploratory), the count of options and artifacts, the recommendation (or "no clear winner" with deciding criteria) and

--- a/han-research/skills/research/references/research-report-template.md
+++ b/han-research/skills/research/references/research-report-template.md
@@ -105,9 +105,11 @@ rewritten into the "No clear winner" form. -->
 <!--
 AT THE VERY BOTTOM. An indexed registry of EVERY information source used that
 is relevant to the results. ALWAYS present, even for a minimal run — never
-omitted. Every A# cited inline in Research Results, Options, or the
-Recommendation must RESOLVE to an entry here; that resolvability is the
-traceability invariant. The Summary stays ID-free.
+omitted. Every A# cited inline in Research Results, Options, the
+Recommendation, or an Evidence status field resolves to an entry here whose
+one-line summary bears on the claim it is attached to, per the skill's
+traceability invariant (defined once, in its Operating Principles). The
+Summary stays ID-free.
 
 Render the registry as a COMPACT TABLE by default — one row per source with its
 ID, title/source, link or location, retrieval date (web only), trust class,


### PR DESCRIPTION
Feedback issue #194 reported four runs where a Han skill confirmed a reference existed without confirming it pointed at the right thing, or produced a complete-looking report without saying what it had not done. Three were in `code-review` and one in `research`. This change makes both skills say what they did not do, and check that a reference supports the thing it is attached to.

What changed:

- `code-review` gains a named **manual-only mode**, entered when the dispatch mechanism fails (not when an agent returns nothing). The manual review sweeps mapped checklist categories in the absent agents' place, the report gains a `## Review Coverage` section that renders only when coverage was absent, and the closing message names the cause and the count. The independent validation pass skips in that mode because it dispatches an agent.
- A `Packaging (when applicable)` checklist category fires on diffs that change what gets packaged. It raises a Warning saying the review did not open the built artifact and what to check by hand. Its summary row opens with `Not checked —`.
- A finding whose location came from a region read of a file over 1000 lines names its enclosing unit and the lines read to confirm it. Guarded twice: a fifth challenge axis in the validator brief, and a structural verification item that runs in every mode.
- `research`'s traceability invariant is now two-part (resolvability and support), defined once in Operating Principles and cited elsewhere. The merge step records an old-to-new mapping across the renumbering, rewrites every citation surface through it including the evidence-status field, and labels a claim whose only source was dropped as no-evidence rather than single-source. Both inline column enumerations now name the one-line summary column.
- `post-code-review-to-pr` carries Review Coverage across to the pull request and exempts it from the clarity pass's length-matching, so the disclosure survives to the widest audience.
- Long-form docs for `code-review`, `research`, and `post-code-review-to-pr` updated to match.

The plan and its artifacts are under `docs/plans/code-review-research-feedback-issue-194/`. Two departures from the issue are recorded there as the operator's decision: the packaging finding discloses the gap rather than inspecting the artifact, and the location rule fires on the region-read path rather than on disassembler output the skill never reads.

Closes #194.
