### PR TITLE
fix(codex): register the three packages missing from the Codex catalog

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -29,6 +29,30 @@
       "category": "Developer Tools"
     },
     {
+      "name": "han-documentation",
+      "source": {
+        "source": "local",
+        "path": "./han-documentation"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "han-research",
+      "source": {
+        "source": "local",
+        "path": "./han-research"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
       "name": "han-planning",
       "source": {
         "source": "local",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -125,6 +125,18 @@
       "category": "Developer Tools"
     },
     {
+      "name": "han-linear",
+      "source": {
+        "source": "local",
+        "path": "./han-linear"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
       "name": "han-ddd",
       "source": {
         "source": "local",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ han-plugin-builder skill:
 │   ├── .claude-plugin/
 │   │   └── plugin.json
 │   ├── .codex-plugin/
-│   │   └── plugin.json    # Codex-format manifest; every plugin except han and han-linear carries one (omitted from the entries below)
+│   │   └── plugin.json    # Codex-format manifest; every han-* plugin carries one, han/ is excluded (omitted from the entries below)
 │   ├── scripts/        # han-config-dir.sh, a symlink to the repo-root script; every plugin except han carries one (omitted from the entries below), and each skill's `personal config directory` probe runs it
 │   ├── agents/         # readability-editor agent definition
 │   ├── skills/         # readability-guidance + explanation-guidance (both inline, each surfaces one standard) + edit-for-readability

--- a/docs/plans/codex-marketplace-catalog-consistency/artifacts/change-decision-log.md
+++ b/docs/plans/codex-marketplace-catalog-consistency/artifacts/change-decision-log.md
@@ -1,0 +1,405 @@
+# Change Decision Log: Codex Marketplace Catalog Consistency
+
+<!--
+This file records every decision committed while planning the Codex marketplace
+catalog consistency change. The plan itself lives in
+[../change-plan.md](../change-plan.md) — this file captures the question,
+rationale, evidence, and rejected alternatives behind each decision. Evidence
+about the code as it stands today lives in
+[current-state-findings.md](current-state-findings.md) as numbered C-N findings.
+-->
+
+## Trivial decisions
+
+- D-12: `README.md` needs no edit — its Codex section already names all thirteen packages correctly, eight in the
+  install block and five in the prose sentence, so the file the operator named as in-scope requires no change
+  ([C-1](current-state-findings.md#c-1-four-hand-maintained-lists-name-overlapping-but-non-identical-package-sets)). —
+  Referenced in plan: Target State.
+- D-13: No version is bumped anywhere by this change — the plan adds a new file at its baseline and edits no existing
+  version field. — Referenced in plan: Risks.
+
+## Full decisions
+
+### D-1: The directory tree is the authority
+
+- **Question:** Which of the four lists that enumerate Codex-installable packages is authoritative, so the other files
+  can be checked against it?
+- **Decision:** The `han-*` directory tree. Every `han-*` directory except `han/` must carry a Codex manifest and a
+  catalog entry. The check's subject is the tree, expressed as the glob `han-*/`, which excludes the `han` meta-plugin
+  structurally rather than by an exception list.
+- **Rationale:** The operator chose this reading over the alternative, that the README's install list decides, because
+  it is the reading that would have caught the defect when `han-linear` and `han-ddd` landed. A README-driven check
+  would also need a machine-readable marker inside prose that has none.
+- **Evidence:** Operator answer, quoted in [scope-boundary.md](scope-boundary.md) Operator-Stated Scope: "directory
+  tree". Supported by
+  [C-1](current-state-findings.md#c-1-four-hand-maintained-lists-name-overlapping-but-non-identical-package-sets), which
+  shows no list currently derives from another.
+- **Behavior impact:** Preserving on its own. It shapes S-5, whose classification is Changing.
+- **Rejected alternatives:**
+  - The README's install list decides — rejected because the operator chose otherwise, and because the five opt-in
+    packages appear in a prose sentence with no marker a check could read.
+  - The catalog decides — rejected because it is the file that was wrong; making it authoritative would make the defect
+    correct by definition.
+- **Revisit criterion:** If a `han-*` directory is ever added that deliberately ships to Claude Code and not to Codex,
+  the glob stops being the right expression of the authority and needs an explicit exclusion list.
+- **Dissent (if any):** None.
+- **Settles delta entry:** —
+- **Dependent decisions:** D-5, D-6, D-10.
+- **Referenced in plan:** What Changes, In One Paragraph; Surface Delta S-1, S-2.
+
+### D-2: New catalog entries take the existing form and the existing order position
+
+- **Question:** What shape does a new catalog entry take, and where in the array does it go?
+- **Decision:** The four-key form every existing entry uses, with `name` and `source.path` supplied per plugin and
+  `policy` and `category` copied verbatim:
+
+  ```json
+  {
+    "name": "han-linear",
+    "source": { "source": "local", "path": "./han-linear" },
+    "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+    "category": "Developer Tools"
+  }
+  ```
+
+  Position: `han-documentation` and `han-research` go after `han-core` and before `han-planning`; `han-linear` goes
+  between `han-atlassian` and `han-ddd`.
+
+- **Rationale:** All ten existing entries are identical in shape, and two of their three non-identity fields never vary,
+  so a new entry has exactly one correct form. The position is not cosmetic guesswork: the Codex catalog's order is the
+  Claude marketplace's order with its four omissions removed, so restoring the omitted names to their Claude positions
+  is the only placement consistent with the file as it stands.
+- **Evidence:**
+  [C-5](current-state-findings.md#c-5-every-catalog-entry-carries-the-same-four-keys-with-the-same-constant-values) for
+  the form;
+  [C-17](current-state-findings.md#c-17-the-codex-catalogs-entry-order-is-the-claude-marketplaces-order-with-its-omissions-removed)
+  for the position.
+- **Behavior impact:** Changing. A Codex user who runs `codex plugin add han-documentation@han` sees an error today and
+  an installed package afterwards. Settled by the recorded boundary rather than by escalation: items 1 and 3 of the
+  issue's suggested fix ask for exactly these entries, quoted word for word in
+  [scope-boundary.md](scope-boundary.md) Stated Scope.
+- **Rejected alternatives:**
+  - Alphabetical placement — rejected because neither marketplace file is alphabetical; both follow the suite's
+    dependency order.
+  - Appending to the end of the array — rejected for the same reason; it would put a foundational plugin after the
+    opt-in ones.
+- **Revisit criterion:** If the catalog schema gains a field that varies per plugin, the "copy the constants" rule stops
+  holding.
+- **Dissent (if any):** None.
+- **Settles delta entry:** S-1, S-2, S-4.
+- **Dependent decisions:** D-6.
+- **Referenced in plan:** Target State; Surface Delta S-1, S-2, S-4.
+
+### D-3: The `han-linear` Codex manifest's field layout
+
+- **Question:** What does the new `han-linear/.codex-plugin/plugin.json` contain, field by field?
+- **Decision:** The full manifest is written out in [../change-plan.md](../change-plan.md) under Surface Delta S-3. Nine
+  fields are copied verbatim from any sibling manifest because they are byte-identical across all twelve: `author`,
+  `homepage`, `repository`, `license`, `skills`, and the `interface` keys `developerName`, `category`, `capabilities`,
+  and `websiteURL`. Eight fields are supplied by the package: `name`, `version`, `description`, `keywords`, and the
+  `interface` keys `displayName`, `shortDescription`, `longDescription`, and `defaultPrompt`. The `keywords` array
+  follows the suite's own pattern, `"han"` first and the package's topic second: `["han", "linear", "work-items",
+"issues"]`.
+- **Rationale:** A manifest two tools read independently is a contract, so it is pinned as a worked example rather than
+  a field list. The prose is drawn from `han-linear/README.md` and the skill's own description, matching the length
+  register of the existing twelve: a one-sentence `shortDescription`, a `longDescription` naming what the skill does,
+  and three `defaultPrompt` entries, which eleven of twelve use.
+- **Evidence:** [C-6](current-state-findings.md#c-6-all-twelve-codex-manifests-carry-an-identical-key-set) for the key
+  set; the nine constant values re-derived across all twelve manifests by this run;
+  `han-linear/skills/work-items-to-linear/SKILL.md` and `han-linear/README.md` for the prose.
+- **Behavior impact:** Changing. A Codex user gains a package that has never been installable. Settled by the recorded
+  boundary's item 2, quoted word for word in [scope-boundary.md](scope-boundary.md) Stated Scope.
+- **Rejected alternatives:**
+  - Copying the Claude manifest's description verbatim — rejected because the Codex manifest carries three
+    description-like strings at three deliberate lengths, and the Claude text is written for a different surface
+    ([C-9](current-state-findings.md#c-9-the-same-plugins-description-is-authored-independently-in-three-places-and-has-drifted-in-all-twelve)).
+  - A minimal manifest carrying only `name`, `version`, and `skills` — rejected because it would be the only manifest of
+    the thirteen missing the storefront fields, and the check would not catch that.
+- **Revisit criterion:** If the Codex manifest schema gains a required field, all thirteen manifests need it, not just
+  this one.
+- **Dissent (if any):** None.
+- **Settles delta entry:** S-3.
+- **Dependent decisions:** D-4.
+- **Referenced in plan:** Target State; Surface Delta S-3.
+
+### D-4: The new Codex manifest ships at `1.0.0`
+
+- **Question:** Should `han-linear`'s Codex manifest carry `1.0.0`, or mirror its Claude manifest's `1.1.1`?
+- **Decision:** `1.0.0`.
+- **Rationale:** Three reasons, in order of weight. First, the repository's own release rule says so: "A brand-new
+  plugin is not bumped by the release that introduces it. Its `plugin.json` version is its established baseline." A
+  Codex manifest that has never existed on any commit is exactly that case. Second, there is nothing to be compatible
+  with, so no installed user can be stranded by starting at `1.0.0`. Third, the two version fields are separate
+  lineages: the release skill bumps `{source}/.claude-plugin/plugin.json` and the Claude marketplace and contains no
+  reference to Codex at all, so seeding `1.1.1` would manufacture a parity the next release destroys, and would invite
+  someone to later "fix" the other eleven to match.
+- **Evidence:** `.claude/skills/han-release/SKILL.md` lines 165 through 168 for the baseline rule, and the same file's
+  Step 4 for the paths it bumps, both read directly by this run;
+  [C-4](current-state-findings.md#c-4-han-linear-fails-one-layer-earlier-because-no-codex-manifest-exists-at-all) for the
+  file never having existed;
+  [C-8](current-state-findings.md#c-8-the-version-field-differs-between-the-two-manifests-for-eleven-of-twelve-plugins)
+  for the drift table.
+- **Behavior impact:** Part of S-3's Changing classification rather than a separate observable change. `han-linear` has
+  never been installable under Codex, so no user has a prior version to compare against.
+- **Rejected alternatives:**
+  - Mirror the Claude `1.1.1` — rejected because it manufactures a parity nothing maintains, and the argument for it
+    (avoiding a downgrade) protects against a break that cannot happen for a package never published.
+  - Bump `han-linear`'s Claude version alongside — rejected outright. Nothing asked for a version bump, and the release
+    skill owns that decision at release time.
+- **Revisit criterion:** If Codex is found to compare a manifest version against an installed one in a way that gates
+  upgrades. This could not be inspected, because no Codex CLI was available; the choice is arranged to hold either way.
+- **Dissent (if any):** None.
+- **Settles delta entry:** S-3.
+- **Dependent decisions:** None.
+- **Referenced in plan:** Surface Delta S-3; Risks.
+
+### D-5: The check is one Bats file in `test/`, using bash and grep only
+
+- **Question:** What form should the consistency check take, and where does it live?
+- **Decision:** A single Bats file at `test/codex-packaging.bats`, depending on bash, grep, POSIX file tests, and Bats,
+  and on nothing else. No companion shell script, no prek hook, no generator. Its header comment states the invariant,
+  names the commit that broke it, and records the Prettier formatting dependency the literal greps rest on.
+- **Rationale:** The repository has one worked example of a cross-file consistency check and it uses bash and grep only.
+  Placement in `test/` follows the repository's own stated convention: script tests sit beside the script they cover,
+  and `test/` holds checks whose subject is the repository rather than any one script. This check covers no script. The
+  file is discovered by `npm test` with no registration step and runs in CI on every pull request.
+- **Evidence:**
+  [C-11](current-state-findings.md#c-11-scriptshan-config-dirbats-is-the-repos-one-worked-example-of-a-cross-file-consistency-check)
+  for the pattern and the convention;
+  [C-12](current-state-findings.md#c-12-npm-test-discovers-every-bats-file-in-the-tree-with-no-registration-step) for
+  discovery;
+  [C-13](current-state-findings.md#c-13-node-is-guaranteed-to-the-test-job-jq-is-not-pinned-anywhere) for the tool
+  constraint; [C-10](current-state-findings.md#c-10-nothing-in-the-test-lint-or-ci-chain-reads-any-manifest-or-marketplace-file)
+  and [C-15](current-state-findings.md#c-15-the-drift-entered-on-a-commit-that-updated-the-claude-marketplace-and-not-the-codex-catalog)
+  for why a check is needed at all.
+- **Behavior impact:** Changing. A contributor who adds a `han-*` directory without both files sees `npm test` fail
+  where it passed before. Settled by the recorded boundary's item 4, quoted word for word in
+  [scope-boundary.md](scope-boundary.md) Stated Scope.
+- **Rejected alternatives:**
+  - A shell script plus a Bats file, matching the `han-config-dir.sh` and `.bats` pairing — rejected because that
+    pairing exists for a script a skill invokes at runtime, so the script has a second caller. This check has exactly
+    one caller, `npm test`. A script here is a single-implementation abstraction with no named second use.
+  - A prek hook — rejected because it duplicates a signal CI already gives on every pull request, and adds a second
+    place a contributor's failure can originate. No evidence of commit-time friction is recorded.
+  - Generating the catalog from the tree — rejected on cost. It needs a generator, a freshness check, and a JSON writer
+    in a repository whose tooling is Prettier, ShellCheck, and Bats, with `jq` pinned nowhere. The catalog has changed
+    five times in its whole history.
+  - Reaching for `node -e` to parse the JSON — rejected because it introduces a second language into a Bats suite that
+    has none, for a check two `grep -F` calls satisfy. `node` is available; that is cost avoided, not evidence.
+- **Revisit criterion:** Each rejected alternative carries its own trigger, recorded in the plan's Deferred (YAGNI)
+  section.
+- **Dissent (if any):** None.
+- **Settles delta entry:** S-5.
+- **Dependent decisions:** D-6, D-7, D-9.
+- **Referenced in plan:** Target State; Surface Delta S-5; Change Units Unit 3.
+
+### D-6: The check asserts three things, and not six others
+
+- **Question:** Which invariants does the check assert, and which tempting ones does it leave alone?
+- **Decision:** Three assertions. First, the `han-*/` enumeration is non-empty, so the other two cannot pass over an
+  empty set. Second, for every package, `<package>/.codex-plugin/plugin.json` is a regular file. Third, for every
+  package, the catalog holds the literals `"name": "han-x"` and `"path": "./han-x"` **within one entry**, matched with a
+  three-line window rather than tested for presence anywhere in the file.
+
+  Not asserted: version parity between the Claude and Codex manifests; description parity; the manifest key set;
+  constant-value assertions on the catalog's `policy`, `category`, and `source.source`; agreement between the README's
+  install list and the tree; and JSON validity.
+
+- **Rationale:** Each assertion maps to a symptom the issue reports. The first catches the `han-linear` class, the
+  third catches the `han-documentation` and `han-research` class. The third asserts both literals rather than one
+  because the realistic authoring error is copying an existing entry and changing only one of the two fields, and either
+  single-field slip leaves the other literal absent. It scopes them to a single entry because two independent greps
+  would pass on a catalog holding the name in one entry and the path in another.
+
+  The non-empty assertion is required rather than optional. Three reviewers raised it independently, and it needs
+  pinning because the safe-looking implementation is the dangerous one. Two shapes pass vacuously: piping into
+  `while read`, whose loop body runs in a subshell where `return 1` cannot fail the test, and setting `shopt -s
+nullglob`, which turns zero matches into zero iterations. Neither hazard is present today, which is exactly why a
+  builder would introduce one without noticing.
+
+  The exclusions divide into two groups. Version and description parity are false today, for eleven of twelve and
+  twelve of twelve pairs, so asserting either would fail the build the day it landed, and neither is a latent goal: the
+  release skill touches only the Claude side, so forced parity would break again at the next release. The key-set,
+  constant-value, README, and JSON-validity assertions would all pass today and are rejected as symmetry, a named YAGNI
+  anti-pattern. Prettier already parses these files, which is why `.pre-commit-config.yaml` omits `check-json` by its
+  own stated reasoning.
+
+- **Evidence:**
+  [C-1](current-state-findings.md#c-1-four-hand-maintained-lists-name-overlapping-but-non-identical-package-sets) for
+  the symptom mapping;
+  [C-8](current-state-findings.md#c-8-the-version-field-differs-between-the-two-manifests-for-eleven-of-twelve-plugins)
+  and [C-9](current-state-findings.md#c-9-the-same-plugins-description-is-authored-independently-in-three-places-and-has-drifted-in-all-twelve)
+  for the two that would fail;
+  [C-5](current-state-findings.md#c-5-every-catalog-entry-carries-the-same-four-keys-with-the-same-constant-values) and
+  [C-6](current-state-findings.md#c-6-all-twelve-codex-manifests-carry-an-identical-key-set) for the two that would pass
+  and are rejected anyway;
+  [C-10](current-state-findings.md#c-10-nothing-in-the-test-lint-or-ci-chain-reads-any-manifest-or-marketplace-file) for
+  Prettier's ownership of JSON parsing.
+- **Behavior impact:** Part of S-5's Changing classification.
+- **Rejected alternatives:**
+  - Assert version parity — rejected because it fails for eleven of twelve pairs today
+    ([C-8](current-state-findings.md#c-8-the-version-field-differs-between-the-two-manifests-for-eleven-of-twelve-plugins)).
+  - Assert the manifest key set — rejected as symmetry; it needs field-level JSON reading with no `jq`, and no reported
+    failure was caused by a missing field.
+  - Assert only manifest presence, dropping the catalog assertions — rejected because that is the simpler version and it
+    does not catch the reported error, which is a catalog miss
+    ([C-3](current-state-findings.md#c-3-han-documentation-and-han-research-fail-at-the-catalog-step-with-correct-manifests-never-reached)).
+- **Revisit criterion:** Recorded per-alternative in the plan's Deferred (YAGNI) section.
+- **Dissent (if any):** None.
+- **Settles delta entry:** S-5.
+- **Dependent decisions:** D-10.
+- **Referenced in plan:** Surface Delta S-5; Deferred (YAGNI).
+
+### D-7: The check's failure output names the package and the repair
+
+- **Question:** What does a contributor see when the check fails?
+- **Decision:** Each failing test prints one line per offending package before returning 1. The literal forms:
+
+  ```
+  codex manifest missing: han-linear/.codex-plugin/plugin.json (copy han-ddd/.codex-plugin/plugin.json and edit the package-specific fields)
+  catalog entry missing: add "name": "han-linear" with "path": "./han-linear" to .agents/plugins/marketplace.json
+  ```
+
+- **Rationale:** What the check says is a contract between the check and the person reading a failed CI run, and they
+  cannot see each other. A message naming only "consistency check failed" makes the reader re-derive the repair from a
+  file they have probably never opened. Both lines name the file to create or edit and what to put in it.
+- **Evidence:** [C-14](current-state-findings.md#c-14-contributingmd-has-no-section-for-adding-a-plugin-and-never-names-the-codex-surface)
+  makes this load-bearing: there is no written process for adding a plugin, so the failure message is the only guidance
+  a contributor gets.
+- **Behavior impact:** Part of S-5's Changing classification. The observer is a contributor reading a failed CI run.
+- **Rejected alternatives:**
+  - A bare assertion with no message — rejected because Bats would print only the failing line number, and the repair
+    lives in two files the reader has no reason to know about.
+- **Revisit criterion:** If the check fires on a real contributor branch and the message proves insufficient.
+- **Dissent (if any):** None.
+- **Settles delta entry:** S-5.
+- **Dependent decisions:** None.
+- **Referenced in plan:** Target State, "The check's failure output"; Surface Delta S-5.
+
+### D-8: `CLAUDE.md` line 83 is inside the recorded area
+
+- **Question:** The operator confirmed an area that did not name `CLAUDE.md`. Does correcting its statement that
+  `han-linear` carries no Codex manifest belong in this change or in separate work?
+- **Decision:** In this change. S-6 rewrites line 83 to say every `han-*` plugin carries a Codex manifest, with `han/`
+  excluded because Codex has no meta-plugins.
+- **Rationale:** Three things settle it without the operator. The line goes false the moment S-3 lands, so this is not
+  a stale line the change happens to pass by; the change is what makes it wrong. The repository has a worked precedent:
+  `556b49e` added `han-ddd` and updated the Codex catalog, the Claude marketplace, and `CLAUDE.md` in one commit, while
+  `2c09799`, the commit that caused this defect, updated neither the Codex catalog nor the map. And the operator's
+  "yes" was given to a four-item list this run proposed; a yes to four named things is weak evidence that a fifth was
+  excluded, since it was never in front of them.
+
+  One correction to the reasoning that reached this decision: an earlier framing of mine held that line 83 is how the
+  defect arose. It is not. The wording entered on `d62e1eb`, five days after the drift commit, in a documentation audit
+  that saw the gap and recorded it as intent. It documents the defect rather than causing it. The decision does not
+  depend on the causal claim, and the claim is dropped.
+
+- **Evidence:** [C-16](current-state-findings.md#c-16-claudemd-records-the-han-linear-manifest-gap-as-though-it-were-the-intended-design)
+  for the current wording; `git show --stat 556b49e` and `git log -S` on the line's text, both run by this run, for the
+  precedent and the chronology; [scope-boundary.md](scope-boundary.md) Operator-Stated Scope for what the operator
+  actually answered; `han-core:junior-developer` reframing for the "yes to a proposed list" argument and the chronology
+  correction.
+- **Behavior impact:** Changing. The observer is an agent or contributor reading the repository map, who is told a Codex
+  manifest is required rather than optional. No install, command, or test outcome differs, and no automated reader is
+  affected: no `.bats` file in the repository greps `CLAUDE.md`'s content. An earlier draft labeled this Preserving,
+  which was too broad, because the entry's whole justification is that a reader acts differently afterwards.
+- **Rejected alternatives:**
+  - Leave line 83 and raise it as separate work — rejected because it leaves the file every agent reads each session
+    asserting that a file this change just created does not exist, in the same form that recorded the last gap as
+    intent.
+  - Escalate to the operator — rejected because the precedent and the "your own edit makes it false" argument settle it,
+    and the boundary excludes nothing here.
+- **Revisit criterion:** If the operator says `CLAUDE.md` is out of bounds for this change.
+- **Dissent (if any):** None. `han-core:junior-developer` initially framed this as the one question worth the
+  operator's time, then concluded on the precedent that line 83 specifically does not need them.
+- **Settles delta entry:** S-6.
+- **Dependent decisions:** D-11.
+- **Referenced in plan:** Surface Delta S-6; Change Units Unit 2.
+
+### D-9: The `sanity.bats` header is amended rather than the check relocated
+
+- **Question:** `test/sanity.bats` states that `test/` keeps only harness-level checks. Adding `test/codex-packaging.bats`
+  contradicts it. Amend the comment, or put the check somewhere else?
+- **Decision:** Amend the comment. It becomes: `test/` holds harness-level checks and repository-wide structural
+  invariants that cover no single script.
+- **Rationale:** The convention that comment states has a real basis, that a script's tests sit beside the script. This
+  check covers no script, so the alternative locations are worse: beside a JSON file it reads, or in `scripts/` next to
+  nothing. The comment describes a two-category directory as a one-category one; the check is the second category
+  arriving.
+- **Evidence:** [C-11](current-state-findings.md#c-11-scriptshan-config-dirbats-is-the-repos-one-worked-example-of-a-cross-file-consistency-check)
+  for the stated convention and the sibling pattern.
+- **Behavior impact:** Changing. The observer is a contributor deciding where to put a new test: a class of test that
+  had no stated home now has one. No test outcome differs. Corrected from Preserving for the same reason as D-8.
+- **Rejected alternatives:**
+  - Put the check at `.agents/plugins/codex-packaging.bats`, beside the file it reads — rejected because it drops a
+    non-manifest file into a directory a third-party CLI scans, and whether Codex tolerates that could not be inspected.
+  - Leave the comment stale — rejected for the same reason as D-8: a written statement contradicting the file beside it.
+- **Revisit criterion:** None foreseen.
+- **Dissent (if any):** None.
+- **Settles delta entry:** S-7.
+- **Dependent decisions:** None.
+- **Referenced in plan:** Surface Delta S-7.
+
+### D-10: The reverse check is deferred
+
+- **Question:** Should the check also assert the other direction, that every catalog entry names something that exists?
+- **Decision:** Deferred, with the reopening trigger recorded, and with a note that the stronger form is the one to
+  build if it is reopened.
+- **Rationale:** The issue's item 4 is one-directional: every package advertised for Codex has a manifest and a catalog
+  entry. "The tree is the authority" answers which file wins when the two disagree; it does not say the catalog holds
+  nothing else. Set equality is an additional commitment rather than an entailment of authority. On evidence, the
+  orphan-entry failure has never occurred here, while the failure that did occur ran tree to catalog. "It costs one
+  grep" is cost, not evidence.
+
+  If reopened, assert the stronger form. The architect proposed checking that an entry names an existing directory. The
+  failure that actually breaks a user is an entry resolving to a directory with no Codex manifest, because that is what
+  an install reads second.
+
+- **Evidence:**
+  [C-1](current-state-findings.md#c-1-four-hand-maintained-lists-name-overlapping-but-non-identical-package-sets) shows
+  zero orphan entries today;
+  [C-15](current-state-findings.md#c-15-the-drift-entered-on-a-commit-that-updated-the-claude-marketplace-and-not-the-codex-catalog)
+  shows the direction the real failure ran;
+  [C-2](current-state-findings.md#c-2-a-codex-install-reads-the-catalog-first-and-the-per-plugin-manifest-second) for
+  why the entry-to-manifest form is the stronger one; `han-core:junior-developer` reframing for the authority-versus-set-equality
+  distinction and for identifying the stronger form.
+- **Behavior impact:** Preserving. Deferring an assertion changes nothing observable.
+- **Rejected alternatives:**
+  - Include the reverse check now — rejected on the evidence test: it protects a failure mode with no occurrences in
+    this repository.
+  - Put it on the cut list instead of the deferred list — rejected because the two lists differ by whether a trigger
+    exists to reopen. The boundary is silent here rather than excluding it, and a plugin rename or deletion is a
+    concrete trigger, so it belongs in the deferred list.
+- **Revisit criterion:** An orphan entry reaches `main`, or a plugin is renamed or removed.
+- **Dissent (if any):** `han-core:software-architect` recommended including it as a third assertion, arguing it is one
+  grep and covers the rename case that the forward direction structurally cannot see. Recorded and not adopted, on the
+  evidence test.
+- **Settles delta entry:** S-5.
+- **Dependent decisions:** None.
+- **Referenced in plan:** Deferred (YAGNI).
+
+### D-11: `CLAUDE.md` line 73 is cut for scope
+
+- **Question:** Line 73 calls the Codex catalog "the Codex-compatible subset of the plugins". Should this change reword
+  it?
+- **Decision:** Cut. Recorded in the plan's Cut for Scope section, where the operator can reinstate it.
+- **Rationale:** Unlike line 83, this line does not become false. After the change the catalog still excludes `han`, so
+  it is still a subset. The reason to reword it is to stop a future reader concluding that some plugins legitimately sit
+  outside the Codex surface, which is prevention work, and the recorded boundary already chose a mechanism for
+  prevention in item 4: a test rather than prose.
+- **Evidence:** [C-16](current-state-findings.md#c-16-claudemd-records-the-han-linear-manifest-gap-as-though-it-were-the-intended-design)
+  for the wording; [scope-boundary.md](scope-boundary.md) Stated Scope item 4 for the chosen prevention mechanism;
+  `han-core:junior-developer` reframing for the distinction between a line the change falsifies and a characterization
+  it does not.
+- **Behavior impact:** Preserving.
+- **Rejected alternatives:**
+  - Reword it alongside line 83 — rejected because the two lines are not the same case, and treating them as one is how
+    a four-item bug fix becomes a documentation pass.
+  - Escalate it as its own question — rejected because the cut list is the channel for exactly this, and it reaches the
+    operator either way.
+- **Revisit criterion:** The operator asks for it, which is itself a valid justification the reinstated entry records.
+- **Dissent (if any):** `han-core:junior-developer` held that this one either goes to the operator or to the cut list,
+  and did not choose between them. The cut list is the choice, and it surfaces to the operator in the closing summary.
+- **Settles delta entry:** —
+- **Dependent decisions:** None.
+- **Referenced in plan:** Cut for Scope.

--- a/docs/plans/codex-marketplace-catalog-consistency/artifacts/current-state-findings.md
+++ b/docs/plans/codex-marketplace-catalog-consistency/artifacts/current-state-findings.md
@@ -1,0 +1,424 @@
+# Current State Findings: Codex Marketplace Catalog Consistency
+
+## Provenance
+
+Produced by this run's own discovery round on 2026-09-10. No prior findings report existed.
+
+Agents dispatched in parallel, both given the Codex packaging surface as their area:
+
+- `han-core:structural-analyst` — static structure: the four package lists, the two manifest schemas, where duplication
+  lives, the enforcement surface, and structural gaps.
+- `han-core:behavioral-analyst` — install-time and test-time behavior: what a Codex install reads in what order, the
+  failure a user sees, dependency semantics under Codex, and the `npm test` / `npm run lint` execution paths.
+
+`han-core:concurrency-analyst` was not dispatched. The area is packaging metadata and a test harness, with no concurrent
+access, async coordination, or shared mutable state.
+
+The run's own Glob, Grep, and `git log` sweep supplied the project context, the churn history, and findings C-16 through
+C-18. Findings C-1, C-5, C-6, and C-8 were additionally re-derived by the run directly rather than accepted from an
+agent, because each one pins a concrete value the plan commits to.
+
+## Project Context
+
+- **Stack:** Markdown (skill, agent, and doc content) and Bash (skill `scripts/`, plus the shared repo-root `scripts/`).
+  No application build and no dev server.
+- **Conventions source:** `CLAUDE.md`, `## Project Discovery` section. No `project-discovery.md` file exists.
+- **Package manager:** npm. The root `package.json` manages dev tooling only.
+- **Test runner:** Bats, via `npm test`. Lint is prek via `npm run lint`.
+- **ADRs found:** `docs/adr/0001-project-configurable-default-swarm-size.md` — the only ADR in the repo, and unrelated
+  to packaging.
+- **Coding standards found:** None governing JSON manifests or the marketplace catalog. `CONTRIBUTING.md` carries the
+  process for adding a skill and adding an agent (see C-14).
+- **Recent churn:** `git log --since="90 days ago"` over `.agents/`, `.claude-plugin/`, and `*/.codex-plugin/` shows the
+  Codex catalog file changed five times in its whole history and twice in the last ninety days. See C-16.
+
+## Gaps
+
+What was searched for and not found:
+
+- **No ADR on Codex packaging.** `docs/adr/` holds one file, on an unrelated subject. Nothing records why the `han`
+  meta-plugin is excluded from the Codex catalog; the issue reporter had to infer it.
+- **No JSON Schema file.** A repo-wide search for `*schema*` returns nothing.
+- **No plugin-builder guidance for the Codex surface.** `han-plugin-builder/skills/guidance/references/` is the
+  designated home for plugin-authoring rules per `CLAUDE.md`, and its three `codex` mentions all concern plugin naming,
+  not the packaging surface, the manifest schema, or catalog maintenance.
+- **No `Adding a plugin` section in `CONTRIBUTING.md`.** See C-14.
+- **No test, hook, or CI step reading any manifest or marketplace file.** See C-10.
+
+Taken together: there is no authored statement anywhere in the repo of what a package advertised for Codex must carry.
+
+## Findings
+
+### C-1: Four hand-maintained lists name overlapping but non-identical package sets
+
+- **Claim:** Four independent lists enumerate the packages Codex can install, none derived from another, and their set
+  differences reproduce all three symptoms issue #198 reports.
+- **Location:** the `han-*` directory tree; `han-*/.codex-plugin/plugin.json`; `.agents/plugins/marketplace.json`;
+  `README.md` lines 69 through 94.
+- **Evidence:** Re-derived by the run directly, reading all four sources in one pass:
+
+  ```text
+  directories (13, excluding the meta-plugin han/):
+    han-atlassian han-coding han-communication han-core han-ddd han-documentation
+    han-feedback han-github han-linear han-planning han-plugin-builder han-reporting han-research
+
+  codex manifests (12): every directory above except han-linear
+
+  catalog entries (10): han-communication han-core han-planning han-coding han-github
+    han-reporting han-feedback han-atlassian han-ddd han-plugin-builder
+
+  README Codex section (13): 8 in the codex plugin add block, 5 more in the prose sentence
+
+  MISSING from catalog (directory tree, excluding han): han-documentation, han-linear, han-research
+  MISSING manifest    (directory tree, excluding han): han-linear
+  catalog entries with no directory:                   (none)
+  ```
+
+- **Raised by:** `han-core:structural-analyst` C1; `han-core:behavioral-analyst` C1; re-derived by the run.
+- **Confidence:** Verified.
+- **Bears on:** S-1, S-2, S-3, S-4, S-5; D-1, D-2, D-5.
+
+### C-2: A Codex install reads the catalog first and the per-plugin manifest second
+
+- **Claim:** `codex plugin add <name>@han` resolves `<name>` against the catalog's `plugins` array to obtain a
+  `source.path`, then reads `.codex-plugin/plugin.json` inside that directory. Both files must agree for an install to
+  succeed.
+- **Location:** `.agents/plugins/marketplace.json`; `han-*/.codex-plugin/plugin.json`.
+- **Evidence:** Each of the ten catalog entries carries a `source.path` that resolves to a directory holding a
+  `.codex-plugin/plugin.json`. The containment `catalog ⊆ manifests` holds with no exceptions, so the catalog names
+  nothing that would fail to resolve at the second step.
+- **Raised by:** `han-core:behavioral-analyst` C1.
+- **Confidence:** Unverified. No Codex CLI was available in this environment, so the two-step lookup order is traced
+  from the repo's file shapes and the error text quoted in issue #198, not observed against a running `codex` binary.
+  What could not be inspected: Codex's own install-command implementation.
+- **Bears on:** S-1, S-2, S-3; D-1.
+
+### C-3: `han-documentation` and `han-research` fail at the catalog step, with correct manifests never reached
+
+- **Claim:** Both plugins carry a complete, well-formed Codex manifest. The install fails before Codex reads it, because
+  neither name appears in the catalog array.
+- **Location:** `.agents/plugins/marketplace.json`; `han-documentation/.codex-plugin/plugin.json`;
+  `han-research/.codex-plugin/plugin.json`; `README.md` lines 84 and 85.
+- **Evidence:** The catalog array runs `han-core` straight into `han-planning`, with no entry between them.
+  `han-research/.codex-plugin/plugin.json` is complete:
+
+  ```json
+  {
+    "name": "han-research",
+    "version": "1.0.0",
+    "description": "Pre-planning knowledge-work skills: open-ended research, gap analysis, and issue triage.",
+    "skills": "./skills/"
+  }
+  ```
+
+  The reported error, `Error: plugin han-documentation was not found in marketplace han`, names the marketplace rather
+  than the plugin directory.
+
+- **Raised by:** `han-core:behavioral-analyst` C2.
+- **Confidence:** Verified as to the file contents. The attribution of the error string to the catalog step inherits
+  C-2's Unverified label.
+- **Bears on:** S-1, S-2; D-1.
+
+### C-4: `han-linear` fails one layer earlier, because no Codex manifest exists at all
+
+- **Claim:** `han-linear/` has no `.codex-plugin/` directory. Adding a catalog entry alone would not make it
+  installable.
+- **Location:** `han-linear/`; `han-linear/.claude-plugin/plugin.json`.
+- **Evidence:** The directory holds `.claude-plugin/`, `docs/`, `README.md`, `references/`, `scripts/`, and `skills/`,
+  and no `.codex-plugin/`. `git log --diff-filter=A -- han-linear/.codex-plugin/plugin.json` returns nothing: the file
+  has never existed on any commit. Its Claude manifest exists and declares no dependencies:
+
+  ```json
+  { "name": "han-linear", "description": "Linear-facing extensions to the Han suite. ...", "version": "1.1.1" }
+  ```
+
+- **Raised by:** `han-core:behavioral-analyst` C3; `han-core:structural-analyst` C1.
+- **Confidence:** Verified.
+- **Bears on:** S-3, S-4; D-3, D-4.
+
+### C-5: Every catalog entry carries the same four keys with the same constant values
+
+- **Claim:** All ten entries are byte-identical in shape, and two of the three non-identity fields never vary across the
+  suite. A new entry has exactly one form to take.
+- **Location:** `.agents/plugins/marketplace.json`, `plugins[]`.
+- **Evidence:** Re-derived by the run. Every entry has keys `name`, `source`, `policy`, `category`; every `source` has
+  keys `source` and `path`; every `policy` is `{"installation": "AVAILABLE", "authentication": "ON_INSTALL"}`; every
+  `category` is `"Developer Tools"`. The entry form:
+
+  ```json
+  {
+    "name": "han-core",
+    "source": { "source": "local", "path": "./han-core" },
+    "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+    "category": "Developer Tools"
+  }
+  ```
+
+- **Raised by:** `han-core:structural-analyst` C5; re-derived by the run.
+- **Confidence:** Verified.
+- **Bears on:** S-1, S-2, S-4; D-2.
+
+### C-6: All twelve Codex manifests carry an identical key set
+
+- **Claim:** Every existing `.codex-plugin/plugin.json` has the same ten top-level keys and the same eight `interface`
+  keys, with no plugin adding or omitting one.
+- **Location:** `han-*/.codex-plugin/plugin.json`, all twelve.
+- **Evidence:** Re-derived by the run across all twelve files:
+
+  ```text
+  top-level: name version description author homepage repository license keywords skills interface
+  interface: displayName shortDescription longDescription developerName category capabilities
+             websiteURL defaultPrompt
+  ```
+
+  No file deviates.
+
+- **Raised by:** the run's own sweep; corroborates `han-core:structural-analyst` C2.
+- **Confidence:** Verified.
+- **Bears on:** S-3; D-3.
+
+### C-7: The Codex manifest schema shares almost nothing with the Claude manifest schema, and encodes no dependencies
+
+- **Claim:** The Claude manifest is flat with four fields; the Codex manifest is nested with roughly fifteen. Neither the
+  Codex manifest schema nor the Codex catalog schema has any field that encodes a dependency between plugins.
+- **Location:** `han-documentation/.claude-plugin/plugin.json` against
+  `han-documentation/.codex-plugin/plugin.json`; the pattern holds across all twelve pairs.
+- **Evidence:** The Claude schema is `{name, description, version, dependencies?}`. A grep for `dependencies` across all
+  twelve Codex manifests returns zero hits, against nine hits across the Claude manifests. `README.md` line 77 states
+  the consequence: Codex "resolves no dependencies". The dependency is load-bearing at runtime, not merely declarative:
+  `han-documentation/skills/project-documentation/SKILL.md` invokes `han-communication:readability-guidance` by
+  cross-plugin name and dispatches the `han-communication:readability-editor` agent.
+- **Raised by:** `han-core:structural-analyst` C2; `han-core:behavioral-analyst` C4.
+- **Confidence:** Verified as to the field absence and the SKILL.md invocation. What Codex does at the moment a skill
+  body names an uninstalled plugin's skill could not be inspected, because no Codex CLI was available and no Codex
+  documentation is vendored in this repo.
+- **Bears on:** S-3, S-5; D-3, D-6.
+
+### C-8: The `version` field differs between the two manifests for eleven of twelve plugins
+
+- **Claim:** Version parity between a plugin's Claude manifest and its Codex manifest is not an invariant this repo
+  holds today, and asserting it would fail for eleven of the twelve existing pairs.
+- **Location:** `han-*/.claude-plugin/plugin.json` against `han-*/.codex-plugin/plugin.json`.
+- **Evidence:** Re-derived by the run:
+
+  ```text
+  plugin              claude   codex
+  han-atlassian       2.3.1    1.1.0
+  han-coding          3.3.0    1.0.0
+  han-communication   1.2.0    1.0.0
+  han-core            3.1.1    1.2.0
+  han-ddd             1.0.0    1.0.0
+  han-documentation   1.0.1    1.0.0
+  han-feedback        2.0.2    1.1.1
+  han-github          2.3.1    1.2.0
+  han-linear          1.1.1    (no manifest)
+  han-planning        2.2.1    1.0.0
+  han-plugin-builder  2.2.0    1.1.0
+  han-reporting       2.2.1    1.0.1
+  han-research        1.0.1    1.0.0
+  ```
+
+  `han-ddd` is the only matching pair, and it is the most recently added plugin.
+
+- **Raised by:** `han-core:structural-analyst` C3; re-derived by the run.
+- **Confidence:** Verified.
+- **Bears on:** S-3, S-5; D-4, D-6.
+
+### C-9: The same plugin's description is authored independently in three places and has drifted in all twelve
+
+- **Claim:** A plugin's description exists in its Claude manifest, in the Claude marketplace entry, and in its Codex
+  manifest, with nothing keeping the three in step. All twelve pairs that have both manifests differ.
+- **Location:** `han-*/.claude-plugin/plugin.json`; `.claude-plugin/marketplace.json`;
+  `han-*/.codex-plugin/plugin.json`.
+- **Evidence:** For `han-documentation`, the Codex manifest reads:
+
+  ```text
+  "Documentation skills for writing down what the team built and decided: project docs, ADRs, and runbooks."
+  ```
+
+  while its Claude manifest carries a substantially longer text naming each skill and the plugin's dependencies, and the
+  Claude marketplace entry carries a third, intermediate text.
+
+- **Raised by:** `han-core:structural-analyst` C4.
+- **Confidence:** Verified.
+- **Bears on:** S-5; D-3, D-6.
+
+### C-10: Nothing in the test, lint, or CI chain reads any manifest or marketplace file
+
+- **Claim:** No committed automation validates any JSON manifest's content or any agreement between the packaging files.
+- **Location:** `test/sanity.bats`; `scripts/han-config-dir.bats`; `.pre-commit-config.yaml`;
+  `.github/workflows/ci.yml`; `package.json`.
+- **Evidence:** `.github/workflows/ci.yml` runs exactly two commands across its two jobs: `npm run lint` and
+  `npm test`, each after `npm ci`. `.pre-commit-config.yaml` runs Prettier (formatting only), ShellCheck, and generic
+  hygiene hooks; its comment states `check-yaml and check-json are intentionally omitted: Prettier parses and so
+validates those types already`, which is a syntax check and not a content check. A grep for `marketplace.json`,
+  `codex`, or `.codex-plugin` across every `*.bats`, `*.sh`, and `*.yml` file outside `node_modules` returns no hit in
+  `test/`, `scripts/`, or the workflow.
+- **Raised by:** `han-core:structural-analyst` C6; `han-core:behavioral-analyst` C8.
+- **Confidence:** Verified.
+- **Bears on:** S-5; D-5, D-6.
+
+### C-11: `scripts/han-config-dir.bats` is the repo's one worked example of a cross-file consistency check
+
+- **Claim:** A test asserting that several files agree already exists in this repo, and it establishes the pattern a new
+  one would follow: bash and grep only, no `jq` and no `node`, a repo root computed from the test file's own location,
+  and a header comment stating why the invariant matters.
+- **Location:** `scripts/han-config-dir.bats`; `scripts/han-config-dir.sh`.
+- **Evidence:** The file computes its root and enumerates matching files, then asserts an invariant over each:
+
+  ```bash
+  REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+  SCRIPT_REL='scripts/han-config-dir.sh'
+
+  probe_skills() {
+    cd "$REPO_ROOT" || return 1
+    grep -rlF -- "${SCRIPT_REL}\" 2>/dev/null" ./*/skills/*/SKILL.md
+  }
+
+  @test "at least one skill carries the probe" {
+    run probe_skills
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+  }
+  ```
+
+  Its seven tests use only `grep`, `[ -f ]`, `[ -x ]`, `run`, and parameter expansion. `test/sanity.bats` states the
+  sibling convention: "Real script tests sit next to the script they cover... `test/` keeps only harness-level checks."
+
+- **Raised by:** `han-core:structural-analyst` C7; `han-core:behavioral-analyst` C7.
+- **Confidence:** Verified.
+- **Bears on:** S-5; D-5, D-9.
+
+### C-12: `npm test` discovers every `*.bats` file in the tree with no registration step
+
+- **Claim:** A new Bats file placed anywhere outside `node_modules` runs automatically.
+- **Location:** `package.json`.
+- **Evidence:**
+
+  ```json
+  "test": "find . -name node_modules -prune -o -name '*.bats' -print0 | xargs -0 bats"
+  ```
+
+  Nine `.bats` files exist outside `node_modules` today.
+
+- **Raised by:** `han-core:behavioral-analyst` C5.
+- **Confidence:** Verified.
+- **Bears on:** S-5; D-5.
+
+### C-13: `node` is guaranteed to the test job; `jq` is not pinned anywhere
+
+- **Claim:** A test may rely on `node` and on Bats being present in CI, because the workflow installs both. It may not
+  rely on `jq`, which no committed file pins.
+- **Location:** `.github/workflows/ci.yml`; `package.json`.
+- **Evidence:** The test job runs `actions/setup-node@v7.0.0` with `node-version: lts/*`, then `npm ci`, then
+  `npm test`. `package.json` `devDependencies` holds exactly `@j178/prek`, `bats`, and `prettier`; a grep for `jq` in
+  `package.json` returns zero hits. On the development machine the behavioral analyst verified by direct execution:
+  `bash 3.2.57` (macOS, pre-4.0, so no associative arrays and no `mapfile`), `jq 1.8.2`, `node v22.14.0`,
+  `git 2.55.0`, `bats 1.13.0`.
+- **Raised by:** `han-core:behavioral-analyst` C6; `han-core:structural-analyst` C7; the workflow re-read by the run.
+- **Confidence:** Verified as to the workflow and `package.json`. Whether the `ubuntu-latest` runner happens to
+  preinstall `jq` could not be inspected from this filesystem, which is the reason it counts as unpinned rather than
+  absent.
+- **Bears on:** S-5; D-5, D-6.
+
+### C-14: `CONTRIBUTING.md` has no section for adding a plugin and never names the Codex surface
+
+- **Claim:** A contributor following the written process has no documented step that touches the Codex catalog or a
+  Codex manifest.
+- **Location:** `CONTRIBUTING.md`.
+- **Evidence:** The file carries "Adding a skill" and "Adding an agent" sections and no "Adding a plugin" section. The
+  only marketplace file it names is `.claude-plugin/marketplace.json`, at lines 167 through 168 and 200 through 201. A
+  search for `codex` or `.agents/plugins` returns zero matches.
+- **Raised by:** `han-core:structural-analyst` C8.
+- **Confidence:** Verified.
+- **Bears on:** S-5; D-7.
+
+### C-15: The drift entered on a commit that updated the Claude marketplace and not the Codex catalog
+
+- **Claim:** `han-documentation` and `han-research` were registered in one of the two marketplace files at the moment
+  they were scaffolded, and the omission has stood since.
+- **Location:** commit `2c09799`, 2026-07-22, `feat(plugins): scaffold han-documentation and han-research`.
+- **Evidence:** The commit's own message says both plugins are "registered in the marketplace", singular. Its diffstat
+  against the two marketplace paths shows one file touched:
+
+  ```text
+  .claude-plugin/marketplace.json | 14 +++++++++++++-
+  1 file changed, 13 insertions(+), 1 deletion(-)
+  ```
+
+  The Codex catalog has five commits in its entire history and none is `2c09799`. The comparison case is `556b49e`
+  (`feat(han-ddd)`, 2026-08-19), which updated both files, which is why `han-ddd` installs.
+
+- **Raised by:** the run's own `git log` sweep.
+- **Confidence:** Verified.
+- **Bears on:** S-5; D-5, D-8.
+
+### C-16: `CLAUDE.md` records the `han-linear` manifest gap as though it were the intended design
+
+- **Claim:** The repository map states that `han-linear` is one of two plugins that deliberately carries no Codex
+  manifest, so the map itself has to change when the manifest is added.
+- **Location:** `CLAUDE.md` line 83.
+- **Evidence:**
+
+  ```text
+  │   │   └── plugin.json    # Codex-format manifest; every plugin except han and han-linear carries one
+  ```
+
+  `CLAUDE.md` line 73 describes the catalog as covering "the Codex-compatible subset of the plugins", which likewise
+  reads as intentional rather than as drift.
+
+- **Raised by:** the run's own sweep.
+- **Confidence:** Verified.
+- **Bears on:** S-6; D-8, D-11.
+
+### C-17: The Codex catalog's entry order is the Claude marketplace's order with its omissions removed
+
+- **Claim:** The two files order their entries identically once the four names absent from Codex are dropped, which
+  fixes where a new entry belongs.
+- **Location:** `.agents/plugins/marketplace.json`; `.claude-plugin/marketplace.json`.
+- **Evidence:** Re-derived by the run:
+
+  ```text
+  claude: han han-communication han-core han-documentation han-research han-planning han-coding
+          han-github han-reporting han-feedback han-atlassian han-linear han-ddd han-plugin-builder
+  codex:      han-communication han-core                                han-planning han-coding
+          han-github han-reporting han-feedback han-atlassian           han-ddd han-plugin-builder
+  ```
+
+  Neither file is alphabetical. The order is the suite's dependency order: the foundational plugins first, then the
+  bundled layers, then the opt-in plugins.
+
+- **Raised by:** the run's own sweep.
+- **Confidence:** Verified.
+- **Bears on:** S-1, S-2, S-4; D-2.
+
+### C-18: prek's exclude list keeps this plan folder out of every lint hook
+
+- **Claim:** Files written under `docs/plans/` are formatted by no hook, so the plan itself does not need to satisfy
+  Prettier.
+- **Location:** `.pre-commit-config.yaml`.
+- **Evidence:**
+
+  ```yaml
+  exclude: "^(docs/plans/|docs/research/|han-reporting/skills/html-summary/assets/)"
+  ```
+
+- **Raised by:** the run's own sweep.
+- **Confidence:** Verified.
+- **Bears on:** —
+
+## Findings No Agent Could Audit
+
+Two evidence classes nobody in this run could reach:
+
+- **Codex's own install behavior.** No `codex` CLI is available in this environment and no Codex documentation is
+  vendored in the repo, so the two-step catalog-then-manifest lookup (C-2), the attribution of the reported error string
+  to the catalog step (C-3), and what happens when a skill body names an uninstalled plugin's skill (C-7) are traced
+  from file shapes and the issue's quoted error rather than observed. Closing this would take running `codex plugin
+marketplace add` and `codex plugin add` against a checkout.
+- **The GitHub Actions runner's preinstalled tool set.** `ubuntu-latest` runs outside this filesystem, so whether `jq`
+  is present there could not be checked (C-13). Closing this would take a CI run that probes for it, or reading
+  GitHub's published runner image manifest.
+
+Every other class in the area was covered: the repository's own files, its git history, its lint and CI configuration,
+and the local toolchain versions.

--- a/docs/plans/codex-marketplace-catalog-consistency/artifacts/scope-boundary.md
+++ b/docs/plans/codex-marketplace-catalog-consistency/artifacts/scope-boundary.md
@@ -1,0 +1,72 @@
+# Scope Boundary: Codex Marketplace Catalog Consistency
+
+## Work Item
+
+GitHub issue [testdouble/han#198](https://github.com/testdouble/han/issues/198), "Codex marketplace catalog omits
+han-documentation, han-research, and han-linear". Read via `gh issue view 198` on 2026-09-10. State: OPEN, no comments,
+no labels.
+
+## Stated Scope
+
+Quoted from the issue's "Suggested fix" section, word for word:
+
+> 1. Add `han-documentation` and `han-research` to `.agents/plugins/marketplace.json`.
+> 2. Add `han-linear/.codex-plugin/plugin.json`.
+> 3. Add `han-linear` to `.agents/plugins/marketplace.json`.
+> 4. Add a consistency test ensuring every package advertised for Codex has a manifest and catalog entry.
+
+Quoted from the issue's expectation statement:
+
+> I expected every package advertised for Codex to appear in its marketplace catalog and include a valid Codex manifest.
+
+Quoted from the issue's closing line:
+
+> The affected installation instructions are in the [Han README](https://github.com/testdouble/han#codex).
+
+## Stated Exclusions
+
+Quoted from the issue, word for word:
+
+> The parent `han` package appears intentionally excluded because Codex does not support meta-plugins. [see Codex issue
+> 23531](https://github.com/openai/codex/issues/23531)
+
+## Operator-Stated Scope
+
+The operator confirmed the area in the Step 1.5 confirmation turn. Asked whether the Codex catalog file, a new
+`han-linear/.codex-plugin/plugin.json`, the README's Codex section, and the test harness under `test/` that `npm test`
+runs were the whole area the change may touch, they answered:
+
+> yes
+
+Asked which of two readings of "advertised for Codex" the consistency test should enforce — the directory tree, or the
+README's install list — they answered:
+
+> directory tree
+
+That answer settles the test's subject: every `han-*` directory except `han/` must carry a Codex manifest and a catalog
+entry.
+
+Asked to confirm the plan folder `docs/plans/codex-marketplace-catalog-consistency/`, they answered:
+
+> that's fine
+
+## Direction of Travel
+
+Unanswered. The operator was not asked whether the Codex packaging surface is being deprecated, replaced, or migrated
+away from.
+
+## Visual Material Received
+
+None received.
+
+## Record Provenance
+
+Established by `han-planning:plan-a-change` on 2026-09-10. Not inherited from another folder. No conflicting record was
+found and no conflict was resolved.
+
+One boundary question arose during the run and was settled without returning to the operator. `CLAUDE.md` was not in the
+area list the operator confirmed, and the change makes one of its lines false. It was brought inside the boundary on
+precedent rather than by escalation: commit `556b49e` added `han-ddd` and updated the Codex catalog, the Claude
+marketplace, and `CLAUDE.md` in one commit. See
+[change-decision-log.md](change-decision-log.md) D-8. A second line in the same file was cut for scope instead, and
+appears in the plan's Cut for Scope section where the operator can reinstate it.

--- a/docs/plans/codex-marketplace-catalog-consistency/change-plan.md
+++ b/docs/plans/codex-marketplace-catalog-consistency/change-plan.md
@@ -530,6 +530,15 @@ so writing one is authoring a new process rather than repairing this defect. The
 Codex paragraph would have said in prose. **Reopen when** a contributor asks how to add a plugin, or when the check
 fires on a human branch and its error line proves insufficient.
 
+**A Codex packaging document in `han-plugin-builder`'s authoring guidance.** The repository routes every plugin-asset
+decision through that guidance, and it has no document describing the Codex packaging surface. Its only mentions of
+Codex are in `plugin-naming.md`, which forbids a dot in a plugin name because Codex rejects it, and whose rename
+checklist is the one place acknowledging that `.codex-plugin/plugin.json` and a Codex marketplace exist as things to
+keep in step. Nothing states that a plugin needs both to ship. Deferred because this change already answers the
+question mechanically, and a check that fails is a stronger statement than a document nobody is required to read.
+**Reopen when** someone adds a plugin and asks what its Codex packaging must contain, or when the Codex manifest schema
+changes and there is no document to change with it.
+
 **An ADR recording why `han/` is excluded from the Codex catalog.** The issue reporter had to infer this. After the
 change the exclusion is structural in the check's `han-*` glob and stated in both its header comment and `CLAUDE.md`.
 **Reopen when** someone proposes adding `han` to the catalog.

--- a/docs/plans/codex-marketplace-catalog-consistency/change-plan.md
+++ b/docs/plans/codex-marketplace-catalog-consistency/change-plan.md
@@ -1,0 +1,659 @@
+# Change Plan: Codex Marketplace Catalog Consistency
+
+## Why This Change
+
+A defect whose root cause is structural. A Codex user who follows the Han README runs
+`codex plugin add han-documentation@han` and gets back `Error: plugin han-documentation was not found in marketplace
+han`. The same happens for `han-research`, and `han-linear` cannot be installed at all. Four hand-maintained lists have
+to agree about which packages Codex can install, and nothing checks that they do
+([C-1](artifacts/current-state-findings.md#c-1-four-hand-maintained-lists-name-overlapping-but-non-identical-package-sets),
+[C-10](artifacts/current-state-findings.md#c-10-nothing-in-the-test-lint-or-ci-chain-reads-any-manifest-or-marketplace-file)).
+
+Source: GitHub issue [testdouble/han#198](https://github.com/testdouble/han/issues/198), recorded in
+[`artifacts/scope-boundary.md`](artifacts/scope-boundary.md).
+
+## What Changes, In One Paragraph
+
+After this change the `han-*` directory tree is the authority on which packages Codex can install, and one test enforces
+that the catalog and the manifests agree with it ([D-1](artifacts/change-decision-log.md#d-1-the-directory-tree-is-the-authority)).
+Today no file holds that authority. Three packages sit in a state no file objects to: two are advertised and
+manifest-complete but unlisted, and one is advertised with neither a manifest nor a listing. Afterwards every `han-*`
+directory except the `han` meta-plugin carries both a Codex manifest and a catalog entry. A commit that adds a
+plugin directory without both fails CI on the pull request.
+
+## Current State
+
+Four lists enumerate the packages Codex can install, and none is derived from another
+([C-1](artifacts/current-state-findings.md#c-1-four-hand-maintained-lists-name-overlapping-but-non-identical-package-sets)):
+thirteen directories, twelve manifests, ten catalog entries, and a README section naming all thirteen. The gaps are
+exactly the three the issue reports.
+
+An install reads the catalog first and the per-plugin manifest second
+([C-2](artifacts/current-state-findings.md#c-2-a-codex-install-reads-the-catalog-first-and-the-per-plugin-manifest-second)),
+which is why the three failures are not the same failure. `han-documentation` and `han-research` have complete,
+well-formed manifests that the install never reaches, because the lookup fails at the catalog step
+([C-3](artifacts/current-state-findings.md#c-3-han-documentation-and-han-research-fail-at-the-catalog-step-with-correct-manifests-never-reached)).
+`han-linear` fails one layer deeper: its `.codex-plugin/` directory has never existed on any commit
+([C-4](artifacts/current-state-findings.md#c-4-han-linear-fails-one-layer-earlier-because-no-codex-manifest-exists-at-all)).
+
+**The structural property this change addresses** is the absence of any authority among the four lists, and the absence
+of any check that they agree. Nothing in the test, lint, or CI chain reads a manifest or a marketplace file
+([C-10](artifacts/current-state-findings.md#c-10-nothing-in-the-test-lint-or-ci-chain-reads-any-manifest-or-marketplace-file)).
+The evidence that this is structural rather than a one-off slip is in the history. Commit `2c09799` scaffolded both
+plugins and updated one marketplace file, its own message saying "registered in the marketplace", singular
+([C-15](artifacts/current-state-findings.md#c-15-the-drift-entered-on-a-commit-that-updated-the-claude-marketplace-and-not-the-codex-catalog)).
+The comparison case is `556b49e`, which added `han-ddd` and updated both marketplace files plus the repository map,
+which is why `han-ddd` installs.
+
+Two properties of the current state constrain what the fix can assert. Version parity between a plugin's Claude and
+Codex manifests is false for eleven of twelve pairs
+([C-8](artifacts/current-state-findings.md#c-8-the-version-field-differs-between-the-two-manifests-for-eleven-of-twelve-plugins)),
+and description parity is false for all twelve
+([C-9](artifacts/current-state-findings.md#c-9-the-same-plugins-description-is-authored-independently-in-three-places-and-has-drifted-in-all-twelve)).
+Both have a mechanical cause: the release skill bumps `{source}/.claude-plugin/plugin.json` and the Claude marketplace,
+and contains no reference to Codex at all. The two version fields are independent lineages rather than drift.
+
+## Target State
+
+The `han-*` directory tree is the authority. Every other file in the Codex surface either points at it or is checked
+against it.
+
+**`.agents/plugins/marketplace.json`** answers one question: which names `codex plugin add` resolves, and the on-disk
+path each resolves to. It is answerable for nothing else. It holds no version and no description, because its schema has
+no field for either ([C-5](artifacts/current-state-findings.md#c-5-every-catalog-entry-carries-the-same-four-keys-with-the-same-constant-values)).
+
+Every entry takes this form, with `name` and `path` supplied per plugin and the rest constant across all thirteen
+([D-2](artifacts/change-decision-log.md#d-2-new-catalog-entries-take-the-existing-form-and-the-existing-order-position)):
+
+```json
+    {
+      "name": "han-linear",
+      "source": {
+        "source": "local",
+        "path": "./han-linear"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+```
+
+Copy that shape exactly, including the line breaks. Prettier preserves whichever form an author writes rather than
+imposing one, so a compacted entry stays compacted and no lint step corrects it back. Every one of the ten existing
+entries is expanded like the above.
+
+Entry order stays the Claude marketplace's order with its omissions removed
+([C-17](artifacts/current-state-findings.md#c-17-the-codex-catalogs-entry-order-is-the-claude-marketplaces-order-with-its-omissions-removed)).
+That fixes where each new entry goes: `han-documentation` and `han-research` after `han-core` and before
+`han-planning`, and `han-linear` between `han-atlassian` and `han-ddd`.
+
+**`han-*/.codex-plugin/plugin.json`** answers one question: that package's Codex-published identity. It is not
+answerable for dependencies, because no field in the Codex schema holds one
+([C-7](artifacts/current-state-findings.md#c-7-the-codex-manifest-schema-shares-almost-nothing-with-the-claude-manifest-schema-and-encodes-no-dependencies)),
+and it is not answerable for agreement with its Claude sibling.
+
+Nine of the eighteen fields are byte-identical across all twelve existing manifests and are copied verbatim into a new
+one. They are `author`, `homepage`, `repository`, `license`, `skills`, and the four `interface` keys `developerName`,
+`category`, `capabilities`, and `websiteURL`. The package supplies `name`, `version`, `description`, `keywords`, and the
+four `interface` text keys ([D-3](artifacts/change-decision-log.md#d-3-the-han-linear-codex-manifests-field-layout)).
+
+**`test/codex-packaging.bats`** answers one question: whether the tree, the catalog, and the manifests name the same
+package set. It is not answerable for field values, schema shape, or parity with anything on the Claude side.
+
+**`.claude-plugin/marketplace.json` and `han-*/.claude-plugin/plugin.json`** are answerable for the Claude surface
+alone, and this change does not touch them. They are not the upstream of the Codex manifests, and treating them as one
+is what makes independent version lineages look like drift.
+
+**`README.md`'s Codex section** already names all thirteen packages correctly and needs no edit
+([C-1](artifacts/current-state-findings.md#c-1-four-hand-maintained-lists-name-overlapping-but-non-identical-package-sets)).
+
+### The check's failure output
+
+What a contributor sees when the check fails is a contract between the check and the person reading CI, so it is pinned
+to literal lines ([D-7](artifacts/change-decision-log.md#d-7-the-checks-failure-output-names-the-package-and-the-repair)).
+Each failing test prints one line per offending package before returning 1:
+
+```
+codex manifest missing: han-linear/.codex-plugin/plugin.json (copy han-ddd/.codex-plugin/plugin.json and edit the package-specific fields)
+catalog entry missing: add "name": "han-linear" with "path": "./han-linear" to .agents/plugins/marketplace.json
+```
+
+## Surface Delta
+
+### S-1: `han-documentation` entry in `.agents/plugins/marketplace.json` — Added
+
+**Target state.** The catalog contains an entry named `han-documentation` whose `source.path` is `./han-documentation`,
+carrying the same `policy` and `category` as every other entry. It sits after `han-core` and before `han-planning`.
+`codex plugin add han-documentation@han` resolves it and reads the manifest that already exists at
+`han-documentation/.codex-plugin/plugin.json`.
+
+**Behavior.** Changing. A Codex user who runs `codex plugin add han-documentation@han` gets an error today and an
+installed package afterwards. Settled by the recorded boundary, which asks for this in item 1 word for word, rather than
+by escalation ([D-1](artifacts/change-decision-log.md#d-1-the-directory-tree-is-the-authority)).
+
+**Why.** The manifest is complete and well-formed; the install fails at the catalog step before reaching it
+([C-3](artifacts/current-state-findings.md#c-3-han-documentation-and-han-research-fail-at-the-catalog-step-with-correct-manifests-never-reached)).
+
+**Decision.** [D-2](artifacts/change-decision-log.md#d-2-new-catalog-entries-take-the-existing-form-and-the-existing-order-position)
+
+### S-2: `han-research` entry in `.agents/plugins/marketplace.json` — Added
+
+**Target state.** The catalog contains an entry named `han-research` whose `source.path` is `./han-research`, in the
+same form as every other entry, sitting after `han-documentation` and before `han-planning`.
+`codex plugin add han-research@han` resolves it and reads the existing manifest.
+
+**Behavior.** Changing. Same observer and same change as S-1: a Codex user's install goes from an error to a working
+package. Settled by the recorded boundary's item 1.
+
+**Why.** Same cause as S-1. Both plugins were scaffolded by the same commit, which registered them in the Claude
+marketplace only ([C-15](artifacts/current-state-findings.md#c-15-the-drift-entered-on-a-commit-that-updated-the-claude-marketplace-and-not-the-codex-catalog)).
+
+**Depends on.** S-1, for entry order only.
+
+**Decision.** [D-2](artifacts/change-decision-log.md#d-2-new-catalog-entries-take-the-existing-form-and-the-existing-order-position)
+
+### S-3: `han-linear/.codex-plugin/plugin.json` — Added
+
+**Target state.** `han-linear` carries a Codex manifest with the same ten top-level keys and eight `interface` keys as
+every other manifest ([C-6](artifacts/current-state-findings.md#c-6-all-twelve-codex-manifests-carry-an-identical-key-set)).
+Its version is `1.0.0`. Its nine constant fields are copied verbatim from any sibling; its eight package-specific fields
+describe the `work-items-to-linear` skill:
+
+```json
+{
+  "name": "han-linear",
+  "version": "1.0.0",
+  "description": "Linear-facing extensions to the Han suite: publish Han work items to Linear through the Linear MCP server, one issue per slice.",
+  "author": { "name": "Test Double", "url": "https://testdouble.com" },
+  "homepage": "https://github.com/testdouble/han#readme",
+  "repository": "https://github.com/testdouble/han",
+  "license": "MIT",
+  "keywords": ["han", "linear", "work-items", "issues"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Han Linear",
+    "shortDescription": "Publish Han work items to Linear as issues.",
+    "longDescription": "Creates one Linear issue per slice from a /plan-work-items work-items file in a single target team, resolving the team's real workflow states, labels, Projects, and members before it creates anything, and linking within-file dependencies as native \"blocked by\" relations. Requires a configured Linear MCP server.",
+    "developerName": "Test Double",
+    "category": "Developer Tools",
+    "capabilities": ["Skills"],
+    "websiteURL": "https://github.com/testdouble/han",
+    "defaultPrompt": [
+      "Publish these work items to Linear.",
+      "Create Linear issues from my work-items file.",
+      "Push this plan's slices into my Linear team."
+    ]
+  }
+}
+```
+
+**Behavior.** Changing. A Codex user gains a package that has never been installable. Settled by the recorded
+boundary's item 2 word for word.
+
+**Why.** The directory has never held a `.codex-plugin/` on any commit, so a catalog entry alone would still fail one
+layer deeper ([C-4](artifacts/current-state-findings.md#c-4-han-linear-fails-one-layer-earlier-because-no-codex-manifest-exists-at-all)).
+
+**Decision.** [D-3](artifacts/change-decision-log.md#d-3-the-han-linear-codex-manifests-field-layout), [D-4](artifacts/change-decision-log.md#d-4-the-new-codex-manifest-ships-at-100)
+
+### S-4: `han-linear` entry in `.agents/plugins/marketplace.json` — Added
+
+**Target state.** The catalog contains an entry named `han-linear` whose `source.path` is `./han-linear`, in the same
+form as every other entry, sitting between `han-atlassian` and `han-ddd`. `codex plugin add han-linear@han` resolves it
+and reads the manifest S-3 adds.
+
+**Behavior.** Changing. Together with S-3 this takes `han-linear` from uninstallable to installable for a Codex user.
+Settled by the recorded boundary's item 3 word for word.
+
+**Why.** The catalog is the first of the two files an install reads
+([C-2](artifacts/current-state-findings.md#c-2-a-codex-install-reads-the-catalog-first-and-the-per-plugin-manifest-second)),
+so the manifest S-3 adds is unreachable without it.
+
+**Depends on.** S-3. A catalog entry pointing at a directory with no manifest is a state the check in S-5 rejects, so
+the two land together.
+
+**Decision.** [D-2](artifacts/change-decision-log.md#d-2-new-catalog-entries-take-the-existing-form-and-the-existing-order-position)
+
+### S-5: `test/codex-packaging.bats` — Added
+
+**Target state.** A Bats file at `test/codex-packaging.bats` asserts three things, using bash and grep only, with no
+`jq` and no `node`. It is discovered by `npm test` with no registration step
+([C-12](artifacts/current-state-findings.md#c-12-npm-test-discovers-every-bats-file-in-the-tree-with-no-registration-step))
+and runs in CI on every pull request. Its header comment states why the invariant exists, names the commit that broke
+it, and records the Prettier formatting dependency the literal greps rest on.
+
+The enumeration is what the check and the directory tree must independently agree on, so it is pinned rather than
+described. The `han-*/` glob excludes the `han` meta-plugin structurally: `han/` does not match it, so no exception list
+is needed.
+
+```bash
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+CATALOG='.agents/plugins/marketplace.json'
+
+# Every Codex package, one per line.
+codex_packages() {
+  cd "$REPO_ROOT" || return 1
+  for dir in han-*/; do printf '%s\n' "${dir%/}"; done
+}
+```
+
+The three assertions:
+
+1. **The enumeration is not empty.** Without this the other two run over an empty set and pass while checking nothing.
+   This is a required assertion, not an optional hardening, and it mirrors the `at least one skill carries the probe`
+   test in `scripts/han-config-dir.bats`
+   ([C-11](artifacts/current-state-findings.md#c-11-scriptshan-config-dirbats-is-the-repos-one-worked-example-of-a-cross-file-consistency-check)).
+2. **Every package has a manifest.** `<package>/.codex-plugin/plugin.json` is a regular file.
+3. **Every package has a catalog entry naming it and pointing at it.** The `name` and `path` literals are matched
+   together within one entry rather than anywhere in the file, which the fixed entry shape makes a three-line window:
+
+   ```bash
+   grep -A3 -- "\"name\": \"${pkg}\"" "$CATALOG" | grep -q -- "\"path\": \"./${pkg}\""
+   ```
+
+The check runs on macOS locally and on `ubuntu-latest` in CI, and three differences between those decide how it is
+written. The divergence runs the opposite way from the usual: the authoring machine has the older bash. So a feature
+that works while writing the check may be the one that is unavailable.
+
+- **Bash 3.2 compatible.** No `mapfile` or `readarray`, no `declare -A`, no `${x^^}` case conversion, no globstar.
+  These all work on the CI runner's bash 5 and fail on macOS bash 3.2, so CI will not catch their use.
+- **Grep one named file, never `-r`.** BSD grep follows symlinks during a recursive search and GNU grep does not, and
+  this repository has thirteen root-escaping symlinks, one per plugin at `han-*/scripts/han-config-dir.sh`. The check
+  greps exactly `.agents/plugins/marketplace.json`. Use `-qF` only: BSD grep has no `-P`. Note that `han-config-dir.bats`
+  uses `grep -rlF`, so it is the wrong half of that file to copy.
+- **Loop and assert, never sort and diff.** macOS and the runner default to different locales, so glob expansion order
+  is not guaranteed to match. Per-package assertions in a loop do not care; a `diff` of two sorted lists would.
+- **Emit failures from the test body.** Bats surfaces a test's stdout only when the test fails, and output produced
+  inside a function called under `run` is captured into `$output` instead of printed. `printf '%s\n'` followed by
+  `return 1` directly in the test body is what puts the pinned failure lines from D-7 into a CI log. It is the shape
+  the three cross-file tests in `scripts/han-config-dir.bats` already use.
+- **Mode 755 with the `#!/usr/bin/env bats` shebang.** prek's `check-shebang-scripts-are-executable` hook covers
+  `test/`, and both existing `.bats` files are 755. A new file created at the default 644 fails `npm run lint` before
+  `npm test` ever runs.
+
+**Behavior.** Changing. A contributor who adds a `han-*` directory without both files sees `npm test` fail where it
+passed before. Settled by the recorded boundary's item 4 word for word, and by the operator's answer that the directory
+tree decides which packages the check covers.
+
+**Why.** Nothing currently reads any manifest or marketplace file
+([C-10](artifacts/current-state-findings.md#c-10-nothing-in-the-test-lint-or-ci-chain-reads-any-manifest-or-marketplace-file)),
+so the four data fixes above would not stop the next plugin repeating `2c09799`.
+
+**Depends on.** S-1, S-2, S-3, S-4. The check fails until all four land.
+
+**Decision.** [D-5](artifacts/change-decision-log.md#d-5-the-check-is-one-bats-file-in-test-using-bash-and-grep-only), [D-6](artifacts/change-decision-log.md#d-6-the-check-asserts-three-things-and-not-six-others), [D-7](artifacts/change-decision-log.md#d-7-the-checks-failure-output-names-the-package-and-the-repair)
+
+### S-6: `CLAUDE.md`'s record of which plugins carry a Codex manifest — Re-scoped
+
+**Target state.** `CLAUDE.md` line 83 no longer names `han-linear` as an exception, because after S-3 there is no
+exception. The line sits inside a column-aligned ASCII tree, so the replacement is pinned to preserve that alignment:
+
+```text
+│   │   └── plugin.json    # Codex-format manifest; every han-* plugin carries one (han/ is excluded: no meta-plugins)
+```
+
+**Behavior.** Changing. An agent or contributor reading the repository map is told something different: that a Codex
+manifest is required rather than optional. No install, command, or test outcome differs, and no automated reader is
+affected, which was checked rather than assumed: no `.bats` file in the repository globs or greps `CLAUDE.md`'s content.
+Settled by [D-8](artifacts/change-decision-log.md#d-8-claudemd-line-83-is-inside-the-recorded-area) rather than by
+escalation.
+
+**Why.** The line goes false the moment S-3 lands
+([C-16](artifacts/current-state-findings.md#c-16-claudemd-records-the-han-linear-manifest-gap-as-though-it-were-the-intended-design)).
+It is the file every agent reads at the start of every session. Leaving it asserting that a file you created
+does not exist teaches the next contributor that shipping without a Codex manifest is a legitimate choice. Precedent:
+`556b49e` added `han-ddd` and updated both marketplace files and `CLAUDE.md` in one commit
+([D-8](artifacts/change-decision-log.md#d-8-claudemd-line-83-is-inside-the-recorded-area)).
+
+**Depends on.** S-3.
+
+**Decision.** [D-8](artifacts/change-decision-log.md#d-8-claudemd-line-83-is-inside-the-recorded-area)
+
+### S-7: `test/`'s stated remit, in `test/sanity.bats`'s header — Re-scoped
+
+**Target state.** The header comment states a two-category remit for `test/`, and says what still does not belong
+there. The replacement, pinned:
+
+```text
+# Sanity check: proves the Bats harness and the CI test job actually run.
+# Real script tests sit next to the script they cover (e.g.
+# scripts/foo.sh alongside scripts/foo.bats); test/ keeps harness-level
+# checks like this one, plus repository-wide structural invariants that
+# cover no single script.
+```
+
+The clause that survives unchanged is the one that still decides most cases: a test covering one script sits beside that
+script. Only a check whose subject is the repository itself belongs in `test/`.
+
+**Behavior.** Changing. A contributor deciding where to put a new test is told something different, because a class of
+test that previously had no stated home now has one. No test outcome differs. Settled by
+[D-9](artifacts/change-decision-log.md#d-9-the-sanitybats-header-is-amended-rather-than-the-check-relocated) rather
+than by escalation.
+
+**Why.** The existing comment states a convention S-5 breaks: "test/ keeps only harness-level checks like this one."
+This repository has one ADR and no coding-standards directory, so a header comment is where a convention
+lives. Widening it deliberately, and saying what the widening does not cover, is the difference between amending a
+standard and quietly contradicting it.
+
+**Depends on.** S-5.
+
+**Decision.** [D-9](artifacts/change-decision-log.md#d-9-the-sanitybats-header-is-amended-rather-than-the-check-relocated)
+
+## Behavior Changes
+
+**A Codex user gains three packages they could not install.** Running `codex plugin add han-documentation@han` today
+prints `Error: plugin han-documentation was not found in marketplace han`. Afterwards it installs the package. The same
+holds for `han-research`, and for `han-linear`, which has never been installable at all (S-1 through S-4, and items 1
+through 3 of the issue).
+
+One caveat travels with that. Codex resolves no dependencies of its own, so someone who installs `han-documentation`
+alone gets a package whose skills call into `han-communication`, which they may not have installed. The README already
+handles this by telling people to install `han-communication` first, and this change does not alter that ordering. What
+Codex does at the moment a skill names an uninstalled package could not be checked, because no Codex CLI was available
+to this run
+([C-7](artifacts/current-state-findings.md#c-7-the-codex-manifest-schema-shares-almost-nothing-with-the-claude-manifest-schema-and-encodes-no-dependencies)).
+
+**A contributor gains a test that can fail on work unrelated to Codex.** Anyone who adds a new `han-*` directory sees
+`npm test` fail until that directory has both a Codex manifest and a catalog entry. This is the intended effect and it
+is item 4 of the issue. The failure fires on the next person to add a plugin, not on
+anyone touching Codex. The failure message names the package and the repair, so the fix is mechanical (S-5).
+
+**Two written statements start saying something different.** The repository map currently tells a reader that
+`han-linear` is one of two plugins that legitimately ships without a Codex manifest; afterwards it tells them every
+plugin carries one. And the note at the top of the test directory currently says only harness-level checks belong
+there; afterwards it says repository-wide structural checks belong there too. Nothing an automated tool observes
+changes in either case. The observer is a person or an agent reading the repository to decide what to do next, which is
+the whole reason both edits are here (S-6, S-7).
+
+Every one of these was asked for by the recorded boundary or follows directly from something that was, so none needed a
+decision from you during planning. They are listed here so you can object to any of them now.
+
+## Change Units
+
+### Unit 1: Register the two plugins that already have manifests
+
+**What it does.** Adds two entries to the Codex catalog so the two packages that are advertised and manifest-complete
+become installable.
+
+**Delta entries.** S-1, S-2.
+
+**Ordering constraint.** None. This unit stands alone and fixes two of the three reported symptoms.
+
+**How you know it worked.** The catalog names `han-documentation` and `han-research`, each with a `path` that resolves
+to a directory holding a `.codex-plugin/plugin.json`. `npm run lint` passes, which is what confirms the JSON is still
+well-formed and Prettier-clean. To confirm the user-visible fix directly, run
+`codex plugin marketplace add` against the checkout and then `codex plugin add han-documentation@han`. No Codex CLI was
+available to this planning run, so that check is unperformed rather than passing.
+
+### Unit 2: Give `han-linear` a Codex manifest and register it
+
+**What it does.** Creates the Codex manifest `han-linear` has never had, adds its catalog entry, and corrects the
+repository map that recorded its absence as intentional.
+
+**Delta entries.** S-3, S-4, S-6.
+
+**Ordering constraint.** S-5 requires both artifacts for every `han-*` directory, so `han-linear` fails the check until
+the manifest and the entry both exist. They land in one unit for that reason. The write order within the unit is author
+convenience rather than correctness: the check iterates directories, not catalog entries, so it flags `han-linear`
+today whether or not an entry exists. Catching an entry that points at a manifest-less directory is the deferred
+reverse check's job.
+
+**How you know it worked.** `han-linear/.codex-plugin/plugin.json` parses and carries the same ten top-level keys as its
+twelve siblings. The catalog names `han-linear` with `path` `./han-linear`. `CLAUDE.md` no longer names `han-linear` as
+a plugin without a Codex manifest. `npm run lint` passes.
+
+### Unit 3: Add the consistency check
+
+**What it does.** Adds the test that keeps the tree, the catalog, and the manifests in agreement, and updates the one
+comment that says tests of this kind do not belong in `test/`.
+
+**Delta entries.** S-5, S-7.
+
+**Ordering constraint.** Lands after Units 1 and 2 are on `main`, not merely after them in branch order. A Unit 3 pull
+request opened before they merge runs red on its own CI, and that red is indistinguishable to a reviewer from a broken
+check. Open it after both have merged, or hold it in draft. Merging Units 1 and 2 together as one pull request and
+Unit 3 as a second removes the ambiguity, at the cost of the unit boundaries.
+
+**How you know it worked.** `npm run lint` passes, which is the step that catches a new `.bats` file left at mode 644,
+and `npm test` passes with the new file discovered automatically.
+
+Then prove the check catches the defect rather than passing vacuously. `git stash` cannot do this: once Units
+1 and 2 are committed it has nothing to stash. While they are uncommitted, the new `han-linear` manifest is an
+untracked file a plain stash leaves in place. Use a worktree on the commit before Unit 1 instead, which operates on
+committed history:
+
+```bash
+git worktree add /tmp/codex-check-verify <sha-before-unit-1>
+cp test/codex-packaging.bats /tmp/codex-check-verify/test/
+cd /tmp/codex-check-verify && npm ci && npm test    # expect failure naming all three packages
+cd - && git worktree remove --force /tmp/codex-check-verify
+```
+
+The run must fail and name `han-documentation`, `han-research`, and `han-linear`. A consistency check nobody has seen
+fail is a check nobody knows works.
+
+## Risks
+
+**The check can pass vacuously**, which is why S-5 requires the non-empty assertion rather than suggesting it. If the
+enumeration matches nothing, the other two assertions run over an empty set and the test is green while checking
+nothing. This is the failure mode most likely to survive review, because it looks identical to success.
+
+The exposure is narrower than it first appears and worth knowing precisely. Bash leaves an unmatched glob as its own
+literal text unless `nullglob` is set, and nothing in this repository sets it. So a naive loop today would iterate once
+over the literal string and fail loudly with a nonsense filename. That is an accident, not a safeguard: the idiomatic
+fix for that ugly output is to set `nullglob`, which converts the loud failure into the silent pass. The non-empty
+assertion is what makes the check safe under either choice.
+
+**The two literal greps depend on Prettier's byte formatting.** Asserting the literal `"name": "han-linear"` assumes one
+space after the colon. That holds because `.pre-commit-config.yaml` gives Prettier ownership of JSON and runs it first,
+but the coupling is invisible at the grep site. State it in the file's header comment so a future reader who reformats
+the catalog knows what breaks.
+
+**Unit 3 makes Units 1 and 2 no longer independently revertible.** Before it lands, reverting either data unit affects
+only Codex users. After it lands, reverting either turns `npm test` red for every open pull request, because the check
+then fails on a package that no longer has what it asserts. If a revert is needed, revert Unit 3 first or fix forward.
+Unit 3 is itself the cheapest of the three to undo: delete one file and restore one comment.
+
+**Unit 3 goes red for anyone with a plugin-adding branch already open.** Such a branch fails on its next push with no
+context beyond the check's error line, which is the strongest argument for pinning that line in D-7. Worth a look at
+open branches before merging Unit 3.
+
+**A release can still be cut from a red `main`.** The release skill gates on a clean working tree and reads no CI
+status, so the check protects the pull request rather than the release.
+
+**The next release will bump `han-linear` for a change no Claude user can observe.** The release skill classifies a
+child as changed when anything under its directory changed, and adding the Codex manifest does that. Its three
+level buckets have no entry for "gained Codex installability", so the release run will make that call unaided. Decide it
+deliberately at release time and record the choice; this plan bumps nothing.
+
+**Nothing here was verified against a running Codex.** No Codex CLI was available. The catalog-then-manifest lookup
+order, the attribution of the reported error to the catalog step, and the effect of installing a plugin without its
+dependency are traced from the repository's files and the error text quoted in the issue
+([C-2](artifacts/current-state-findings.md#c-2-a-codex-install-reads-the-catalog-first-and-the-per-plugin-manifest-second),
+[C-7](artifacts/current-state-findings.md#c-7-the-codex-manifest-schema-shares-almost-nothing-with-the-claude-manifest-schema-and-encodes-no-dependencies)).
+The fix follows the shape of the ten entries that demonstrably work, which is the strongest available evidence short of
+running the tool.
+
+**The new Codex manifest will not be bumped by the release process.** The release skill contains no reference to Codex
+and bumps only `{source}/.claude-plugin/plugin.json` and the Claude marketplace, so `han-linear`'s Codex version stays
+at `1.0.0` until someone edits it by hand. This is already true of all twelve existing manifests
+([C-8](artifacts/current-state-findings.md#c-8-the-version-field-differs-between-the-two-manifests-for-eleven-of-twelve-plugins))
+and this change neither creates nor worsens it.
+
+## Deferred (YAGNI)
+
+**A reverse check that every catalog entry names an existing directory.** It would catch a plugin being renamed or
+deleted with its catalog entry left behind. Deferred because that failure has never occurred here: the catalog names no
+package that has no directory today
+([C-1](artifacts/current-state-findings.md#c-1-four-hand-maintained-lists-name-overlapping-but-non-identical-package-sets)),
+and the failure that did occur ran the other direction. **Reopen when** a plugin is renamed or removed, which is a
+deliberate act someone performs and can notice. The trigger is deliberately not "an orphan entry reaches `main`",
+because the only thing that would detect that is the reverse check itself. If it is reopened, assert the stronger form:
+that every entry resolves to a directory holding a Codex manifest, rather than merely to a directory. That is what an
+install needs ([D-10](artifacts/change-decision-log.md#d-10-the-reverse-check-is-deferred)).
+
+**Checking the README's Codex section against the directory tree.** This is the fourth of the four lists in
+[C-1](artifacts/current-state-findings.md#c-1-four-hand-maintained-lists-name-overlapping-but-non-identical-package-sets),
+and the check covers the other three. After this change someone can add a plugin, satisfy the check, and leave the
+README's install instructions without it. That is the same shape of drift as the one being fixed, and it lands on the
+surface the issue's closing line points at. Deferred because the operator settled the check's subject as the directory
+tree. It is also deferred because the five opt-in packages sit in a prose sentence with no marker a grep could anchor
+on. Enforcing it means first inventing a machine-readable form for that prose. **Reopen when** a package is reported
+installable but undocumented, or when the README's Codex section gains a list a check could read.
+
+**Checking that catalog entries sit in the right order.** The order carries real meaning, the suite's dependency order
+([C-17](artifacts/current-state-findings.md#c-17-the-codex-catalogs-entry-order-is-the-claude-marketplaces-order-with-its-omissions-removed)),
+and S-1, S-2, and S-4 each commit to a position, but the check is order-agnostic. Deferred because Codex resolves an
+entry by name, so a misplaced entry has no install-time consequence. **Reopen when** entry order is found to affect
+resolution or display.
+
+**Generating the catalog from the directory tree.** Structurally the strongest answer, and rejected on cost. It needs a
+generator, a check that the generated file is current, and a JSON writer. The repository's entire tooling is
+Prettier, ShellCheck, and Bats, with `jq` pinned nowhere
+([C-13](artifacts/current-state-findings.md#c-13-node-is-guaranteed-to-the-test-job-jq-is-not-pinned-anywhere)). The
+catalog has changed five times in its whole history. **Reopen when** a catalog entry gains a field that varies per
+plugin; all three non-identity fields are constants today
+([C-5](artifacts/current-state-findings.md#c-5-every-catalog-entry-carries-the-same-four-keys-with-the-same-constant-values)).
+
+**A prek hook running the same check at commit time.** Duplicates a signal CI already gives on every pull request.
+**Reopen when** catalog drift reaches `main` despite the Bats check.
+
+**Asserting the manifest key set.** True today across all twelve manifests
+([C-6](artifacts/current-state-findings.md#c-6-all-twelve-codex-manifests-carry-an-identical-key-set)), and rejected
+because it needs field-level JSON reading with no `jq`, and no reported failure was caused by a missing field.
+**Reopen when** an install fails on a malformed manifest rather than an absent one.
+
+**A `CONTRIBUTING.md` section on adding a plugin.** The file has no such section at all
+([C-14](artifacts/current-state-findings.md#c-14-contributingmd-has-no-section-for-adding-a-plugin-and-never-names-the-codex-surface)),
+so writing one is authoring a new process rather than repairing this defect. The check enforces mechanically what its
+Codex paragraph would have said in prose. **Reopen when** a contributor asks how to add a plugin, or when the check
+fires on a human branch and its error line proves insufficient.
+
+**An ADR recording why `han/` is excluded from the Codex catalog.** The issue reporter had to infer this. After the
+change the exclusion is structural in the check's `han-*` glob and stated in both its header comment and `CLAUDE.md`.
+**Reopen when** someone proposes adding `han` to the catalog.
+
+## Cut for Scope
+
+**Rewording `CLAUDE.md` line 73, which calls the catalog "the Codex-compatible subset of the plugins".** It would stop a
+future reader concluding that some plugins are legitimately outside the Codex surface. Cut because the line does not
+become false: after the change the catalog still excludes `han`, so it remains a subset. Rewording it is prevention
+work, and the recorded boundary already chose a mechanism for prevention in item 4, a test rather than prose
+([`artifacts/scope-boundary.md`](artifacts/scope-boundary.md), Stated Scope). Note that
+[C-16](artifacts/current-state-findings.md#c-16-claudemd-records-the-han-linear-manifest-gap-as-though-it-were-the-intended-design)
+treats lines 73 and 83 together; splitting them is this plan's judgment, on the test of whether this change makes the
+line false. You can reinstate this, and saying so is
+itself a valid justification the reinstated entry records
+([D-11](artifacts/change-decision-log.md#d-11-claudemd-line-73-is-cut-for-scope)).
+
+**Reconciling the three independently-authored descriptions of each plugin.** Every plugin's description exists in its
+Claude manifest, its Claude marketplace entry, and its Codex manifest, and all twelve differ
+([C-9](artifacts/current-state-findings.md#c-9-the-same-plugins-description-is-authored-independently-in-three-places-and-has-drifted-in-all-twelve)).
+Cut because the issue asks about installability, not description accuracy, and the three texts serve three surfaces at
+three deliberate lengths. Worth saying plainly rather than implying neutrality: S-3 adds a thirteenth instance of the
+pattern, authoring three new independently-written texts for `han-linear`.
+
+## Open Items
+
+**Whether a Codex install succeeds after this change.** Non-blocking. Every claim about what Codex does at
+install time is traced from this repository's files and the error text in the issue. No Codex CLI was available
+to this run. What would settle it: run `codex plugin marketplace add` against the branch and then `codex plugin add` for
+each of the three packages. The builder inherits this as a verification step, not as a design question.
+
+**Whether the `ubuntu-latest` runner preinstalls `jq`.** Non-blocking, and the plan is arranged so the answer does not
+matter: the check uses bash and grep only. Named here because it is the reason for that constraint rather than an open
+design choice.
+
+**`docs/choosing-a-han-plugin.md` still misleads a Codex user, and this change does not fix it.** Non-blocking, and
+outside the recorded boundary, which names the README's Codex section rather than `docs/`. The README routes readers to
+that file as the plugin index. It never mentions Codex, and its install commands are Claude-only, including
+`/plugin install han@han` for a meta-plugin Codex cannot install. This is the residual half of what the issue calls "the
+affected installation instructions". What would settle it: a follow-up issue. Do not widen this change to cover it.
+
+**Whether Codex packages a plugin's `scripts/` directory and preserves a root-escaping symlink.** Non-blocking and
+inherited rather than introduced. Every plugin's `scripts/han-config-dir.sh` is a symlink out of the plugin root, and
+the Codex manifest declares only `skills/`. All thirteen plugins share this, so `han-linear` gaining a manifest extends
+an existing condition rather than creating one. What would settle it: installing any Han package under Codex and
+running a skill that probes the personal config directory.
+
+## Review Findings
+
+Three specialists reviewed the plan in one round: `han-core:test-engineer` on the check's verification design,
+`han-core:devops-engineer` on the build and distribution boundary, and `han-core:junior-developer` as a generalist
+stress-test. The round cap for a medium change is two rounds; one was enough, because no finding named a domain the
+round did not cover.
+
+`han-core:system-architect` was not dispatched. This change crosses no service boundary, changes no context-map
+relationship, and shifts no data ownership, so it stayed inside `han-core:software-architect`'s altitude. That
+architect deferred nothing to it.
+
+Every finding that changed the plan is recorded below. Each produced an edit rather than a decision of its own, so
+there is no new `D-N` entry for them; the decisions they altered are D-6, D-8, and D-9.
+
+**Raised independently by all three reviewers, and the round's most valuable finding.** The check's own top risk had no
+assertion closing it. The plan named vacuous pass as "the failure mode most likely to survive review" and then left the
+mitigation as a suggestion in Risks rather than a requirement in S-5. Two reviewers went further and named the specific
+shapes that produce it. Piping into `while read` runs the loop body in a subshell, where a failure cannot fail the
+test. Setting `nullglob` turns an unmatched glob from a loud failure into zero iterations. Neither hazard
+exists in the repository today, which is what makes a builder likely to introduce one. The non-empty assertion is now a
+required part of S-5.
+
+**Raised by `han-core:test-engineer` and `han-core:junior-developer`.** The Unit 3 verification step named `git stash`,
+which cannot reproduce the pre-fix state. Once Units 1 and 2 are committed there is nothing to stash. While they
+are uncommitted, a plain stash leaves the untracked new manifest in place and removes the test file besides. Replaced
+with a `git worktree` on the commit before Unit 1, which operates on committed history.
+
+**Raised by `han-core:test-engineer` and `han-core:devops-engineer`.** The plan's own worked catalog entry was
+compacted while all ten committed entries are expanded, and Prettier preserves whichever shape an author writes rather
+than normalizing it. A contributor copying the plan's snippet would have introduced a permanent second shape that no
+lint step corrects. The snippet now matches the file.
+
+**Raised by `han-core:test-engineer`.** The two catalog greps tested for the name and the path appearing anywhere in
+the file rather than within one entry. Now scoped to a three-line window, which the fixed entry shape makes exact.
+
+**Raised by `han-core:devops-engineer`.** Four cross-platform constraints the plan had not stated, each verified. The
+bash version divergence runs the opposite way from the usual, because the authoring machine has the older shell.
+`grep -r` is unsafe here because BSD and GNU grep differ on symlinks, and this repository has thirteen root-escaping
+ones. Locale differences make sorted comparison unreliable. And Bats prints a test's output only on failure and only
+from the test body, which is what puts D-7's pinned lines into a CI log. It also caught that a new `.bats` file left
+at mode 644 fails `npm run lint` before `npm test` ever runs. Both existing files are 755, and prek's shebang hooks
+cover `test/`. All five are now in S-5.
+
+**Raised by `han-core:devops-engineer`.** The Risks section had the revert asymmetry backwards. It claimed Units 1 and
+2 were the revertible ones; in fact Unit 3 is the cheapest to undo, and once it lands, reverting either data unit turns
+`npm test` red repository-wide. It also found that Unit 2's ordering rationale cited a property the plan deliberately
+does not build: the deferred reverse check. A Unit 3 pull request opened before Units 1 and 2 merge also runs red
+on its own CI, in a way a reviewer cannot distinguish from a broken check. All corrected.
+
+**Raised by `han-core:junior-developer`.** S-6 and S-7 were labeled behavior-preserving while their own justification
+paragraphs argued the opposite: both exist precisely because a reader acts differently afterwards. Both are now
+classified Changing with the observer named. The same reviewer found that the target text for those two entries was
+described rather than pinned, unlike every other entry in the delta. S-6's line also sits inside a column-aligned
+ASCII tree, where two builders would produce two different lines. Both replacement lines are now pinned literally.
+
+**Raised by `han-core:junior-developer`.** The deferred reverse check carried a reopening trigger nothing could
+observe: an orphan entry reaching `main` would be detected only by the reverse check itself. Retriggered on a plugin
+rename or removal, which is a deliberate act someone performs. The same reviewer found the Behavior Changes section
+opened on planning bookkeeping in vocabulary appearing in neither the issue nor a user's world; it was rewritten.
+
+**Raised by `han-core:junior-developer` and confirmed by `han-core:devops-engineer`.** The README is the fourth of the
+four lists and the check covers three, so a contributor can add a plugin, satisfy the check, and leave the install
+instructions without it. Now a deferral with a stated trigger rather than an unmentioned gap. The devops reviewer
+extended this to `docs/choosing-a-han-plugin.md`, which the README routes Codex readers to and which never mentions
+Codex. That sits outside the recorded boundary and is recorded as an open item and a follow-up.
+
+**Findings kept but not acted on.** `han-core:software-architect` recommended a third assertion checking that every
+catalog entry names an existing directory. Not adopted, on the evidence test, and recorded as dissent in
+[D-10](artifacts/change-decision-log.md#d-10-the-reverse-check-is-deferred). `han-core:test-engineer` noted that entry
+order is committed to in the delta and unchecked by the test, and argued itself that testing it would be
+YAGNI-incorrect since Codex resolves by name. It is recorded as a deferral. `han-core:devops-engineer` raised that this
+change adds a thirteenth instance of the three-way description drift, which is noted in the cut list rather than fixed.
+The same reviewer raised that Codex may not package a plugin's symlinked `scripts/` directory, which is inherited by
+all thirteen plugins and recorded as an open item.
+
+**Findings labeled `Unverified`, none carrying blocking severity.** Every claim about what Codex does at install time
+rests on files and the error text in the issue rather than on a running Codex. No Codex CLI was available to any
+agent in this run. The same applies to the `ubuntu-latest` runner's preinstalled tools and to what `claude plugin tag`
+reads. The plan is arranged so none of these decides anything: the fix copies the shape of ten entries that
+demonstrably work, and the check depends only on tools this repository pins.

--- a/han-linear/.codex-plugin/plugin.json
+++ b/han-linear/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "han-linear",
+  "version": "1.0.0",
+  "description": "Linear-facing extensions to the Han suite: publish Han work items to Linear through the Linear MCP server, one issue per slice.",
+  "author": {
+    "name": "Test Double",
+    "url": "https://testdouble.com"
+  },
+  "homepage": "https://github.com/testdouble/han#readme",
+  "repository": "https://github.com/testdouble/han",
+  "license": "MIT",
+  "keywords": ["han", "linear", "work-items", "issues"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Han Linear",
+    "shortDescription": "Publish Han work items to Linear as issues.",
+    "longDescription": "Creates one Linear issue per slice from a /plan-work-items work-items file in a single target team, resolving the team's real workflow states, labels, Projects, and members before it creates anything, and linking within-file dependencies as native \"blocked by\" relations. Requires a configured Linear MCP server.",
+    "developerName": "Test Double",
+    "category": "Developer Tools",
+    "capabilities": ["Skills"],
+    "websiteURL": "https://github.com/testdouble/han",
+    "defaultPrompt": [
+      "Publish these work items to Linear.",
+      "Create Linear issues from my work-items file.",
+      "Push this plan's slices into my Linear team."
+    ]
+  }
+}

--- a/test/codex-packaging.bats
+++ b/test/codex-packaging.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+#
+# Guards the Codex packaging surface. A package Codex can install needs
+# two files that nothing derives from the other: a .codex-plugin/plugin.json
+# in its own directory, and an entry in .agents/plugins/marketplace.json.
+# Commit 2c09799 added two plugins and updated only the Claude marketplace,
+# so both stayed uninstallable until issue #198 reported it.
+#
+# The directory tree is the authority: every han-* directory needs both.
+# The han-* glob excludes the han/ meta-plugin structurally, because han/
+# does not match it and Codex does not support meta-plugins.
+#
+# Portability, since this runs on macOS locally and ubuntu-latest in CI.
+# The older shell is the local one, so CI will not catch a bash 4+ feature:
+# keep to bash 3.2 (no mapfile, no declare -A, no ${x^^}, no globstar).
+# Grep one named file, never -r: BSD grep follows symlinks during a
+# recursive search and GNU grep does not, and this repo has thirteen
+# root-escaping symlinks at han-*/scripts/han-config-dir.sh.
+#
+# The catalog greps match Prettier's byte formatting: one space after each
+# colon, one key per line. .pre-commit-config.yaml gives Prettier ownership
+# of JSON and runs it first, so that shape is stable. Reformatting the
+# catalog by hand would break these matches.
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+CATALOG='.agents/plugins/marketplace.json'
+
+# Every Codex package, one per line.
+codex_packages() {
+  cd "$REPO_ROOT" || return 1
+  for dir in han-*/; do printf '%s\n' "${dir%/}"; done
+}
+
+@test "at least one han-* package is found" {
+  run codex_packages
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+@test "every han-* package carries a Codex manifest" {
+  cd "$REPO_ROOT" || return 1
+  failed=0
+  for pkg in $(codex_packages); do
+    [ -f "${pkg}/.codex-plugin/plugin.json" ] || {
+      printf '%s\n' "codex manifest missing: ${pkg}/.codex-plugin/plugin.json (copy han-ddd/.codex-plugin/plugin.json and edit the package-specific fields)"
+      failed=1
+    }
+  done
+  [ "$failed" -eq 0 ]
+}
+
+@test "every han-* package has a catalog entry naming it and pointing at it" {
+  cd "$REPO_ROOT" || return 1
+  failed=0
+  for pkg in $(codex_packages); do
+    grep -A3 -- "\"name\": \"${pkg}\"" "$CATALOG" | grep -qF -- "\"path\": \"./${pkg}\"" || {
+      printf '%s\n' "catalog entry missing: add \"name\": \"${pkg}\" with \"path\": \"./${pkg}\" to ${CATALOG}"
+      failed=1
+    }
+  done
+  [ "$failed" -eq 0 ]
+}

--- a/test/sanity.bats
+++ b/test/sanity.bats
@@ -2,8 +2,9 @@
 #
 # Sanity check: proves the Bats harness and the CI test job actually run.
 # Real script tests sit next to the script they cover (e.g.
-# scripts/foo.sh alongside scripts/foo.bats); test/ keeps only
-# harness-level checks like this one.
+# scripts/foo.sh alongside scripts/foo.bats); test/ keeps harness-level
+# checks like this one, plus repository-wide structural invariants that
+# cover no single script.
 
 @test "sanity: arithmetic works (2 + 2 == 4)" {
   result=$((2 + 2))


### PR DESCRIPTION
Closes #198. Plans and implements the fix in five commits: two documentation commits carrying the change plan, then the three change units.

## What #198 reported

Three Han packages the README tells Codex users to install could not be installed:

```
$ codex plugin add han-documentation@han
Error: plugin `han-documentation` was not found in marketplace `han`
```

`han-research` failed identically. `han-linear` failed one layer deeper: absent from the catalog *and* never carrying a Codex manifest on any commit.

## Why it happened

Four hand-maintained lists enumerate the Codex-installable packages — the `han-*` directory tree, the per-plugin manifests, `.agents/plugins/marketplace.json`, and the README — and nothing checked that they agreed.

The drift is visible in the history. `2c09799` scaffolded `han-documentation` and `han-research` and updated only the Claude marketplace; its own message says "registered in the marketplace", singular. The comparison case is `556b49e`, which added `han-ddd` and updated both marketplace files plus `CLAUDE.md`, which is why `han-ddd` installs today.

## The three units

| Unit | Commit | What it does |
| --- | --- | --- |
| 1 | `b83712f` | Two catalog entries for the plugins that already had manifests |
| 2 | `1928de6` | `han-linear`'s manifest, its catalog entry, and the `CLAUDE.md` line that recorded its absence as intentional |
| 3 | `f15663f` | The consistency check, plus the `sanity.bats` header it makes stale |

Each unit leaves the repository green on its own.

## The check

The directory tree is the authority: every `han-*` directory needs both files. The `han-*` glob excludes the `han` meta-plugin structurally rather than by an exception list.

Three assertions, bash and grep only:

1. the enumeration is non-empty, so the other two cannot pass over an empty set while looking identical to success
2. every package has a `.codex-plugin/plugin.json`
3. every package has a catalog entry whose `name` and `path` sit in the **same** entry, matched in a three-line window rather than tested for presence anywhere in the file

**Deliberately not asserted:** version parity (false for eleven of twelve pairs) and description parity (false for all twelve). Both would fail the build the day they landed, and neither is a latent goal — the release skill touches only the Claude side.

### Verified to actually fail

Run against a worktree on the commit before Unit 1, with only the test file copied in:

```
not ok 2 every han-* package carries a Codex manifest
# codex manifest missing: han-linear/.codex-plugin/plugin.json (copy han-ddd/... and edit the package-specific fields)
not ok 3 every han-* package has a catalog entry naming it and pointing at it
# catalog entry missing: add "name": "han-documentation" with "path": "./han-documentation" to .agents/plugins/marketplace.json
# catalog entry missing: add "name": "han-linear" with "path": "./han-linear" to .agents/plugins/marketplace.json
# catalog entry missing: add "name": "han-research" with "path": "./han-research" to .agents/plugins/marketplace.json
```

Exactly the three packages #198 names. On `HEAD`: 121 tests pass, 0 fail, every lint hook passes.

## Worth a reviewer's attention

- **`han-linear`'s Codex manifest ships at `1.0.0`**, not the Claude manifest's `1.1.1`. The release skill's own rule is that a brand-new plugin is not bumped by the release that introduces it. The two version fields are separate lineages; seeding `1.1.1` would manufacture a parity the next release destroys. **No version is bumped by this PR.**
- **The next release will classify `han-linear` as changed** on the strength of the new manifest alone, and the level buckets have no entry for "gained Codex installability." Worth deciding deliberately at release time.
- **`CLAUDE.md` is edited**, and it was not in the area originally scoped. Brought in because this change makes line 83 false, on the `556b49e` precedent. Line 73 was cut for scope and is reinstatable.
- **Nothing was verified against a running Codex.** No CLI was available. Every install-time claim traces to the repo's files and the error text in #198; the fix copies the shape of the ten entries that demonstrably work.
- **`docs/choosing-a-han-plugin.md` still gives Codex readers Claude-only install commands.** Left alone as outside scope; recorded as a follow-up.

## Planning artifacts

`docs/plans/codex-marketplace-catalog-consistency/` carries the change plan, 11 decisions, 18 current-state findings, and the scope boundary. Nine items are deferred with reopening triggers, including a reverse check on the catalog and a Codex packaging document for the `han-plugin-builder` guidance, which has none.

Produced with `/han-planning:plan-a-change`. The review round (`test-engineer`, `devops-engineer`, `junior-developer`) found nine defects in the draft plan, including a verification step using `git stash` that cannot reach committed history, and a worked JSON example whose formatting would have diverged permanently from every sibling entry.
